### PR TITLE
Add initial test runner and initial results for Duktape 2.0

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -36,6 +36,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: true,
         }
       },
       {
@@ -57,6 +58,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: true,
         }
       },
       {
@@ -79,6 +81,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
     ],
@@ -113,6 +116,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -140,6 +144,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -167,6 +172,7 @@ exports.tests = [
           safari10: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         },
       },
       {
@@ -184,6 +190,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         },
       },
     ],
@@ -215,6 +222,7 @@ exports.tests = [
           chrome47: true,
           edge14: true,
           firefox43: true,
+          duktape20: false,
         }
       },
       {
@@ -254,6 +262,7 @@ exports.tests = [
           chrome47: true,
           edge14: true,
           firefox43: true,
+          duktape20: false,
         }
       },
       {
@@ -276,6 +285,7 @@ exports.tests = [
           safaritp: true,
           safari10: true,
           webkit: true,
+          duktape20: false,
         }
       },
     ],
@@ -307,6 +317,7 @@ exports.tests = [
           safari10: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -330,6 +341,7 @@ exports.tests = [
           safari10: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       }
     ]
@@ -357,6 +369,7 @@ exports.tests = [
           safari10: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -375,6 +388,7 @@ exports.tests = [
           safari10: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
     ],
@@ -417,6 +431,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -448,6 +463,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -469,6 +485,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -490,6 +507,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         },
       },
       {
@@ -518,6 +536,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -547,6 +566,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -568,6 +588,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -594,6 +615,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -615,6 +637,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -646,6 +669,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -677,6 +701,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -706,6 +731,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         }
       },
       {
@@ -729,6 +755,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         },
       },
       {
@@ -749,6 +776,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         },
       },
       {
@@ -778,6 +806,7 @@ exports.tests = [
           firefox52: true,
           safari10_1: true,
           safaritp: true,
+          duktape20: false,
         },
       },
     ]
@@ -802,6 +831,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -815,6 +845,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -830,6 +861,7 @@ exports.tests = [
           chrome48: chrome.sharedmem,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -844,6 +876,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -858,6 +891,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -874,6 +908,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -890,6 +925,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -906,6 +942,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -922,6 +959,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -938,6 +976,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -954,6 +993,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -970,6 +1010,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -986,6 +1027,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -1002,6 +1044,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -1018,6 +1061,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -1034,6 +1078,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -1050,6 +1095,7 @@ exports.tests = [
           safari10_1: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       }
     ]
@@ -1083,6 +1129,7 @@ exports.tests = [
       safari10: true,
       safaritp: true,
       webkit: true,
+      duktape20: false,
     }
   },
   {
@@ -1123,6 +1170,7 @@ exports.tests = [
       safari10: true,
       safaritp: true,
       webkit: true,
+      duktape20: false,
     }
   },
   {
@@ -1151,6 +1199,7 @@ exports.tests = [
       safari10: true,
       safaritp: true,
       webkit: true,
+      duktape20: false,
     }
   },
   {
@@ -1180,6 +1229,7 @@ exports.tests = [
       chrome49: true,
       safaritp: true,
       webkit: true,
+      duktape20: false,
     }
   },
   {
@@ -1209,6 +1259,7 @@ exports.tests = [
       safari10_1: true,
       safaritp: true,
       webkit: true,
+      duktape20: false,
     }
   },
   {
@@ -1242,6 +1293,7 @@ exports.tests = [
       safari10: true,
       safaritp: true,
       webkit: true,
+      duktape20: true,
     },
   },
   {
@@ -1268,6 +1320,7 @@ exports.tests = [
       safari10: true,
       safaritp: true,
       webkit: true,
+      duktape20: false,
     },
   },
   {
@@ -1300,6 +1353,7 @@ exports.tests = [
         webkit: true,
         android40: true,
         ios51: true,
+        duktape20: false,
       }
     },
       {
@@ -1326,6 +1380,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           android40: true,
+          duktape20: false,
         }
       },
       {
@@ -1347,6 +1402,7 @@ exports.tests = [
           safari9: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         },
       },
       {
@@ -1374,6 +1430,7 @@ exports.tests = [
           webkit: true,
           android40: true,
           ios51: true,
+          duktape20: false,
         },
       },
       {
@@ -1400,6 +1457,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           android40: true,
+          duktape20: false,
         },
       },
       {
@@ -1421,6 +1479,7 @@ exports.tests = [
           safari9: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         },
       },
       {
@@ -1450,6 +1509,7 @@ exports.tests = [
           webkit: true,
           android40: true,
           ios51: true,
+          duktape20: false,
         },
       },
       {
@@ -1478,6 +1538,7 @@ exports.tests = [
           webkit: true,
           android40: true,
           ios51: true,
+          duktape20: false,
         },
       },
       {
@@ -1506,6 +1567,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           android40: true,
+          duktape20: false,
         },
       },
       {
@@ -1527,6 +1589,7 @@ exports.tests = [
           safari9: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         },
       },
       {
@@ -1548,6 +1611,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           ios51: true,
+          duktape20: false,
         },
       },
       {
@@ -1577,6 +1641,7 @@ exports.tests = [
           webkit: true,
           android40: true,
           ios51: true,
+          duktape20: false,
         },
       },
       {
@@ -1605,6 +1670,7 @@ exports.tests = [
           webkit: true,
           android40: true,
           ios51: true,
+          duktape20: false,
         },
       },
       {
@@ -1633,6 +1699,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           android40: true,
+          duktape20: false,
         },
       },
       {
@@ -1654,6 +1721,7 @@ exports.tests = [
           safari9: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         },
       },
       {
@@ -1675,6 +1743,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           ios51: true,
+          duktape20: false,
         },
       }
     ]
@@ -1700,6 +1769,7 @@ exports.tests = [
         safari10: true,
         safaritp: true,
         webkit: true,
+        duktape20: false,
       }
     },
       {
@@ -1718,6 +1788,7 @@ exports.tests = [
           safari10: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -1741,6 +1812,7 @@ exports.tests = [
           safari10: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       },
       {
@@ -1764,6 +1836,7 @@ exports.tests = [
           safari10: true,
           safaritp: true,
           webkit: true,
+          duktape20: false,
         }
       }
     ]
@@ -1789,6 +1862,7 @@ exports.tests = [
       safari10_1: true,
       safaritp: true,
       webkit: true,
+      duktape20: true,
     },
   },
   {
@@ -1809,6 +1883,7 @@ exports.tests = [
       safari10_1: true,
       safaritp: true,
       webkit: true,
+      duktape20: false,
     },
   },
   {
@@ -1838,6 +1913,7 @@ exports.tests = [
       node012: true,
       android40: true,
       ios51: true,
+      duktape20: true,
     },
   },
   {
@@ -1857,6 +1933,7 @@ exports.tests = [
       safari10_1: true,
       safaritp: true,
       firefox53: true,
+      duktape20: false,
     },
   },
   {
@@ -1879,6 +1956,7 @@ exports.tests = [
       chrome59: 'flagged',
       safaritp: true,
       webkit: true,
+      duktape20: false,
     }
   },
 ];

--- a/data-es5.js
+++ b/data-es5.js
@@ -28,6 +28,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -50,6 +51,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     },
   },
   {
@@ -73,6 +75,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: null,
+      duktape20: true,
     },
   },
   {
@@ -96,6 +99,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: null,
+      duktape20: true,
     },
   },
   {
@@ -121,6 +125,7 @@ exports.tests = [
       rhino17: false,
       ejs: true,
       android40: true,
+      duktape20: true,
     },
   }],
   separator: 'after'
@@ -147,6 +152,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -180,6 +186,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -201,6 +208,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -224,6 +232,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -248,6 +257,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -269,6 +279,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -290,6 +301,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -311,6 +323,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -332,6 +345,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -353,6 +367,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -374,6 +389,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -403,6 +419,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -426,6 +443,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     },
     separator: 'after'
   }],
@@ -455,6 +473,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -477,6 +496,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -499,6 +519,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -521,6 +542,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -543,6 +565,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -565,6 +588,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -587,6 +611,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -609,6 +634,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -631,6 +657,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -653,6 +680,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     },
   }, {
     name: 'Array.prototype.sort: compareFn must be function or undefined',
@@ -695,6 +723,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: false,
+      duktape20: true,
     },
   },
   {
@@ -724,6 +753,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: true,
+      duktape20: true,
     },
   }],
 },
@@ -750,6 +780,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -774,6 +805,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     },
     separator: 'after'
   }
@@ -802,6 +834,7 @@ exports.tests = [
       rhino17: true,
       ejs: false,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -824,6 +857,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   },
   {
@@ -857,6 +891,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android40: true,
+      duktape20: true,
     }
   }]
 },
@@ -883,6 +918,7 @@ exports.tests = [
     ejs: true,
     ios7: true,
     android40: true,
+    duktape20: true,
   },
 },
 {
@@ -912,6 +948,7 @@ exports.tests = [
     ejs: true,
     ios7: true,
     android40: true,
+    duktape20: true,
   },
   separator: 'after'
 },
@@ -943,6 +980,7 @@ exports.tests = [
       rhino17: true,
       ejs: false,
       android41: true,
+      duktape20: true,
     }
   },
   {
@@ -969,6 +1007,7 @@ exports.tests = [
       rhino17: true,
       ejs: false,
       android41: true,
+      duktape20: true,
     }
   },
   {
@@ -995,6 +1034,7 @@ exports.tests = [
       rhino17: true,
       ejs: false,
       android41: true,
+      duktape20: true,
     }
   }]
 },
@@ -1023,6 +1063,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: null,
+      duktape20: true,
     },
   },
   {
@@ -1047,6 +1088,7 @@ exports.tests = [
       rhino17: false,
       ejs: true,
       android44: true,
+      duktape20: true,
     }
   },
   {
@@ -1072,6 +1114,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: null,
+      duktape20: true,
     },
   },
   {
@@ -1098,6 +1141,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: null,
+      duktape20: true,
     },
   },
   {
@@ -1126,6 +1170,7 @@ exports.tests = [
       rhino17: true,
       ejs: true,
       android41: true,
+      duktape20: true,
     }
   },
   {
@@ -1152,6 +1197,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: null,
+      duktape20: true,
     }
   },
   {
@@ -1183,6 +1229,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: null,
+      duktape20: false,
     }
   },
   {
@@ -1212,6 +1259,7 @@ exports.tests = [
       rhino17: null,
       ejs: null,
       android40: null,
+      duktape20: true,
     },
   }]
 },
@@ -1241,6 +1289,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1264,6 +1313,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1285,6 +1335,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1321,6 +1372,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1342,6 +1394,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1361,6 +1414,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1384,6 +1438,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1407,6 +1462,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1432,6 +1488,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1456,6 +1513,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1478,6 +1536,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1499,6 +1558,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1524,6 +1584,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1543,6 +1604,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1562,6 +1624,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1581,6 +1644,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1600,6 +1664,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1619,6 +1684,7 @@ exports.tests = [
       ejs: true,
       ios7: true,
       android41: true,
+      duktape20: true,
     },
   },
   {
@@ -1643,6 +1709,7 @@ exports.tests = [
       ios8: true,
       ios9: true,
       android41: true,
+      duktape20: true,
     }
   }]
 }

--- a/data-es6.js
+++ b/data-es6.js
@@ -36,6 +36,7 @@ exports.tests = [
         chrome51: "flagged",
         safari10: true,
         xs6: true,
+        duktape20: true,
       },
     },
     {
@@ -62,6 +63,7 @@ exports.tests = [
         chrome51: "flagged",
         safari10: true,
         xs6: true,
+        duktape20: true,
       },
     }
   ]
@@ -95,6 +97,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -120,6 +123,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -145,6 +149,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -168,6 +173,7 @@ exports.tests = [
         safari10: true,
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -191,6 +197,7 @@ exports.tests = [
         safari10: true,
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -214,6 +221,7 @@ exports.tests = [
         safari10: true,
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -235,6 +243,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -255,6 +264,7 @@ exports.tests = [
         chrome45: true,
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -274,6 +284,7 @@ exports.tests = [
         node65: true,
         edge13: true,
         xs6: false,
+        duktape20: false,
       },
     },
     {
@@ -291,6 +302,7 @@ exports.tests = [
         safari10: true,
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -326,6 +338,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -359,6 +372,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -376,6 +390,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -410,6 +425,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       }
     },
     {
@@ -435,6 +451,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -463,6 +480,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -490,6 +508,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -515,6 +534,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -539,6 +559,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -563,6 +584,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -585,6 +607,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -611,6 +634,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       }
     },
     {
@@ -637,6 +661,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -666,6 +691,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -694,6 +720,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -720,6 +747,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -745,6 +773,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -770,6 +799,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -793,6 +823,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ]
@@ -830,6 +861,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -855,6 +887,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -883,6 +916,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -908,6 +942,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -930,6 +965,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -961,6 +997,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -986,6 +1023,7 @@ exports.tests = [
         firefox44: true,
         safari10: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1012,6 +1050,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1041,6 +1080,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1067,6 +1107,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1090,6 +1131,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1122,6 +1164,7 @@ exports.tests = [
         node012: "flagged",
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
   ],
@@ -1154,6 +1197,7 @@ exports.tests = [
         edge12: "flagged",
         edge14: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1177,6 +1221,7 @@ exports.tests = [
         edge12: "flagged",
         edge14: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1200,6 +1245,7 @@ exports.tests = [
         edge12: "flagged",
         edge14: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1229,6 +1275,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1257,6 +1304,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -1281,6 +1329,7 @@ exports.tests = [
         node6: true,
         node65: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -1302,6 +1351,7 @@ exports.tests = [
         firefox53: true,
         xs6: true,
         ejs: { val: false, note_id: 'ejs-no-function-ctor' },
+        duktape20: false,
       },
     },
   ]
@@ -1337,6 +1387,7 @@ exports.tests = [
         node65: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -1359,6 +1410,7 @@ exports.tests = [
         node65: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -1388,6 +1440,7 @@ exports.tests = [
         firefox43: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -1416,6 +1469,7 @@ exports.tests = [
         node65: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -1436,6 +1490,7 @@ exports.tests = [
         xs6: true,
         ejs: { val: false, note_id: 'ejs-no-function-ctor' },
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -1469,6 +1524,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1491,6 +1547,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1516,6 +1573,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1534,6 +1592,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1554,6 +1613,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -1573,6 +1633,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1592,6 +1653,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -1610,6 +1672,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1632,6 +1695,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -1652,6 +1716,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -1679,6 +1744,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1701,6 +1767,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1724,6 +1791,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1746,6 +1814,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1771,6 +1840,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ]
@@ -1805,6 +1875,7 @@ exports.tests = [
         typescript: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1833,6 +1904,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1857,6 +1929,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1881,6 +1954,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1909,6 +1983,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1937,6 +2012,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1964,6 +2040,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -1992,6 +2069,7 @@ exports.tests = [
         node4: "strict",
         safari10: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -2024,6 +2102,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2052,6 +2131,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2080,6 +2160,7 @@ exports.tests = [
         node4: "strict",
         safari10: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -2110,6 +2191,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2138,6 +2220,7 @@ exports.tests = [
         node4: "strict",
         safari10: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -2168,6 +2251,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2195,6 +2279,7 @@ exports.tests = [
         node4: "strict",
         safari10: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -2222,6 +2307,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2245,6 +2331,7 @@ exports.tests = [
         node4: "strict",
         safari10: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -2268,6 +2355,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2294,6 +2382,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2318,6 +2407,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2356,6 +2446,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2385,6 +2476,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2411,6 +2503,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2439,6 +2532,7 @@ exports.tests = [
         node5: "strict",
         xs6: true,
         ejs: true,
+        duktape20: false,
       },
     },
   ],
@@ -2479,6 +2573,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2509,6 +2604,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2539,6 +2635,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2569,6 +2666,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2601,6 +2699,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2625,6 +2724,7 @@ exports.tests = [
         node5: "strict",
         xs6: true,
         ejs: true,
+        duktape20: false,
       },
     },
     {
@@ -2658,6 +2758,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2692,6 +2793,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -2724,6 +2826,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -2748,6 +2851,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -2771,6 +2875,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -2794,6 +2899,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -2817,6 +2923,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -2842,6 +2949,7 @@ exports.tests = [
         node4: true,
         safari10: true,
         xs6: true,
+        duktape20: false,
       }
     }
   ]
@@ -2880,6 +2988,7 @@ exports.tests = [
         chrome49: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -2903,6 +3012,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -2929,6 +3039,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
   ],
@@ -2960,6 +3071,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2980,6 +3092,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -2999,6 +3112,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -3018,6 +3132,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -3036,6 +3151,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -3069,6 +3185,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -3095,6 +3212,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -3118,6 +3236,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -3140,6 +3259,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -3166,6 +3286,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3193,6 +3314,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -3220,6 +3342,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -3243,6 +3366,7 @@ exports.tests = [
         chrome51: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -3268,6 +3392,7 @@ exports.tests = [
         chrome51: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -3308,6 +3433,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3339,6 +3465,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3370,6 +3497,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3393,6 +3521,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3422,6 +3551,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3450,6 +3580,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3481,6 +3612,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3510,6 +3642,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3542,6 +3675,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3570,6 +3704,7 @@ exports.tests = [
         node65: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3598,6 +3733,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3628,6 +3764,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3658,6 +3795,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3688,6 +3826,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3717,6 +3856,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3749,6 +3889,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3781,6 +3922,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3813,6 +3955,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3844,6 +3987,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3878,6 +4022,7 @@ exports.tests = [
         node65: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3910,6 +4055,7 @@ exports.tests = [
         node65: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3942,6 +4088,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -3973,6 +4120,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4005,6 +4153,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4036,6 +4185,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4068,6 +4218,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4094,6 +4245,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -4131,6 +4283,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4159,6 +4312,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4187,6 +4341,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4217,6 +4372,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -4244,6 +4400,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -4275,6 +4432,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4298,6 +4456,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4319,6 +4478,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4340,6 +4500,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
   ],
@@ -4372,6 +4533,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -4392,6 +4554,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -4425,6 +4588,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -4447,6 +4611,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -4474,6 +4639,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -4505,6 +4671,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4528,6 +4695,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4546,6 +4714,7 @@ exports.tests = [
         node6: true,
         node65: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4564,6 +4733,7 @@ exports.tests = [
         node6: true,
         node65: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -4581,6 +4751,7 @@ exports.tests = [
         node6: true,
         node65: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -4614,6 +4785,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4638,6 +4810,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4659,6 +4832,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4683,6 +4857,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4707,6 +4882,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4731,6 +4907,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4755,6 +4932,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4779,6 +4957,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4804,6 +4983,7 @@ exports.tests = [
         android41: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4828,6 +5008,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4852,6 +5033,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4876,6 +5058,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4900,6 +5083,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4924,6 +5108,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4948,6 +5133,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4972,6 +5158,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -4996,6 +5183,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -5015,6 +5203,7 @@ exports.tests = [
         chrome50: "flagged",
         chrome51: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5057,6 +5246,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         ejs: true,
+        duktape20: true,
       },
     },
     {
@@ -5089,6 +5279,7 @@ exports.tests = [
         firefox52:true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5126,6 +5317,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ].concat([ //@@ jph
@@ -5142,6 +5334,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.of',
@@ -5157,6 +5350,7 @@ exports.tests = [
       xs6: true,
       ejs: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.subarray',
@@ -5173,6 +5367,7 @@ exports.tests = [
       node012: true,
       xs6: true,
       jxa: true,
+      duktape20: true,
     }},
     {
       name: '.prototype.join',
@@ -5188,6 +5383,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.indexOf',
@@ -5203,6 +5399,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.lastIndexOf',
@@ -5218,6 +5415,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.slice',
@@ -5232,6 +5430,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.every',
@@ -5247,6 +5446,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.filter',
@@ -5261,6 +5461,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.forEach',
@@ -5276,6 +5477,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.map',
@@ -5290,6 +5492,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.reduce',
@@ -5305,6 +5508,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.reduceRight',
@@ -5320,6 +5524,7 @@ exports.tests = [
         safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.reverse',
@@ -5335,6 +5540,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.some',
@@ -5350,6 +5556,7 @@ exports.tests = [
         safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.sort',
@@ -5364,6 +5571,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.copyWithin',
@@ -5379,6 +5587,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.find',
@@ -5394,6 +5603,7 @@ exports.tests = [
         safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.findIndex',
@@ -5409,6 +5619,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.fill',
@@ -5424,6 +5635,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.keys',
@@ -5439,6 +5651,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.values',
@@ -5454,6 +5667,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype.entries',
@@ -5468,6 +5682,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '.prototype[Symbol.iterator]',
@@ -5483,6 +5698,7 @@ exports.tests = [
       safari10: true,
       xs6: true,
       jxa: true,
+      duktape20: false,
     }},
     {
       name: '[Symbol.species]',
@@ -5498,6 +5714,7 @@ exports.tests = [
       chrome51: true,
       safari10: true,
       jxa: true,
+      duktape20: false,
     }},
     ].map(function(m) {
       var eqFn = ' === "function"';
@@ -5551,6 +5768,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5577,6 +5795,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5602,6 +5821,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5625,6 +5845,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5655,6 +5876,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5678,6 +5900,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5701,6 +5924,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5726,6 +5950,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5754,6 +5979,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5777,6 +6003,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5800,6 +6027,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5823,6 +6051,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5846,6 +6075,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5869,6 +6099,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5892,6 +6123,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5914,6 +6146,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5943,6 +6176,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5972,6 +6206,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -5991,6 +6226,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -6028,6 +6264,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6053,6 +6290,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6078,6 +6316,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6101,6 +6340,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6131,6 +6371,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6157,6 +6398,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6179,6 +6421,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6205,6 +6448,7 @@ exports.tests = [
         ejs: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6235,6 +6479,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6258,6 +6503,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6281,6 +6527,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6304,6 +6551,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6326,6 +6574,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6349,6 +6598,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6372,6 +6622,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6395,6 +6646,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6424,6 +6676,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6453,6 +6706,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6472,6 +6726,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -6507,6 +6762,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6531,6 +6787,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6555,6 +6812,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6577,6 +6835,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6606,6 +6865,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6629,6 +6889,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6652,6 +6913,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6675,6 +6937,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6697,6 +6960,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6726,6 +6990,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6748,6 +7013,7 @@ exports.tests = [
         ejs: null,
         xs6: null,
         jxa: null,
+        duktape20: false,
       },
     },
     {
@@ -6775,6 +7041,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -6811,6 +7078,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6833,6 +7101,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6857,6 +7126,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6879,6 +7149,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6908,6 +7179,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6931,6 +7203,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6953,6 +7226,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -6974,6 +7248,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -7000,6 +7275,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -7021,6 +7297,7 @@ exports.tests = [
         ejs: null,
         xs6: null,
         jxa: null,
+        duktape20: false,
       },
     },
     {
@@ -7048,6 +7325,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -7082,6 +7360,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7098,6 +7377,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7120,6 +7400,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7146,6 +7427,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7188,6 +7470,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7212,6 +7495,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7235,6 +7519,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7277,6 +7562,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7300,6 +7586,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7322,6 +7609,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7361,6 +7649,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7384,6 +7673,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7414,6 +7704,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7448,6 +7739,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7512,6 +7804,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7540,6 +7833,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7583,6 +7877,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7606,6 +7901,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7634,6 +7930,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7662,6 +7959,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7692,6 +7990,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7717,6 +8016,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7753,6 +8053,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7779,6 +8080,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7807,6 +8109,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7838,6 +8141,7 @@ exports.tests = [
         ejs: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -7884,6 +8188,7 @@ exports.tests = [
         ejs: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7909,6 +8214,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7936,6 +8242,7 @@ exports.tests = [
         chrome50: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7959,6 +8266,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -7996,6 +8304,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8019,6 +8328,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8034,6 +8344,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8051,6 +8362,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -8077,6 +8389,7 @@ exports.tests = [
         ejs: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8095,6 +8408,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8114,6 +8428,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8135,6 +8450,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         edge14: true,
+        duktape20: false,
       },
     },
     {
@@ -8152,6 +8468,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8171,6 +8488,7 @@ exports.tests = [
         ejs: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8200,6 +8518,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8226,6 +8545,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8243,6 +8563,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8260,6 +8581,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8277,6 +8599,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8295,6 +8618,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8314,6 +8638,7 @@ exports.tests = [
         firefox34: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8334,6 +8659,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8353,6 +8679,7 @@ exports.tests = [
         chrome49: true,
         edge14: "flagged",
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8370,6 +8697,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8388,6 +8716,7 @@ exports.tests = [
         xs6: null,
         echojs: null,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8407,6 +8736,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8426,6 +8756,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8444,6 +8775,7 @@ exports.tests = [
         chrome56: false,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8464,6 +8796,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8482,6 +8815,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8508,6 +8842,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8538,6 +8873,7 @@ exports.tests = [
         edge12: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8556,6 +8892,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8573,6 +8910,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8591,6 +8929,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8611,6 +8950,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8629,6 +8969,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8647,6 +8988,7 @@ exports.tests = [
         firefox18: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8665,6 +9007,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8683,6 +9026,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8702,6 +9046,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8720,6 +9065,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8739,6 +9085,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8756,6 +9103,7 @@ exports.tests = [
         firefox44: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -8783,6 +9131,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true
       },
     },
     {
@@ -8801,6 +9150,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8819,6 +9169,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8836,6 +9187,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8853,6 +9205,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -8870,6 +9223,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8887,6 +9241,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8904,6 +9259,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8923,6 +9279,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8942,6 +9299,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -8961,6 +9319,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
   ],
@@ -8987,6 +9346,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9004,6 +9364,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -9030,6 +9391,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9050,6 +9412,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -9069,6 +9432,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -9088,6 +9452,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -9107,6 +9472,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -9126,6 +9492,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
   ],
@@ -9154,6 +9521,7 @@ exports.tests = [
         chrome49: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9172,6 +9540,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9191,6 +9560,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9209,6 +9579,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -9236,6 +9607,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9254,6 +9626,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9272,6 +9645,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
   ],
@@ -9302,6 +9676,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9323,6 +9698,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -9342,6 +9718,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9362,6 +9739,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9384,6 +9762,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9405,6 +9784,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9424,6 +9804,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9445,6 +9826,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9465,6 +9847,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9486,6 +9869,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9509,6 +9893,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9536,6 +9921,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9555,6 +9941,7 @@ exports.tests = [
         firefox42: true,
         xs6: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -9576,6 +9963,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -9595,6 +9983,7 @@ exports.tests = [
         ejs: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9615,6 +10004,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9633,6 +10023,7 @@ exports.tests = [
         xs6: null,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9653,6 +10044,7 @@ exports.tests = [
         xs6: null,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9670,6 +10062,7 @@ exports.tests = [
         xs6: null,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -9704,6 +10097,7 @@ exports.tests = [
         firefox42: true,
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -9739,6 +10133,7 @@ exports.tests = [
     node4: true,
     xs6: true,
     safari10: true,
+    duktape20: false,
   }
 },
 {
@@ -9771,6 +10166,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -9796,6 +10192,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -9821,6 +10218,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -9843,6 +10241,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -9865,6 +10264,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -9888,6 +10288,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -9911,6 +10312,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -9934,6 +10336,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -9958,6 +10361,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -9987,6 +10391,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10014,6 +10419,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10039,6 +10445,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10077,6 +10484,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10100,6 +10508,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -10125,6 +10534,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10151,6 +10561,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10173,6 +10584,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10197,6 +10609,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10223,6 +10636,7 @@ exports.tests = [
         node65: true,
         edge14: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -10249,6 +10663,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10274,6 +10689,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10302,6 +10718,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -10337,6 +10754,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10363,6 +10781,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -10389,6 +10808,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10412,6 +10832,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10435,6 +10856,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -10459,6 +10881,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10483,6 +10906,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10506,6 +10930,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10529,6 +10954,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10553,6 +10979,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10579,6 +11006,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10609,6 +11037,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10639,6 +11068,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10667,6 +11097,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10689,6 +11120,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10717,6 +11149,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10743,6 +11176,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10781,6 +11215,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10804,6 +11239,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -10834,6 +11270,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10861,6 +11298,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10883,6 +11321,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -10909,6 +11348,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10935,6 +11375,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -10970,6 +11411,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -10996,6 +11438,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -11022,6 +11465,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11045,6 +11489,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11069,6 +11514,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -11093,6 +11539,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11117,6 +11564,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11139,6 +11587,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11165,6 +11614,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11195,6 +11645,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11222,6 +11673,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11248,6 +11700,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11279,6 +11732,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11303,6 +11757,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -11329,6 +11784,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11355,6 +11811,7 @@ exports.tests = [
         jxa: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -11376,6 +11833,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },{
       name: 'in parameters, function \'length\' property',
@@ -11398,6 +11856,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11424,6 +11883,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11449,6 +11909,7 @@ exports.tests = [
         node6: true,
         node65: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -11474,6 +11935,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
     {
@@ -11497,6 +11959,7 @@ exports.tests = [
         node6: true,
         node65: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -11517,6 +11980,7 @@ exports.tests = [
         chrome49: true,
         node6: true,
         node65: true,
+        duktape20: false,
       },
     },
   ],
@@ -11568,6 +12032,7 @@ exports.tests = [
         safari71_8: true,
         node012: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -11593,6 +12058,7 @@ exports.tests = [
         node4: true,
         safari10: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -11619,6 +12085,7 @@ exports.tests = [
         safari71_8: true,
         node012: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -11653,6 +12120,7 @@ exports.tests = [
         safari71_8: true,
         node012: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -11685,6 +12153,7 @@ exports.tests = [
         safari9: true,
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -11720,6 +12189,7 @@ exports.tests = [
         safari71_8: true,
         node012: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -11752,6 +12222,7 @@ exports.tests = [
         safari9: true,
         node4: true,
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -11771,6 +12242,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -11802,6 +12274,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -11828,6 +12301,7 @@ exports.tests = [
         android41: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -11857,6 +12331,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -11878,6 +12353,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
   ],
@@ -11908,6 +12384,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -11928,6 +12405,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -11951,6 +12429,7 @@ exports.tests = [
         chrome44: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -11971,6 +12450,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -11991,6 +12471,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12011,6 +12492,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12031,6 +12513,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12051,6 +12534,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12071,6 +12555,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12092,6 +12577,7 @@ exports.tests = [
         chrome44: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
   ],
@@ -12122,6 +12608,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12143,6 +12630,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12163,6 +12651,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12183,6 +12672,7 @@ exports.tests = [
         jxa: true,
         android40: true,
         android41: false,
+        duktape20: true,
       },
     },
     {
@@ -12206,6 +12696,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12224,6 +12715,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
   ],
@@ -12259,6 +12751,7 @@ exports.tests = [
         edge14: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12284,6 +12777,7 @@ exports.tests = [
         edge14: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12305,6 +12799,7 @@ exports.tests = [
         xs6: true,
         ejs: { val: false, note_id: 'ejs-no-function-ctor' },
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12323,6 +12818,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12342,6 +12838,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -12364,6 +12861,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -12383,6 +12881,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -12402,6 +12901,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12422,6 +12922,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -12446,6 +12947,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -12470,6 +12972,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -12488,6 +12991,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -12510,6 +13014,7 @@ exports.tests = [
         node65: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -12532,6 +13037,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -12552,6 +13058,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12572,6 +13079,7 @@ exports.tests = [
         node4: "strict",
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12590,6 +13098,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: true,
       },
     },
   ],
@@ -12619,6 +13128,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12643,6 +13153,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
   ],
@@ -12675,6 +13186,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12694,6 +13206,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12719,6 +13232,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -12744,6 +13258,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12772,6 +13287,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12797,6 +13313,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12825,6 +13342,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12855,6 +13373,7 @@ exports.tests = [
         edge12: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12876,6 +13395,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12904,6 +13424,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -12942,6 +13463,7 @@ exports.tests = [
         android40: true,
         xs6: false,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12971,6 +13493,7 @@ exports.tests = [
         android40: true,
         xs6: false,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -12998,6 +13521,7 @@ exports.tests = [
         android40: true,
         xs6: false,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -13027,6 +13551,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       }
     },
     {
@@ -13044,6 +13569,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       }
     },
   ]
@@ -13075,6 +13601,7 @@ exports.tests = [
         node5: true,
         xs6: true,
         ejs: true,
+        duktape20: false,
       }
     },
     {
@@ -13099,6 +13626,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         safari10: true,
+        duktape20: false,
       }
     },
   ]
@@ -13133,6 +13661,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13153,6 +13682,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13183,6 +13713,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13213,6 +13744,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13237,6 +13769,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13266,6 +13799,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13282,6 +13816,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13306,6 +13841,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13330,6 +13866,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -13359,6 +13896,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13396,6 +13934,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       }
     },
     {
@@ -13416,6 +13955,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
   ],
@@ -13455,6 +13995,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -13475,6 +14016,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -13498,6 +14040,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -13520,6 +14063,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -13539,6 +14083,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -13560,6 +14105,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -13581,6 +14127,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13602,6 +14149,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13623,6 +14171,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -13644,6 +14193,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -13667,6 +14217,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13689,6 +14240,7 @@ exports.tests = [
         xs6: null,
         ejs: null,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13711,6 +14263,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13733,6 +14286,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -13755,6 +14309,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13777,6 +14332,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13798,6 +14354,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13820,6 +14377,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13842,6 +14400,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13864,6 +14423,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -13889,6 +14449,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -13911,6 +14472,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -13949,6 +14511,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -13988,6 +14551,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14009,6 +14573,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14035,6 +14600,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -14064,6 +14630,7 @@ exports.tests = [
         chrome49: true,
         edge14: "flagged",
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -14082,6 +14649,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -14100,6 +14668,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -14118,6 +14687,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -14136,6 +14706,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14155,6 +14726,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ]
@@ -14186,6 +14758,7 @@ exports.tests = [
         node012: true,
         android40: true,
         xs6: true,
+        duktape20: false,
       }
     },
     {
@@ -14206,6 +14779,7 @@ exports.tests = [
         node012: false,
         android40: false,
         xs6: null,
+        duktape20: false,
       }
     },
   ]
@@ -14234,6 +14808,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -14253,6 +14828,7 @@ exports.tests = [
         node012: true,
         android40: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -14271,6 +14847,7 @@ exports.tests = [
         node012: true,
         android40: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14290,6 +14867,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14308,6 +14886,7 @@ exports.tests = [
         node012: true,
         android40: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14329,6 +14908,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -14350,6 +14930,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14371,6 +14952,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -14401,6 +14983,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -14423,6 +15006,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -14445,6 +15029,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -14466,6 +15051,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -14487,6 +15073,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -14509,6 +15096,7 @@ exports.tests = [
         edge13: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -14531,6 +15119,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -14552,6 +15141,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -14576,6 +15166,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14601,6 +15192,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14620,6 +15212,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -14649,6 +15242,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14673,6 +15267,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14697,6 +15292,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14721,6 +15317,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14744,6 +15341,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14790,6 +15388,7 @@ exports.tests = [
         node4: false,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14813,6 +15412,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14843,6 +15443,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14870,6 +15471,7 @@ exports.tests = [
         chrome51: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14896,6 +15498,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -14928,6 +15531,7 @@ exports.tests = [
         android41: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14951,6 +15555,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14974,6 +15579,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -14998,6 +15604,7 @@ exports.tests = [
         android41: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -15020,6 +15627,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -15043,6 +15651,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -15066,6 +15675,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -15092,6 +15702,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'imul': {
         ejs: true,
@@ -15114,6 +15725,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'sign': {
         ejs: true,
@@ -15131,6 +15743,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'log10': {
         ejs: true,
@@ -15148,6 +15761,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
       'log2': {
         ejs: true,
@@ -15165,6 +15779,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
       'log1p': {
         ejs: true,
@@ -15182,6 +15797,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'expm1': {
         ejs: true,
@@ -15198,6 +15814,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'cosh': {
         ejs: true,
@@ -15215,6 +15832,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'sinh': {
         ejs: true,
@@ -15232,6 +15850,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'tanh': {
         ejs: true,
@@ -15249,6 +15868,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'acosh': {
         ejs: true,
@@ -15266,6 +15886,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'asinh': {
         ejs: true,
@@ -15282,6 +15903,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'atanh': {
         ejs: true,
@@ -15299,6 +15921,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'trunc': {
         ejs: true,
@@ -15316,6 +15939,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
       'fround': {
         ejs: true,
@@ -15332,6 +15956,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
       'cbrt': {
         ejs: true,
@@ -15349,6 +15974,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     };
     var eqFn = ' === "function"';
@@ -15384,6 +16010,7 @@ exports.tests = [
         node012: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       }
     });
   }()),
@@ -15408,6 +16035,7 @@ exports.tests = [
     chrome47: true,
     xs6: true,
     safari10: true,
+    duktape20: false,
   }
 },
 {
@@ -15436,6 +16064,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -15457,6 +16086,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -15478,6 +16108,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -15495,6 +16126,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -15513,6 +16145,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -15531,6 +16164,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -15549,6 +16183,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         safari10: true,
+        duktape20: false,
       }
     },
     {
@@ -15568,6 +16203,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -15587,6 +16223,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -15607,6 +16244,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       }
     },
     {
@@ -15627,6 +16265,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       }
     },
   ],
@@ -15655,6 +16294,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -15677,6 +16317,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -15697,6 +16338,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -15717,6 +16359,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -15743,6 +16386,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -15762,6 +16406,7 @@ exports.tests = [
         chrome48: "flagged",
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -15782,6 +16427,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -15800,6 +16446,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -15818,6 +16465,7 @@ exports.tests = [
         firefox45: true,
         xs6: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -15835,6 +16483,7 @@ exports.tests = [
         chrome48: "flagged",
         chrome49: true,
         safari10: true,
+        duktape20: false,
       },
     },
   ],
@@ -15882,6 +16531,7 @@ exports.tests = [
         node5: "strict",
         xs6: true,
         ejs: true,
+        duktape20: false,
       },
     },
     {
@@ -15902,6 +16552,7 @@ exports.tests = [
         node5: "strict",
         xs6: true,
         ejs: true,
+        duktape20: false,
       },
     },
     {
@@ -15933,6 +16584,7 @@ exports.tests = [
         safari10: true,
         node5: "strict",
         xs6: true,
+        duktape20: false,
       },
     },
     {
@@ -15964,6 +16616,7 @@ exports.tests = [
         safari10: true,
         node5: "strict",
         xs6: true,
+        duktape20: false,
       },
     },
   ],
@@ -15993,6 +16646,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -16014,6 +16668,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -16037,6 +16692,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -16058,6 +16714,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -16082,6 +16739,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -16107,6 +16765,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         jxa: true,
+        duktape20: false,
       },
     },
   ],
@@ -16168,6 +16827,7 @@ exports.tests = [
         konq414: null,
         rhino17: null,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -16203,6 +16863,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -16242,6 +16903,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -16282,6 +16944,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -16312,6 +16975,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -16350,6 +17014,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         chrome49: true,
+        duktape20: true,
       },
     },
     {
@@ -16382,6 +17047,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         chrome49: true,
+        duktape20: false,
       }
     },
   ],
@@ -16416,6 +17082,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -16433,6 +17100,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -16455,6 +17123,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -16479,6 +17148,7 @@ exports.tests = [
         safari9: true,
         xs6: true,
         jxa: true,
+        duktape20: false,
       },
     },
     {
@@ -16499,6 +17169,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -16522,6 +17193,7 @@ exports.tests = [
         android40: true,
         xs6: true,
         jxa: true,
+        duktape20: true,
       },
     },
     {
@@ -16539,6 +17211,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -16556,6 +17229,7 @@ exports.tests = [
         xs6: null,
         jxa: true,
         safari10: true,
+        duktape20: true,
       },
     },
     {
@@ -16583,6 +17257,7 @@ exports.tests = [
         firefox53: true,
         chrome50: true,
         safari10: true,
+        duktape20: false,
       },
     },
     {
@@ -16606,6 +17281,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         jxa: true,
+        duktape20: true,
       },
     },
   ],
@@ -16634,6 +17310,7 @@ exports.tests = [
     android40: true,
     edge13: false,
     xs6: false,
+    duktape20: false,
   }
 },
 ];

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -20,6 +20,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
     {
@@ -34,6 +35,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
   ],
@@ -55,6 +57,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
     {
@@ -70,6 +73,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
     {
@@ -85,6 +89,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -148,6 +153,7 @@ exports.tests = [
         safaritp: true,
         webkit: true,
         node012: true,
+        duktape20: false,
       },
     },
   ],
@@ -169,6 +175,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
   ],
@@ -190,6 +197,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
   ],
@@ -211,6 +219,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
     {
@@ -225,6 +234,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
     {
@@ -240,6 +250,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
     {
@@ -255,6 +266,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -318,6 +330,7 @@ exports.tests = [
         safaritp: true,
         webkit: true,
         node012: true,
+        duktape20: false,
       },
     },
   ],
@@ -339,6 +352,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
     {
@@ -354,6 +368,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
     {
@@ -369,6 +384,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       },
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -432,6 +448,7 @@ exports.tests = [
         safaritp: true,
         webkit: true,
         node012: true,
+        duktape20: false,
       },
     },
     {
@@ -456,6 +473,7 @@ exports.tests = [
         opera12: null,
         android40: null,
         ios7: false,
+        duktape20: false,
       }
     },
     {
@@ -480,6 +498,7 @@ exports.tests = [
         chrome24: true,
         safari10: true,
         node012: true,
+        duktape20: false,
       }
     }
   ],
@@ -504,6 +523,7 @@ exports.tests = [
         ios7: true,
         node010: true,
         android40: true,
+        duktape20: true,
       },
     },
   ],
@@ -528,6 +548,7 @@ exports.tests = [
         ios7: true,
         node010: true,
         android40: true,
+        duktape20: true,
       },
     },
   ],
@@ -552,6 +573,7 @@ exports.tests = [
         ios7: true,
         node010: true,
         android40: true,
+        duktape20: true,
       },
     },
   ],
@@ -576,6 +598,7 @@ exports.tests = [
         ios7: true,
         node010: true,
         android40: true,
+        duktape20: true,
       },
     },
   ],
@@ -600,6 +623,7 @@ exports.tests = [
         ios7: true,
         node010: true,
         android40: true,
+        duktape20: true,
       },
     },
   ],
@@ -624,6 +648,7 @@ exports.tests = [
         ios7: true,
         node010: true,
         android40: true,
+        duktape20: true,
       },
     },
   ],
@@ -648,6 +673,7 @@ exports.tests = [
         ios7: true,
         node010: true,
         android40: true,
+        duktape20: true,
       },
     },
   ],

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1461,11 +1461,12 @@ exports.tests = [
   category: STAGE3,
   significance: 'small',
   exec: function(){/*
-    return /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb');
+    return /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&
+           !/(?<=a)b/.test('b');
   */},
   res : {
     chrome50: "flagged",
-    duktape20: false,  // tests true due to a bug fixed in Duktape 2.0.3
+    duktape20: false,
   }
 },
 {

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -30,6 +30,7 @@ exports.tests = [
       */},
       res: {
         babel: true,
+        duktape20: false,
       }
     },
     {
@@ -40,6 +41,7 @@ exports.tests = [
       */},
       res: {
         babel: true,
+        duktape20: false,
       },
     },
   ],
@@ -57,6 +59,7 @@ exports.tests = [
   */},
   res: {
     babel: true,
+    duktape20: false,
   }
 },
 {
@@ -74,6 +77,7 @@ exports.tests = [
     return result === 'tromple';
   */},
   res: {
+    duktape20: false,
   }
 },
 {
@@ -93,6 +97,7 @@ exports.tests = [
         edge12: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -105,6 +110,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -117,6 +123,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -129,6 +136,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -141,6 +149,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -153,6 +162,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -165,6 +175,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -177,6 +188,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -189,6 +201,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -201,6 +214,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -213,6 +227,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -225,6 +240,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -237,6 +253,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -249,6 +266,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -261,6 +279,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -273,6 +292,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -285,6 +305,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -297,6 +318,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -309,6 +331,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -321,6 +344,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -333,6 +357,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -345,6 +370,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -357,6 +383,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -369,6 +396,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -381,6 +409,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -393,6 +422,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -405,6 +435,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -417,6 +448,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -429,6 +461,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -441,6 +474,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -453,6 +487,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -465,6 +500,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -477,6 +513,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -489,6 +526,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -501,6 +539,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -513,6 +552,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -525,6 +565,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -537,6 +578,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -549,6 +591,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -561,6 +604,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -573,6 +617,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -585,6 +630,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -597,6 +643,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -609,6 +656,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -621,6 +669,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -633,6 +682,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -645,6 +695,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -657,6 +708,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -669,6 +721,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -681,6 +734,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -693,6 +747,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -705,6 +760,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -716,6 +772,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -728,6 +785,7 @@ exports.tests = [
         edge13: "flagged",
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
+        duktape20: false,
       }
     },
     {
@@ -740,6 +798,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -753,6 +812,7 @@ exports.tests = [
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         edge14: "flagged",
+        duktape20: false,
       }
     },
     {
@@ -764,6 +824,7 @@ exports.tests = [
       */},
       res: {
         chrome37: chrome.simd,
+        duktape20: false,
       }
     }
   ]
@@ -787,6 +848,7 @@ exports.tests = [
   res: {
     babel: {val: false, note_id: "regenerator-decorators-legacy", note_html: "Babel 6 still has no official support decorators, but you can use <a href='https://github.com/loganfsmyth/regenerator-plugin-transform-decorators-legacy'>this plugin</a>."},
     typescript: true,
+    duktape20: false,
   }
 },
 {
@@ -805,6 +867,7 @@ exports.tests = [
     babel: true,
     tr: true,
     typescript: true,
+    duktape20: false,
   }
 },
 {
@@ -819,6 +882,7 @@ exports.tests = [
       });
   */},
   res: {
+    duktape20: false,
   }
 },
 {
@@ -836,6 +900,7 @@ exports.tests = [
     jsx: true,
     chrome58: 'flagged',
     webkit: true,
+    duktape20: false,
   }
 },
 {
@@ -853,6 +918,7 @@ exports.tests = [
     jsx: true,
     chrome58: 'flagged',
     typescript: true,
+    duktape20: false,
   }
 },
 {
@@ -867,6 +933,7 @@ exports.tests = [
     babel: true,
     typescript: typescript.corejs,
     es7shim: true,
+    duktape20: false,
   }
 },
 {
@@ -899,6 +966,7 @@ exports.tests = [
         es7shim: true,
         android40: true,
         ios51: true,
+        duktape20: false,
       }
     },
     {
@@ -925,6 +993,7 @@ exports.tests = [
         es7shim: true,
         android40: true,
         ios51: true,
+        duktape20: false,
       }
     },
     {
@@ -935,6 +1004,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -945,6 +1015,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     }
   ]
@@ -985,6 +1056,7 @@ exports.tests = [
       node65: true,
       node7: true,
       node76: true,
+      duktape20: false,
     }
   }, {
     name: '"global" global property has correct property descriptor',
@@ -1022,6 +1094,7 @@ exports.tests = [
       node65: false,
       node7: false,
       node76: false,
+      duktape20: false,
     }
   }]
 },
@@ -1039,6 +1112,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1049,6 +1123,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1059,6 +1134,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1069,6 +1145,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
   ]
@@ -1087,6 +1164,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1097,6 +1175,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1107,6 +1186,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1127,6 +1207,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1138,6 +1219,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1149,6 +1231,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1159,6 +1242,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1169,6 +1253,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     }
   ]
@@ -1194,6 +1279,7 @@ exports.tests = [
   res: {
     babel: true,
     typescript: typescript.corejs,
+    duktape20: false,
   }
 },
 {
@@ -1209,6 +1295,7 @@ exports.tests = [
         return f();
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1217,6 +1304,7 @@ exports.tests = [
         return (_ => function.count)(1, 2, 3) === 3;
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1230,6 +1318,7 @@ exports.tests = [
           && arr[2] === 3;
       */},
       res: {
+        duktape20: false,
       }
     }
   ]
@@ -1255,6 +1344,7 @@ exports.tests = [
   */},
   res : {
     typescript: true,
+    duktape20: false,
   }
 },
 {
@@ -1273,6 +1363,7 @@ exports.tests = [
     })(2);
   */},
   res : {
+    duktape20: false,
   }
 },
 {
@@ -1288,6 +1379,7 @@ exports.tests = [
     return works && weakref.get() === undefined;
   */},
   res : {
+    duktape20: false,
   }
 },
 {
@@ -1311,6 +1403,7 @@ exports.tests = [
       res: {
         babel: true,
         firefox55: firefox.nightly,
+        duktape20: false,
       }
     },
     {
@@ -1338,6 +1431,7 @@ exports.tests = [
       res: {
         babel: true,
         firefox55: firefox.nightly,
+        duktape20: false,
       }
     }
   ]
@@ -1358,6 +1452,7 @@ exports.tests = [
       && result.groups[3] === '11';
   */},
   res : {
+    duktape20: false,
   }
 },
 {
@@ -1370,6 +1465,7 @@ exports.tests = [
   */},
   res : {
     chrome50: "flagged",
+    duktape20: false,  // tests true due to a bug fixed in Duktape 2.0.3
   }
 },
 {
@@ -1382,6 +1478,7 @@ exports.tests = [
     return regexGreekSymbol.test('π');
   */},
   res: {
+    duktape20: false,
   }
 },
 {
@@ -1398,6 +1495,7 @@ exports.tests = [
           && !Reflect.isCallable(class {});
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1408,6 +1506,7 @@ exports.tests = [
           && Reflect.isConstructor(class {});
       */},
       res: {
+        duktape20: false,
       }
     }
   ]
@@ -1426,6 +1525,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1436,6 +1536,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1446,6 +1547,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1456,6 +1558,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1466,6 +1569,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1476,6 +1580,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1486,6 +1591,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1496,6 +1602,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     },
     {
@@ -1506,6 +1613,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
+        duktape20: false,
       }
     }
   ]
@@ -1522,6 +1630,7 @@ exports.tests = [
         return typeof Zone == 'function';
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1530,6 +1639,7 @@ exports.tests = [
         return 'current' in Zone;
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1538,6 +1648,7 @@ exports.tests = [
         return 'name' in Zone.prototype;
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1546,6 +1657,7 @@ exports.tests = [
         return 'parent' in Zone.prototype;
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1554,6 +1666,7 @@ exports.tests = [
         return typeof Zone.prototype.fork == 'function';
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1562,6 +1675,7 @@ exports.tests = [
         return typeof Zone.prototype.run == 'function';
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1570,6 +1684,7 @@ exports.tests = [
         return typeof Zone.prototype.wrap == 'function';
       */},
       res: {
+        duktape20: false,
       }
     }
   ]
@@ -1584,6 +1699,7 @@ exports.tests = [
       && typeof Reflect.Realm.prototype.spawn === 'function';
   */},
   res: {
+    duktape20: false,
   }
 },
 {
@@ -1607,6 +1723,7 @@ exports.tests = [
         return new C(42).x() === 42;
       */},
       res: {
+        duktape20: false,
       }
     },
     {
@@ -1621,6 +1738,7 @@ exports.tests = [
         return new C().x() === 42;
       */},
       res: {
+        duktape20: false,
       }
     },
   ]
@@ -1639,6 +1757,7 @@ exports.tests = [
   res : {
     babel: true,
     typescript: typescript.corejs,
+    duktape20: false,
   }
 },
 {
@@ -1658,7 +1777,9 @@ exports.tests = [
           return continue f(n - 1);
         }(1e6)) === "foo";
       */},
-      res: {},
+      res: {
+        duktape20: false,
+      },
     },
     {
       name: 'mutual recursion',
@@ -1678,7 +1799,9 @@ exports.tests = [
         }
         return f(1e6) === "foo" && f(1e6+1) === "bar";
       */},
-      res: {},
+      res: {
+        duktape20: false,
+      },
     }
   ]
 },
@@ -1697,6 +1820,7 @@ exports.tests = [
     */},
     res: {
       firefox54: true,
+      duktape20: false,
     },
   }, {
     name: 'arrows',
@@ -1710,6 +1834,7 @@ exports.tests = [
       chrome50: true,
       safari10: true,
       edge13: true,
+      duktape20: false,
     },
   }, {
     name: '[native code]',
@@ -1724,6 +1849,7 @@ exports.tests = [
       chrome50: true,
       safari9: true,
       edge13: true,
+      duktape20: true,
     },
   }, {
     name: 'class expression with implicit constructor',
@@ -1736,6 +1862,7 @@ exports.tests = [
       chrome50: true,
       safari10: true,
       edge14: true,
+      duktape20: false,
     },
   }, {
     name: 'class expression with explicit constructor',
@@ -1748,6 +1875,7 @@ exports.tests = [
       chrome50: true,
       safari10: true,
       edge14: true,
+      duktape20: false,
     },
   }, {
     name: 'unicode escape sequences in identifiers',
@@ -1757,6 +1885,7 @@ exports.tests = [
     */},
     res: {
       firefox54: true,
+      duktape20: false,
     },
   }, {
     name: 'methods and computed property names',
@@ -1766,6 +1895,7 @@ exports.tests = [
     */},
     res: {
       firefox54: true,
+      duktape20: false,
     },
   }]
 },

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -16,6 +16,7 @@ exports.tests = [
       res: {
         firefox2: true,
         rhino17: true,
+        duktape20: false,
       }
     },
     {
@@ -37,6 +38,7 @@ exports.tests = [
         firefox2: true,
         besen: true,
         rhino17: true,
+        duktape20: false,
       },
     },
     {
@@ -47,6 +49,7 @@ exports.tests = [
       res: {
         firefox2: true,
         rhino17: null,
+        duktape20: false,
       },
     },
     {
@@ -147,6 +150,7 @@ exports.tests = [
         firefox2: true,
         besen: null,
         rhino17: null,
+        duktape20: false,
       },
     },
   ]
@@ -164,6 +168,7 @@ exports.tests = [
     firefox3_5: true,
     firefox4: false,
     rhino17: null,
+    duktape20: false,
   },
   separator: 'after'
 },
@@ -186,6 +191,7 @@ exports.tests = [
     rhino17: false,
     phantom: true,
     android40: true,
+    duktape20: false,
   }
 },
 {
@@ -206,7 +212,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -231,6 +238,7 @@ exports.tests = [
     rhino17: true,
     phantom: true,
     android40: true,
+    duktape20: false,
   }
 },
 {
@@ -250,7 +258,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   },
   separator: 'after'
 },
@@ -265,6 +274,7 @@ exports.tests = [
     safari10_1: true,
     safaritp: true,
     webkit: true,
+    duktape20: false,
   },
 },
 {
@@ -285,7 +295,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -305,7 +316,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -330,7 +342,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -347,7 +360,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -364,7 +378,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   },
   separator: 'after'
 },
@@ -388,7 +403,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -401,6 +417,7 @@ exports.tests = [
   */},
   res: {
     firefox30: true,
+    duktape20: false,
   }
 },
 {
@@ -419,7 +436,8 @@ exports.tests = [
     konq44: false,
     besen: true,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -439,7 +457,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -463,7 +482,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -487,7 +507,8 @@ exports.tests = [
     konq49: false,
     besen: null,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   },
   separator: 'after'
 },
@@ -522,7 +543,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -559,7 +581,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -605,7 +628,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   },
 },
 {
@@ -626,7 +650,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -645,6 +670,7 @@ exports.tests = [
   */},
   res: {
     firefox30: true,
+    duktape20: false,
   },
   separator: 'after'
 },
@@ -669,7 +695,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -693,6 +720,7 @@ exports.tests = [
     rhino17: true,
     phantom: true,
     android40: true,
+    duktape20: false,
   }
 },
 {
@@ -716,6 +744,7 @@ exports.tests = [
     rhino17: true,
     phantom: true,
     android40: true,
+    duktape20: false,
   }
 },
 {
@@ -734,7 +763,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -754,7 +784,8 @@ exports.tests = [
     konq49: true,
     besen: null,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,  // tests true due to a bug fixed in Duktape 2.0.3
   },
   separator: 'after'
 },
@@ -779,6 +810,7 @@ exports.tests = [
     rhino17: false,
     phantom: true,
     android40: true,
+    duktape20: false,
   }
 },
 {
@@ -802,6 +834,7 @@ exports.tests = [
     rhino17: false,
     phantom: true,
     android40: true,
+    duktape20: false,
   }
 },
 {
@@ -818,7 +851,8 @@ exports.tests = [
     konq44: false,
     besen: null,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -830,7 +864,8 @@ exports.tests = [
     firefox2: true,
     firefox49: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   },
   separator: 'after'
 },
@@ -848,7 +883,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   },
 },
 {
@@ -870,6 +906,7 @@ exports.tests = [
     rhino17: true,
     ejs: true,
     android40: true,
+    duktape20: false,
   },
   separator: 'after'
 },
@@ -887,7 +924,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -904,7 +942,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -921,7 +960,8 @@ exports.tests = [
     konq44: false,
     besen: true,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   },
 },
 {
@@ -936,6 +976,7 @@ exports.tests = [
     chrome49: false,
     node010: true,
     android50: true,
+    duktape20: false,
   },
   separator: 'after'
 },
@@ -965,6 +1006,7 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     android40: true,
+    duktape20: true,
   }
 },
 {
@@ -983,7 +1025,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: true,
   }
 },
 {
@@ -1003,7 +1046,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   }
 },
 {
@@ -1022,7 +1066,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: true,
-    phantom: false
+    phantom: false,
+    duktape20: true,
   }
 },
 {
@@ -1040,7 +1085,8 @@ exports.tests = [
     konq44: false,
     besen: false,
     rhino17: false,
-    phantom: false
+    phantom: false,
+    duktape20: false,
   },
   separator: 'after'
 }

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -770,7 +770,8 @@ exports.tests = [
 {
   name: 'RegExp named groups',
   exec: function () {/*
-    return /(?P<name>a)(?P=name)/.test("aa");
+    return /(?P<name>a)(?P=name)/.test("aa") &&
+           !/(?P<name>a)(?P=name)/.test("")
   */},
   res: {
     ie7: false,
@@ -785,7 +786,7 @@ exports.tests = [
     besen: null,
     rhino17: false,
     phantom: false,
-    duktape20: false,  // tests true due to a bug fixed in Duktape 2.0.3
+    duktape20: false,
   },
   separator: 'after'
 },

--- a/duktape.js
+++ b/duktape.js
@@ -1,0 +1,109 @@
+/*
+ *  Node.js test runner for running data-*.js tests with Duktape 'duk' command.
+ *
+ *  Reports discrepancies to console; fix them manually in data-*.js files.
+ *  Expects a './duk' command in the current directory.  Example:
+ *
+ *    $ cp /path/to/duk ./duk
+ *    $ node duktape.js
+ */
+
+var fs = require('fs');
+var child_process = require('child_process');
+
+var testCount = 0;
+var testSuccess = 0;
+var testOutOfDate = 0;
+
+var dukCommand = './duk';
+
+// Key for .res (e.g. test.res.duktape20), automatic based on Duktape.version.
+var dukKey = (function () {
+    var stdout = child_process.execFileSync(dukCommand, [ '-e', 'print(Duktape.version)' ], {
+        encoding: 'utf-8'
+    });
+    var dukVersion = Number(stdout);
+    console.log('Duktape version is: ' + dukVersion);
+    return 'duktape' + (Math.floor(dukVersion / 10000)) + (Math.floor(dukVersion / 100 % 100));
+})();
+console.log('Duktape result key is: test.res.' + dukKey);
+
+// Run test / subtests, recursively.  Report results, indicate data files
+// which are out of date.
+function runTest(parents, test, sublevel) {
+    var testPath = parents.join(' -> ') + ' -> ' + test.name;
+
+    if (typeof test.exec === 'function') {
+        var src = test.exec.toString();
+        var m = /^function\s*\w*\s*\(.*?\)\s*\{\s*\/\*([\s\S]*?)\*\/\s*\}$/m.exec(src);
+        var evalcode;
+        if (m) {
+            evalcode = '(function test() {' + m[1] + '})();';
+        } else {
+            evalcode = '(' + src + ')()';
+        }
+        //console.log(evalcode);
+
+        var script = 'var evalcode = ' + JSON.stringify(evalcode) + ';\n' +
+                     'try {\n' +
+                     '    var res = eval(evalcode);\n' +
+                     '    if (res !== true && res !== 1) { throw new Error("failed: " + res); }\n' +
+                     '    console.log("[SUCCESS]");\n' +
+                     '} catch (e) {\n' +
+                     '    console.log("[FAILURE]", e);\n' +
+                     '    /*throw e;*/\n' +
+                     '}\n';
+
+        fs.writeFileSync('duktest.js', script);
+        var stdout = child_process.execFileSync(dukCommand, [ 'duktest.js' ], {
+            encoding: 'utf-8'
+        });
+        //console.log(stdout);
+
+        var success = false;
+        if (/^\[SUCCESS\]$/gm.test(stdout)) {
+            success = true;
+            testSuccess++;
+        } else {
+            //console.log(stdout);
+        }
+        testCount++;
+
+        if (test.res) {
+            if (test.res[dukKey] === success) {
+                // Matches.
+            } else if (test.res[dukKey] === void 0 && !success) {
+                testOutOfDate++;
+                console.log(testPath + ': test result missing, res: ' + test.res[dukKey] + ', actual: ' + success);
+            } else {
+                testOutOfDate++;
+                console.log(testPath + ': test result out of date, res: ' + test.res[dukKey] + ', actual: ' + success);
+            }
+        } else {
+            testOutOfDate++;
+            console.log(testPath + ': test.res missing');
+        }
+    }
+    if (test.subtests) {
+        var newParents = parents.slice(0);
+        newParents.push(test.name);
+        test.subtests.forEach(function (v) { runTest(newParents, v, sublevel + 1); });
+    }
+}
+
+fs.readdirSync('.').forEach(function (filename) {
+    var m = /^(data-.*)\.js$/.exec(filename);
+    if (!m) {
+        return;
+    }
+    var suitename = m[1];
+
+    console.log('');
+    console.log('**** ' + suitename + ' ****');
+    console.log('');
+    var testsuite = require('./' + suitename);
+    testsuite.tests.forEach(function (v) { runTest([ suitename ], v, 0); });
+});
+
+console.log(testCount + ' tests executed: ' + testSuccess + ' success, ' + (testCount - testSuccess) + ' fail');
+console.log(testOutOfDate + ' tests are out of date (data-*.js file .res)');

--- a/environments.json
+++ b/environments.json
@@ -1591,5 +1591,12 @@
     "platformtype": "mobile",
     "equals": "safari10",
     "obsolete": false
+  },
+  "duktape20": {
+    "full": "Duktape 2.0.x",
+    "family": "Duktape",
+    "short": "DUK 20",
+    "platformtype": "engine",
+    "obsolete": false
   }
 }

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -175,12 +175,13 @@
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
 <th class="platform ios9 mobile" data-browser="ios9"><a href="#ios9" class="browser-name"><abbr title="iOS Safari">iOS 9</abbr></a></th>
 <th class="platform ios10 mobile" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10</abbr></a></th>
+<th class="platform duktape20 engine" data-browser="duktape20"><a href="#duktape20" class="browser-name"><abbr title="Duktape 2.0.x">DUK 20</abbr></a></th>
 </tr>
 
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="72">2016 features</td>
+      <tr class="category"><td colspan="73">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -253,6 +254,7 @@
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/3</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/3</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/3</td>
+<td class="tally" data-browser="duktape20" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 </tr>
 <tr class="subtest" data-parent="exponentiation_(**)_operator" id="test-exponentiation_(**)_operator_basic_support"><td><span><a class="anchor" href="#test-exponentiation_(**)_operator_basic_support">&#xA7;</a>basic support</span><script data-source="
 return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
@@ -328,6 +330,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="exponentiation_(**)_operator" id="test-exponentiation_(**)_operator_assignment"><td><span><a class="anchor" href="#test-exponentiation_(**)_operator_assignment">&#xA7;</a>assignment</span><script data-source="
 var a = 2; a **= 3; return a === 8;
@@ -403,6 +406,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="exponentiation_(**)_operator" id="test-exponentiation_(**)_operator_early_syntax_error_for_unary_negation_without_parens"><td><span><a class="anchor" href="#test-exponentiation_(**)_operator_early_syntax_error_for_unary_negation_without_parens">&#xA7;</a>early syntax error for unary negation without parens</span><script data-source="
 if (2 ** 3 !== 8) { return false; }
@@ -483,6 +487,7 @@ return true;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array.prototype.includes"><span><a class="anchor" href="#test-Array.prototype.includes">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-array.prototype.includes">Array.prototype.includes</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
@@ -555,6 +560,7 @@ return true;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/3</td>
 <td class="tally" data-browser="ios9" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ios10" data-tally="1">3/3</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/3</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.includes" id="test-Array.prototype.includes_Array.prototype.includes_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array.prototype.includes_Array.prototype.includes_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.includes <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [1, 2, 3].includes(1)
@@ -634,6 +640,7 @@ return [1, 2, 3].includes(1)
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.includes" id="test-Array.prototype.includes_Array.prototype.includes_is_generic"><td><span><a class="anchor" href="#test-Array.prototype.includes_Array.prototype.includes_is_generic">&#xA7;</a>Array.prototype.includes is generic</span><script data-source="
 var passed = 0;
@@ -731,6 +738,7 @@ return 24;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.includes" id="test-Array.prototype.includes_%TypedArray%.prototype.includes_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array.prototype.includes_%TypedArray%.prototype.includes_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>%TypedArray%.prototype.includes <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
@@ -811,8 +819,9 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr class="category"><td colspan="72">2016 misc</td>
+<tr class="category"><td colspan="73">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -895,6 +904,7 @@ return true;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_throw()_caught_by_inner_generator"><span><a class="anchor" href="#test-generator_throw()_caught_by_inner_generator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-generatorfunction-objects">generator throw() caught by inner generator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#IteratorResult_object_returned_instead_of_throwing" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#gen-throw-note"><sup>[8]</sup></a></span><script data-source="
 function * generator() {
@@ -983,6 +993,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.125"><td id="test-strict_fn_w/_non-strict_non-simple_params_is_error"><span><a class="anchor" href="#test-strict_fn_w/_non-strict_non-simple_params_is_error">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-functiondeclarationinstantiation">strict fn w/ non-strict non-simple params is error</a><a href="#strict-fn-non-strict-params-note"><sup>[9]</sup></a></span><script data-source="
 function foo(...a){}
@@ -1063,6 +1074,7 @@ return true;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.125"><td id="test-nested_rest_destructuring,_declarations"><span><a class="anchor" href="#test-nested_rest_destructuring,_declarations">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-destructuring-assignment">nested rest destructuring, declarations</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Nested_object_and_array_destructuring" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#nested-rest-destruct-decl-note"><sup>[10]</sup></a></span><script data-source="
 var [x, ...[y, ...z]] = [1,2,3,4];
@@ -1139,6 +1151,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.125"><td id="test-nested_rest_destructuring,_parameters"><span><a class="anchor" href="#test-nested_rest_destructuring,_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-destructuring-assignment">nested rest destructuring, parameters</a><a href="#nested-rest-destruct-params-note"><sup>[11]</sup></a></span><script data-source="
 return function([x, ...[y, ...z]]) {
@@ -1216,6 +1229,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy,_enumerate_handler_removed"><span><a class="anchor" href="#test-Proxy,_enumerate_handler_removed">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-proxy-objects">Proxy, &quot;enumerate&quot; handler removed</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/enumerate" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-enumerate-removed-note"><sup>[12]</sup></a></span><script data-source="
 var passed = true;
@@ -1298,6 +1312,7 @@ return passed;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_internal_calls,_Array.prototype.includes"><span><a class="anchor" href="#test-Proxy_internal_calls,_Array.prototype.includes">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-array.prototype.includes">Proxy internal calls, Array.prototype.includes</a></span><script data-source="
 // Array.prototype.includes -&gt; Get -&gt; [[Get]]
@@ -1382,8 +1397,9 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr class="category"><td colspan="72">2017 features</td>
+<tr class="category"><td colspan="73">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1456,6 +1472,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios10" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/4</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.values_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.values_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.values <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = Object.create({ a: &quot;qux&quot;, d: &quot;qux&quot; });
@@ -1534,6 +1551,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.entries_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.entries_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.entries <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = Object.create({ a: &quot;qux&quot;, d: &quot;qux&quot; });
@@ -1616,6 +1634,7 @@ return Array.isArray(e)
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.getOwnPropertyDescriptors_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.getOwnPropertyDescriptors_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.getOwnPropertyDescriptors <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var object = {a: 1};
@@ -1699,6 +1718,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.getOwnPropertyDescriptors_doesn&apos;t_provide_undefined_descriptors"><td><span><a class="anchor" href="#test-Object_static_methods_Object.getOwnPropertyDescriptors_doesn&apos;t_provide_undefined_descriptors">&#xA7;</a>Object.getOwnPropertyDescriptors doesn&apos;t provide undefined descriptors</span><script data-source="
 var P = new Proxy({a:1}, {
@@ -1777,6 +1797,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String_padding"><span><a class="anchor" href="#test-String_padding">&#xA7;</a><a href="https://github.com/tc39/proposal-string-pad-start-end">String padding</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -1849,6 +1870,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios10" data-tally="1">2/2</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="String_padding" id="test-String_padding_String.prototype.padStart_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_padding_String.prototype.padStart_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.padStart <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
@@ -1927,6 +1949,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="String_padding" id="test-String_padding_String.prototype.padEnd_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_padding_String.prototype.padEnd_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.padEnd <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
@@ -2005,6 +2028,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-trailing_commas_in_function_syntax"><span><a class="anchor" href="#test-trailing_commas_in_function_syntax">&#xA7;</a><a href="https://github.com/tc39/proposal-trailing-function-commas">trailing commas in function syntax</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -2077,6 +2101,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios10" data-tally="1">2/2</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="trailing_commas_in_function_syntax" id="test-trailing_commas_in_function_syntax_in_parameter_lists_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Parameter_definitions_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-trailing_commas_in_function_syntax_in_parameter_lists_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Parameter_definitions_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>in parameter lists <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Parameter_definitions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof function f( a, b, ){} === &apos;function&apos;;
@@ -2152,6 +2177,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="trailing_commas_in_function_syntax" id="test-trailing_commas_in_function_syntax_in_argument_lists_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Function_calls_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-trailing_commas_in_function_syntax_in_argument_lists_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Function_calls_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>in argument lists <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Function_calls" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return Math.min(1,2,3,) === 1;
@@ -2227,6 +2253,7 @@ return Math.min(1,2,3,) === 1;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-async_functions"><span><a class="anchor" href="#test-async_functions">&#xA7;</a><a href="https://tc39.github.io/ecmascript-asyncawait/">async functions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
@@ -2299,6 +2326,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/15</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/15</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/15</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/15</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_return"><td><span><a class="anchor" href="#test-async_functions_return">&#xA7;</a>return</span><script data-source="
 async function a(){
@@ -2385,6 +2413,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_throw"><td><span><a class="anchor" href="#test-async_functions_throw">&#xA7;</a>throw</span><script data-source="
 async function a(){
@@ -2471,6 +2500,7 @@ p.catch(function(result) {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_no_line_break_between_async_and_function"><td><span><a class="anchor" href="#test-async_functions_no_line_break_between_async_and_function">&#xA7;</a>no line break between async and function</span><script data-source="
 async function a(){}
@@ -2547,6 +2577,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_no_prototype_property"><td><span><a class="anchor" href="#test-async_functions_no_prototype_property">&#xA7;</a>no &quot;prototype&quot; property</span><script data-source="
 async function a(){};
@@ -2623,6 +2654,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_await_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-async_functions_await_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>await <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 (async function (){
@@ -2705,6 +2737,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_await,_rejection"><td><span><a class="anchor" href="#test-async_functions_await,_rejection">&#xA7;</a>await, rejection</span><script data-source="
 (async function (){
@@ -2789,6 +2822,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_must_await_a_value"><td><span><a class="anchor" href="#test-async_functions_must_await_a_value">&#xA7;</a>must await a value</span><script data-source="
 async function a(){ await Promise.resolve(); }
@@ -2865,6 +2899,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_can_await_non-Promise_values"><td><span><a class="anchor" href="#test-async_functions_can_await_non-Promise_values">&#xA7;</a>can await non-Promise values</span><script data-source="
 (async function (){
@@ -2946,6 +2981,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_cannot_await_in_parameters"><td><span><a class="anchor" href="#test-async_functions_cannot_await_in_parameters">&#xA7;</a>cannot await in parameters</span><script data-source="
 async function a(){ await Promise.resolve(); }
@@ -3022,6 +3058,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_methods,_object_literals"><td><span><a class="anchor" href="#test-async_functions_async_methods,_object_literals">&#xA7;</a>async methods, object literals</span><script data-source="
 var o = {
@@ -3108,6 +3145,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_methods,_classes"><td><span><a class="anchor" href="#test-async_functions_async_methods,_classes">&#xA7;</a>async methods, classes</span><script data-source="
 class C {
@@ -3194,6 +3232,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_arrow_functions"><td><span><a class="anchor" href="#test-async_functions_async_arrow_functions">&#xA7;</a>async arrow functions</span><script data-source="
 var a = async () =&gt; await Promise.resolve(&quot;foo&quot;);
@@ -3278,6 +3317,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_correct_prototype_chain"><td><span><a class="anchor" href="#test-async_functions_correct_prototype_chain">&#xA7;</a>correct prototype chain</span><script data-source="
 var asyncFunctionProto = Object.getPrototypeOf(async function (){});
@@ -3356,6 +3396,7 @@ return passed;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_function_prototype,_Symbol.toStringTag"><td><span><a class="anchor" href="#test-async_functions_async_function_prototype,_Symbol.toStringTag">&#xA7;</a>async function prototype, Symbol.toStringTag</span><script data-source="
 return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;AsyncFunction&quot;;
@@ -3431,6 +3472,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_function_constructor"><td><span><a class="anchor" href="#test-async_functions_async_function_constructor">&#xA7;</a>async function constructor</span><script data-source="
 var a = async function (){}.constructor(&quot;return &apos;foo&apos;;&quot;);
@@ -3515,6 +3557,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-shared_memory_and_atomics"><span><a class="anchor" href="#test-shared_memory_and_atomics">&#xA7;</a><a href="https://github.com/tc39/ecmascript_sharedmem">shared memory and atomics</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/17</td>
@@ -3587,6 +3630,7 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/17</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/17</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/17</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/17</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_SharedArrayBuffer_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_SharedArrayBuffer_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SharedArrayBuffer <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SharedArrayBuffer === &apos;function&apos;;
@@ -3662,6 +3706,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_SharedArrayBuffer[Symbol.species]"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_SharedArrayBuffer[Symbol.species]">&#xA7;</a>SharedArrayBuffer[Symbol.species]</span><script data-source="
 return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
@@ -3737,6 +3782,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_SharedArrayBuffer.prototype.byteLength_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_SharedArrayBuffer.prototype.byteLength_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SharedArrayBuffer.prototype.byteLength <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
@@ -3812,6 +3858,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_SharedArrayBuffer.prototype.slice_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_SharedArrayBuffer.prototype.slice_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SharedArrayBuffer.prototype.slice <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
@@ -3887,6 +3934,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_SharedArrayBuffer.prototype[Symbol.toStringTag]"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_SharedArrayBuffer.prototype[Symbol.toStringTag]">&#xA7;</a>SharedArrayBuffer.prototype[Symbol.toStringTag]</span><script data-source="
 return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuffer&apos;;
@@ -3962,6 +4010,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.add_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.add_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.add <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.add == &apos;function&apos;;
@@ -4037,6 +4086,7 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.and_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.and_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.and <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.and == &apos;function&apos;;
@@ -4112,6 +4162,7 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.compareExchange_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.compareExchange_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.compareExchange <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.compareExchange == &apos;function&apos;;
@@ -4187,6 +4238,7 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.exchange_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.exchange_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.exchange <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.exchange == &apos;function&apos;;
@@ -4262,6 +4314,7 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.wait_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.wait_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.wait <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.wait == &apos;function&apos;;
@@ -4337,6 +4390,7 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.wake_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.wake_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.wake <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.wake == &apos;function&apos;;
@@ -4412,6 +4466,7 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.isLockFree_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.isLockFree_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.isLockFree <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.isLockFree == &apos;function&apos;;
@@ -4487,6 +4542,7 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.load_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.load_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.load <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.load == &apos;function&apos;;
@@ -4562,6 +4618,7 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.or_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.or_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.or <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.or == &apos;function&apos;;
@@ -4637,6 +4694,7 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.store_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.store_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.store <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.store == &apos;function&apos;;
@@ -4712,6 +4770,7 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.sub_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.sub_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.sub <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.sub == &apos;function&apos;;
@@ -4787,6 +4846,7 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_Atomics.xor_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_Atomics.xor_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Atomics.xor <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.xor == &apos;function&apos;;
@@ -4862,8 +4922,9 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr class="category"><td colspan="72">2017 misc</td>
+<tr class="category"><td colspan="73">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -4944,6 +5005,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr significance="0.125"><td id="test-RegExp_u_flag,_case_folding"><span><a class="anchor" href="#test-RegExp_u_flag,_case_folding">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/525">RegExp &quot;u&quot; flag, case folding</a></span><script data-source="
 return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/\W/iu)
@@ -5022,6 +5084,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.125"><td id="test-arguments.caller_removed"><span><a class="anchor" href="#test-arguments.caller_removed">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/689">arguments.caller removed</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return (function(){
@@ -5100,8 +5163,9 @@ return (function(){
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr class="category"><td colspan="72">2017 annex b</td>
+<tr class="category"><td colspan="73">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -5174,6 +5238,7 @@ return (function(){
 <td class="tally obsolete" data-browser="ios8" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally" data-browser="ios9" data-tally="1">16/16</td>
 <td class="tally" data-browser="ios10" data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineGetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineGetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>__defineGetter__ <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = {};
@@ -5254,6 +5319,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineGetter__,_symbols"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineGetter__,_symbols">&#xA7;</a>__defineGetter__, symbols</span><script data-source="
 var obj = {};
@@ -5335,6 +5401,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineGetter__,_ToObject(this)"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineGetter__,_ToObject(this)">&#xA7;</a>__defineGetter__, ToObject(this)</span><script data-source="
 var key = &apos;__accessors_test__&apos;;
@@ -5416,6 +5483,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineSetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineSetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>__defineSetter__ <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = {};
@@ -5496,6 +5564,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineSetter__,_symbols"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineSetter__,_symbols">&#xA7;</a>__defineSetter__, symbols</span><script data-source="
 var obj = {};
@@ -5577,6 +5646,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineSetter__,_ToObject(this)"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineSetter__,_ToObject(this)">&#xA7;</a>__defineSetter__, ToObject(this)</span><script data-source="
 var key = &apos;__accessors_test__&apos;;
@@ -5658,6 +5728,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>__lookupGetter__ <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = {
@@ -5740,6 +5811,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter__,_prototype_chain"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter__,_prototype_chain">&#xA7;</a>__lookupGetter__, prototype chain</span><script data-source="
 var obj = {
@@ -5822,6 +5894,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter__,_symbols"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter__,_symbols">&#xA7;</a>__lookupGetter__, symbols</span><script data-source="
 var sym = Symbol();
@@ -5905,6 +5978,7 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter__,_ToObject(this)"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter__,_ToObject(this)">&#xA7;</a>__lookupGetter__, ToObject(this)</span><script data-source="
 __lookupGetter__.call(1, &apos;key&apos;);
@@ -5985,6 +6059,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter__,_data_properties_can_shadow_accessors"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter__,_data_properties_can_shadow_accessors">&#xA7;</a>__lookupGetter__, data properties can shadow accessors</span><script data-source="
 var a = { };
@@ -6064,6 +6139,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>__lookupSetter__ <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = {
@@ -6146,6 +6222,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__,_prototype_chain"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__,_prototype_chain">&#xA7;</a>__lookupSetter__, prototype chain</span><script data-source="
 var obj = {
@@ -6228,6 +6305,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__,_symbols"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__,_symbols">&#xA7;</a>__lookupSetter__, symbols</span><script data-source="
 var sym = Symbol();
@@ -6311,6 +6389,7 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__,_ToObject(this)"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__,_ToObject(this)">&#xA7;</a>__lookupSetter__, ToObject(this)</span><script data-source="
 __lookupSetter__.call(1, &apos;key&apos;);
@@ -6391,6 +6470,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__,_data_properties_can_shadow_accessors"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__,_data_properties_can_shadow_accessors">&#xA7;</a>__lookupSetter__, data properties can shadow accessors</span><script data-source="
 var a = { };
@@ -6470,6 +6550,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Proxy_internal_calls,_getter/setter_methods"><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Proxy internal calls, getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -6542,6 +6623,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios10" data-tally="1">4/4</td>
+<td class="tally not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 </tr>
 <tr class="subtest" data-parent="Proxy_internal_calls,_getter/setter_methods" id="test-Proxy_internal_calls,_getter/setter_methods___defineGetter__"><td><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods___defineGetter__">&#xA7;</a>__defineGetter__</span><script data-source="
 // Object.prototype.__defineGetter__ -&gt; DefinePropertyOrThrow -&gt; [[DefineOwnProperty]]
@@ -6621,6 +6703,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Proxy_internal_calls,_getter/setter_methods" id="test-Proxy_internal_calls,_getter/setter_methods___defineSetter__"><td><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods___defineSetter__">&#xA7;</a>__defineSetter__</span><script data-source="
 // Object.prototype.__defineSetter__ -&gt; DefinePropertyOrThrow -&gt; [[DefineOwnProperty]]
@@ -6700,6 +6783,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Proxy_internal_calls,_getter/setter_methods" id="test-Proxy_internal_calls,_getter/setter_methods___lookupGetter__"><td><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods___lookupGetter__">&#xA7;</a>__lookupGetter__</span><script data-source="
 // Object.prototype.__lookupGetter__ -&gt; [[GetOwnProperty]]
@@ -6784,6 +6868,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Proxy_internal_calls,_getter/setter_methods" id="test-Proxy_internal_calls,_getter/setter_methods___lookupSetter__"><td><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods___lookupSetter__">&#xA7;</a>__lookupSetter__</span><script data-source="
 // Object.prototype.__lookupSetter__ -&gt; [[GetOwnProperty]]
@@ -6868,6 +6953,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr significance="0.125" class="optional-feature"><td id="test-assignments_allowed_in_for-in_head_in_non-strict_mode"><span><a class="anchor" href="#test-assignments_allowed_in_for-in_head_in_non-strict_mode">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-initializers-in-forin-statement-heads">assignments allowed in for-in head in non-strict mode</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Compatibility_Initializer_expressions_in_strict_mode" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 for (var i = 0 in {}) {}
@@ -6944,8 +7030,9 @@ return i === 0;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="yes not-applicable" data-browser="duktape20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">2018 features</td>
+<tr class="category"><td colspan="73">2018 features</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -7028,6 +7115,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 </tbody>
     </table>

--- a/es5/index.html
+++ b/es5/index.html
@@ -182,6 +182,7 @@
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
 <th class="platform ios9 mobile" data-browser="ios9"><a href="#ios9" class="browser-name"><abbr title="iOS Safari">iOS 9</abbr></a></th>
 <th class="platform ios10 mobile" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10</abbr></a></th>
+<th class="platform duktape20 engine" data-browser="duktape20"><a href="#duktape20" class="browser-name"><abbr title="Duktape 2.0.x">DUK 20</abbr></a></th>
 </tr>
 
       </thead>
@@ -260,6 +261,7 @@
 <td class="tally obsolete" data-browser="ios8" data-tally="1">5/5</td>
 <td class="tally" data-browser="ios9" data-tally="1">5/5</td>
 <td class="tally" data-browser="ios10" data-tally="1">5/5</td>
+<td class="tally" data-browser="duktape20" data-tally="1">5/5</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Getter_accessors"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Getter_accessors">&#xA7;</a>Getter accessors</span><script data-source="
 return ({ get x(){ return 1 } }).x === 1;
@@ -337,6 +339,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Setter_accessors"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Setter_accessors">&#xA7;</a>Setter accessors</span><script data-source="
 var value = 0;
@@ -416,6 +419,7 @@ return value === 1;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Trailing_commas_in_object_literals"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Trailing_commas_in_object_literals">&#xA7;</a>Trailing commas in object literals</span><script data-source="
 return { a: true, }.a === true;
@@ -493,6 +497,7 @@ return { a: true, }.a === true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Trailing_commas_in_array_literals"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Trailing_commas_in_array_literals">&#xA7;</a>Trailing commas in array literals</span><script data-source="
 return [1,].length === 1;
@@ -570,6 +575,7 @@ return [1,].length === 1;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Reserved_words_as_property_names"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Reserved_words_as_property_names">&#xA7;</a>Reserved words as property names</span><script data-source="
 return ({ if: 1 }).if === 1;
@@ -647,8 +653,9 @@ return ({ if: 1 }).if === 1;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
-<tr><th colspan="75" class="separator"></th>
+<tr><th colspan="76" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -723,6 +730,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="ios8" data-tally="1">13/13</td>
 <td class="tally" data-browser="ios9" data-tally="1">13/13</td>
 <td class="tally" data-browser="ios10" data-tally="1">13/13</td>
+<td class="tally" data-browser="duktape20" data-tally="1">13/13</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.create_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.create_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.create <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.create == &apos;function&apos;;
@@ -802,6 +810,7 @@ return typeof Object.create == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.defineProperty_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.defineProperty_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.defineProperty <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.defineProperty == &apos;function&apos;;
@@ -881,6 +890,7 @@ return typeof Object.defineProperty == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.defineProperties_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.defineProperties_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.defineProperties <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.defineProperties == &apos;function&apos;;
@@ -960,6 +970,7 @@ return typeof Object.defineProperties == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.getPrototypeOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.getPrototypeOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.getPrototypeOf <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.getPrototypeOf == &apos;function&apos;;
@@ -1039,6 +1050,7 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.keys_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.keys_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.keys <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.keys == &apos;function&apos;;
@@ -1118,6 +1130,7 @@ return typeof Object.keys == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.seal_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.seal_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.seal <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.seal == &apos;function&apos;;
@@ -1197,6 +1210,7 @@ return typeof Object.seal == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.freeze_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.freeze_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.freeze <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.freeze == &apos;function&apos;;
@@ -1276,6 +1290,7 @@ return typeof Object.freeze == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.preventExtensions_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.preventExtensions_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.preventExtensions <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.preventExtensions == &apos;function&apos;;
@@ -1355,6 +1370,7 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.isSealed_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.isSealed_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.isSealed <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.isSealed == &apos;function&apos;;
@@ -1434,6 +1450,7 @@ return typeof Object.isSealed == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.isFrozen_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.isFrozen_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.isFrozen <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.isFrozen == &apos;function&apos;;
@@ -1513,6 +1530,7 @@ return typeof Object.isFrozen == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.isExtensible_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.isExtensible_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.isExtensible <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.isExtensible == &apos;function&apos;;
@@ -1592,6 +1610,7 @@ return typeof Object.isExtensible == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.getOwnPropertyDescriptor_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.getOwnPropertyDescriptor_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.getOwnPropertyDescriptor <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.getOwnPropertyDescriptor == &apos;function&apos;;
@@ -1671,6 +1690,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.getOwnPropertyNames_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.getOwnPropertyNames_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.getOwnPropertyNames <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.getOwnPropertyNames == &apos;function&apos;;
@@ -1750,6 +1770,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Array_methods"><span><a class="anchor" href="#test-Array_methods">&#xA7;</a>Array methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="1">12/12</td>
@@ -1824,6 +1845,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally obsolete" data-browser="ios8" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="ios9" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="ios10" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
+<td class="tally" data-browser="duktape20" data-tally="1">12/12</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.isArray_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.isArray_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.isArray <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.isArray == &apos;function&apos;;
@@ -1903,6 +1925,7 @@ return typeof Array.isArray == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.indexOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.indexOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.indexOf <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.indexOf == &apos;function&apos;;
@@ -1982,6 +2005,7 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.lastIndexOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.lastIndexOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.lastIndexOf <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.lastIndexOf == &apos;function&apos;;
@@ -2061,6 +2085,7 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.every_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.every_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.every <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.every == &apos;function&apos;;
@@ -2140,6 +2165,7 @@ return typeof Array.prototype.every == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.some_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.some_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.some <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.some == &apos;function&apos;;
@@ -2219,6 +2245,7 @@ return typeof Array.prototype.some == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.forEach_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.forEach_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.forEach <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.forEach == &apos;function&apos;;
@@ -2298,6 +2325,7 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.map_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.map_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.map <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.map == &apos;function&apos;;
@@ -2377,6 +2405,7 @@ return typeof Array.prototype.map == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.filter_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.filter_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.filter <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.filter == &apos;function&apos;;
@@ -2456,6 +2485,7 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.reduce_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.reduce_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.reduce <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.reduce == &apos;function&apos;;
@@ -2535,6 +2565,7 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.reduceRight_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.reduceRight_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.reduceRight <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.reduceRight == &apos;function&apos;;
@@ -2614,6 +2645,7 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.sort:_compareFn_must_be_function_or_undefined"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.sort:_compareFn_must_be_function_or_undefined">&#xA7;</a>Array.prototype.sort: compareFn must be function or undefined</span><script data-source="function () {
 try {
@@ -2733,6 +2765,7 @@ return true;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.sort:_compareFn_may_be_explicit_undefined"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.sort:_compareFn_may_be_explicit_undefined">&#xA7;</a>Array.prototype.sort: compareFn may be explicit undefined</span><script data-source="function () {
 try {
@@ -2822,6 +2855,7 @@ try {
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String_properties_and_methods"><span><a class="anchor" href="#test-String_properties_and_methods">&#xA7;</a>String properties and methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -2896,6 +2930,7 @@ try {
 <td class="tally obsolete" data-browser="ios8" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios9" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios10" data-tally="1">2/2</td>
+<td class="tally" data-browser="duktape20" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="String_properties_and_methods" id="test-String_properties_and_methods_Property_access_on_strings_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Character_access_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_properties_and_methods_Property_access_on_strings_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Character_access_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Property access on strings <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Character_access" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &quot;foobar&quot;[3] === &quot;b&quot;;
@@ -2975,6 +3010,7 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="String_properties_and_methods" id="test-String_properties_and_methods_String.prototype.trim_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_properties_and_methods_String.prototype.trim_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.trim <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof String.prototype.trim == &apos;function&apos;;
@@ -3054,6 +3090,7 @@ return typeof String.prototype.trim == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Date_methods"><span><a class="anchor" href="#test-Date_methods">&#xA7;</a>Date methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="1">3/3</td>
@@ -3128,6 +3165,7 @@ return typeof String.prototype.trim == 'function';
 <td class="tally obsolete" data-browser="ios8" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ios9" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ios10" data-tally="1">3/3</td>
+<td class="tally" data-browser="duktape20" data-tally="1">3/3</td>
 </tr>
 <tr class="subtest" data-parent="Date_methods" id="test-Date_methods_Date.prototype.toISOString_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Date_methods_Date.prototype.toISOString_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Date.prototype.toISOString <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Date.prototype.toISOString == &apos;function&apos;;
@@ -3207,6 +3245,7 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Date_methods" id="test-Date_methods_Date.now_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Date_methods_Date.now_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Date.now <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Date.now == &apos;function&apos;;
@@ -3286,6 +3325,7 @@ return typeof Date.now == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Date_methods" id="test-Date_methods_Date.prototype.toJSON_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Date_methods_Date.prototype.toJSON_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Date.prototype.toJSON <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -3373,6 +3413,7 @@ try {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr significance="0.5"><td id="test-Function.prototype.bind"><span><a class="anchor" href="#test-Function.prototype.bind">&#xA7;</a>Function.prototype.bind <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Function.prototype.bind == &apos;function&apos;;
@@ -3452,6 +3493,7 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr significance="0.5"><td id="test-JSON"><span><a class="anchor" href="#test-JSON">&#xA7;</a>JSON <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof JSON == &apos;object&apos;;
@@ -3531,8 +3573,9 @@ return typeof JSON == 'object';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
-<tr><th colspan="75" class="separator"></th>
+<tr><th colspan="76" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -3607,6 +3650,7 @@ return typeof JSON == 'object';
 <td class="tally obsolete" data-browser="ios8" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios9" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios10" data-tally="1">3/3</td>
+<td class="tally" data-browser="duktape20" data-tally="1">3/3</td>
 </tr>
 <tr class="subtest" data-parent="Immutable_globals" id="test-Immutable_globals_undefined"><td><span><a class="anchor" href="#test-Immutable_globals_undefined">&#xA7;</a>undefined</span><script data-source="
 undefined = 12345;
@@ -3687,6 +3731,7 @@ return result;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Immutable_globals" id="test-Immutable_globals_NaN"><td><span><a class="anchor" href="#test-Immutable_globals_NaN">&#xA7;</a>NaN</span><script data-source="
 NaN = false;
@@ -3767,6 +3812,7 @@ return result;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Immutable_globals" id="test-Immutable_globals_Infinity"><td><span><a class="anchor" href="#test-Immutable_globals_Infinity">&#xA7;</a>Infinity</span><script data-source="
 Infinity = false;
@@ -3847,6 +3893,7 @@ return result;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Miscellaneous"><span><a class="anchor" href="#test-Miscellaneous">&#xA7;</a>Miscellaneous</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
@@ -3921,6 +3968,7 @@ return result;
 <td class="tally obsolete" data-browser="ios8" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="ios9" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="ios10" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally" data-browser="duktape20" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Function.prototype.apply_permits_array-likes"><td><span><a class="anchor" href="#test-Miscellaneous_Function.prototype.apply_permits_array-likes">&#xA7;</a>Function.prototype.apply permits array-likes</span><script data-source="function () {
 return (function(a,b) { return a === 1 &amp;&amp; b === 2; }).apply({}, {0:1, 1:2, length:2});
@@ -4000,6 +4048,7 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_parseInt_ignores_leading_zeros"><td><span><a class="anchor" href="#test-Miscellaneous_parseInt_ignores_leading_zeros">&#xA7;</a>parseInt ignores leading zeros</span><script data-source="function () {
 return parseInt(&apos;010&apos;) === 10;
@@ -4079,6 +4128,7 @@ return parseInt('010') === 10;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Function_prototype_property_is_non-enumerable"><td><span><a class="anchor" href="#test-Miscellaneous_Function_prototype_property_is_non-enumerable">&#xA7;</a>Function &quot;prototype&quot; property is non-enumerable</span><script data-source="
 return !Function().propertyIsEnumerable(&apos;prototype&apos;);
@@ -4156,6 +4206,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Arguments_toStringTag_is_Arguments"><td><span><a class="anchor" href="#test-Miscellaneous_Arguments_toStringTag_is_Arguments">&#xA7;</a>Arguments toStringTag is &quot;Arguments&quot;</span><script data-source="
 return (function(){ return Object.prototype.toString.call(arguments) === &apos;[object Arguments]&apos;; }());
@@ -4233,6 +4284,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Zero-width_chars_in_identifiers"><td><span><a class="anchor" href="#test-Miscellaneous_Zero-width_chars_in_identifiers">&#xA7;</a>Zero-width chars in identifiers</span><script data-source="
 var _\u200c\u200d = true;
@@ -4311,6 +4363,7 @@ return _\u200c\u200d;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Unreserved_words"><td><span><a class="anchor" href="#test-Miscellaneous_Unreserved_words">&#xA7;</a>Unreserved words</span><script data-source="
 var abstract, boolean, byte, char, double, final, float, goto, int, long,
@@ -4390,6 +4443,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Enumerable_properties_can_be_shadowed_by_non-enumerables"><td><span><a class="anchor" href="#test-Miscellaneous_Enumerable_properties_can_be_shadowed_by_non-enumerables">&#xA7;</a>Enumerable properties can be shadowed by non-enumerables</span><script data-source="
 var result = true;
@@ -4475,6 +4529,7 @@ return result;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Thrown_functions_have_proper_this_values"><td><span><a class="anchor" href="#test-Miscellaneous_Thrown_functions_have_proper_this_values">&#xA7;</a>Thrown functions have proper &quot;this&quot; values</span><script data-source="
 try {
@@ -4558,6 +4613,7 @@ catch(e) {
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Strict_mode"><span><a class="anchor" href="#test-Strict_mode">&#xA7;</a>Strict mode <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/19</td>
@@ -4632,6 +4688,7 @@ catch(e) {
 <td class="tally obsolete" data-browser="ios8" data-tally="1">19/19</td>
 <td class="tally" data-browser="ios9" data-tally="1">19/19</td>
 <td class="tally" data-browser="ios10" data-tally="1">19/19</td>
+<td class="tally" data-browser="duktape20" data-tally="1">19/19</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_reserved_words"><td><span><a class="anchor" href="#test-Strict_mode_reserved_words">&#xA7;</a>reserved words</span><script data-source="
 &apos;use strict&apos;;
@@ -4714,6 +4771,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_this_is_undefined_in_functions"><td><span><a class="anchor" href="#test-Strict_mode_this_is_undefined_in_functions">&#xA7;</a>&quot;this&quot; is undefined in functions</span><script data-source="
 &apos;use strict&apos;;
@@ -4792,6 +4850,7 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_this_is_not_coerced_to_object_in_primitive_methods"><td><span><a class="anchor" href="#test-Strict_mode_this_is_not_coerced_to_object_in_primitive_methods">&#xA7;</a>&quot;this&quot; is not coerced to object in primitive methods</span><script data-source="
 &apos;use strict&apos;;
@@ -4872,6 +4931,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_this_is_not_coerced_to_object_in_primitive_accessors"><td><span><a class="anchor" href="#test-Strict_mode_this_is_not_coerced_to_object_in_primitive_accessors">&#xA7;</a>&quot;this&quot; is not coerced to object in primitive accessors</span><script data-source="
 &apos;use strict&apos;;
@@ -4966,6 +5026,7 @@ return test(String, &apos;&apos;)
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_legacy_octal_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_legacy_octal_is_a_SyntaxError">&#xA7;</a>legacy octal is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -5046,6 +5107,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_assignment_to_unresolvable_identifiers_is_a_ReferenceError"><td><span><a class="anchor" href="#test-Strict_mode_assignment_to_unresolvable_identifiers_is_a_ReferenceError">&#xA7;</a>assignment to unresolvable identifiers is a ReferenceError</span><script data-source="
 &apos;use strict&apos;;
@@ -5124,6 +5186,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_assignment_to_eval_or_arguments_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_assignment_to_eval_or_arguments_is_a_SyntaxError">&#xA7;</a>assignment to eval or arguments is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -5206,6 +5269,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_assignment_to_non-writable_properties_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_assignment_to_non-writable_properties_is_a_TypeError">&#xA7;</a>assignment to non-writable properties is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -5288,6 +5352,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_eval_or_arguments_bindings_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_eval_or_arguments_bindings_is_a_SyntaxError">&#xA7;</a>eval or arguments bindings is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -5372,6 +5437,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_arguments.caller_removed_or_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_arguments.caller_removed_or_is_a_TypeError">&#xA7;</a>arguments.caller removed or is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -5453,6 +5519,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_arguments.callee_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_arguments.callee_is_a_TypeError">&#xA7;</a>arguments.callee is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -5532,6 +5599,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_(function(){}).caller_and_(function(){}).arguments_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_(function(){}).caller_and_(function(){}).arguments_is_a_TypeError">&#xA7;</a>(function(){}).caller and (function(){}).arguments is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -5612,6 +5680,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_arguments_is_unmapped"><td><span><a class="anchor" href="#test-Strict_mode_arguments_is_unmapped">&#xA7;</a>arguments is unmapped</span><script data-source="
 &apos;use strict&apos;;
@@ -5696,6 +5765,7 @@ return (function(x){
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_eval()_can&apos;t_create_bindings"><td><span><a class="anchor" href="#test-Strict_mode_eval()_can&apos;t_create_bindings">&#xA7;</a>eval() can&apos;t create bindings</span><script data-source="
 &apos;use strict&apos;;
@@ -5774,6 +5844,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_deleting_bindings_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_deleting_bindings_is_a_SyntaxError">&#xA7;</a>deleting bindings is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -5852,6 +5923,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_deleting_non-configurable_properties_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_deleting_non-configurable_properties_is_a_TypeError">&#xA7;</a>deleting non-configurable properties is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -5930,6 +6002,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_with_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_with_is_a_SyntaxError">&#xA7;</a>&quot;with&quot; is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -6008,6 +6081,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_repeated_parameter_names_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_repeated_parameter_names_is_a_SyntaxError">&#xA7;</a>repeated parameter names is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -6086,6 +6160,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_function_expressions_with_matching_name_and_argument_are_valid"><td><span><a class="anchor" href="#test-Strict_mode_function_expressions_with_matching_name_and_argument_are_valid">&#xA7;</a>function expressions with matching name and argument are valid</span><script data-source="
 var foo = function bar(bar) {&apos;use strict&apos;};
@@ -6164,6 +6239,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 </tbody>
     </table>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -187,6 +187,7 @@
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
 <th class="platform ios9 mobile" data-browser="ios9"><a href="#ios9" class="browser-name"><abbr title="iOS Safari">iOS 9</abbr></a></th>
 <th class="platform ios10 mobile" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10</abbr></a></th>
+<th class="platform duktape20 engine" data-browser="duktape20"><a href="#duktape20" class="browser-name"><abbr title="Duktape 2.0.x">DUK 20</abbr></a></th>
 </tr>
 
       </thead>
@@ -259,6 +260,7 @@
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios10" data-tally="1">2/2</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="Intl_object" id="test-Intl_object_exists_on_global"><td><span><a class="anchor" href="#test-Intl_object_exists_on_global">&#xA7;</a>exists on global</span><script data-source="
 return typeof Intl === &apos;object&apos;;
@@ -330,6 +332,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Intl_object" id="test-Intl_object_has_prototype_of_Object"><td><span><a class="anchor" href="#test-Intl_object_has_prototype_of_Object">&#xA7;</a>has prototype of Object</span><script data-source="
 return Intl.constructor === Object;
@@ -401,6 +404,7 @@ return Intl.constructor === Object;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator"><span><a class="anchor" href="#test-Intl.Collator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10">Intl.Collator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
@@ -469,6 +473,7 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios10" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/4</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_exists_on_intl_object"><td><span><a class="anchor" href="#test-Intl.Collator_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.Collator === &apos;function&apos;;
@@ -540,6 +545,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_creates_new_Collator_instances"><td><span><a class="anchor" href="#test-Intl.Collator_creates_new_Collator_instances">&#xA7;</a>creates new Collator instances</span><script data-source="
 return new Intl.Collator() instanceof Intl.Collator;
@@ -611,6 +617,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_constructor_called_without_new_creates_instances"><td><span><a class="anchor" href="#test-Intl.Collator_constructor_called_without_new_creates_instances">&#xA7;</a>constructor called without new creates instances</span><script data-source="
 return Intl.Collator() instanceof Intl.Collator;
@@ -682,6 +689,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_accepts_valid_language_tags"><td><span><a class="anchor" href="#test-Intl.Collator_accepts_valid_language_tags">&#xA7;</a>accepts valid language tags</span><script data-source="
 try {
@@ -781,6 +789,7 @@ try {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.compare"><span><a class="anchor" href="#test-Intl.Collator.prototype.compare">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.2">Intl.Collator.prototype.compare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
@@ -849,6 +858,7 @@ try {
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/1</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/1</td>
 <td class="tally" data-browser="ios10" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/1</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator.prototype.compare" id="test-Intl.Collator.prototype.compare_exists_on_Collator_prototype"><td><span><a class="anchor" href="#test-Intl.Collator.prototype.compare_exists_on_Collator_prototype">&#xA7;</a>exists on Collator prototype</span><script data-source="
 return typeof Intl.Collator().compare === &apos;function&apos;;
@@ -920,6 +930,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.resolvedOptions"><span><a class="anchor" href="#test-Intl.Collator.prototype.resolvedOptions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.3">Intl.Collator.prototype.resolvedOptions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
@@ -988,6 +999,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/1</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/1</td>
 <td class="tally" data-browser="ios10" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/1</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator.prototype.resolvedOptions" id="test-Intl.Collator.prototype.resolvedOptions_exists_on_Collator_prototype"><td><span><a class="anchor" href="#test-Intl.Collator.prototype.resolvedOptions_exists_on_Collator_prototype">&#xA7;</a>exists on Collator prototype</span><script data-source="
 return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
@@ -1059,6 +1071,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-NumberFormat"><span><a class="anchor" href="#test-NumberFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-11">NumberFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
@@ -1127,6 +1140,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/5</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/5</td>
 <td class="tally" data-browser="ios10" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/5</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-NumberFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.NumberFormat === &apos;function&apos;;
@@ -1198,6 +1212,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-NumberFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.NumberFormat === &apos;function&apos;;
@@ -1269,6 +1284,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_creates_new_NumberFormat_instances"><td><span><a class="anchor" href="#test-NumberFormat_creates_new_NumberFormat_instances">&#xA7;</a>creates new NumberFormat instances</span><script data-source="
 return new Intl.NumberFormat() instanceof Intl.NumberFormat;
@@ -1340,6 +1356,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_constructor_called_without_new_creates_instances"><td><span><a class="anchor" href="#test-NumberFormat_constructor_called_without_new_creates_instances">&#xA7;</a>constructor called without new creates instances</span><script data-source="
 return Intl.NumberFormat() instanceof Intl.NumberFormat;
@@ -1411,6 +1428,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_accepts_valid_language_tags"><td><span><a class="anchor" href="#test-NumberFormat_accepts_valid_language_tags">&#xA7;</a>accepts valid language tags</span><script data-source="
 try {
@@ -1510,6 +1528,7 @@ try {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-DateTimeFormat"><span><a class="anchor" href="#test-DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
@@ -1578,6 +1597,7 @@ try {
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/6</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/6</td>
 <td class="tally" data-browser="ios10" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/6</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-DateTimeFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.DateTimeFormat === &apos;function&apos;;
@@ -1649,6 +1669,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_creates_new_DateTimeFormat_instances"><td><span><a class="anchor" href="#test-DateTimeFormat_creates_new_DateTimeFormat_instances">&#xA7;</a>creates new DateTimeFormat instances</span><script data-source="
 return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
@@ -1720,6 +1741,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_constructor_called_without_new_creates_instances"><td><span><a class="anchor" href="#test-DateTimeFormat_constructor_called_without_new_creates_instances">&#xA7;</a>constructor called without new creates instances</span><script data-source="
 return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
@@ -1791,6 +1813,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_accepts_valid_language_tags"><td><span><a class="anchor" href="#test-DateTimeFormat_accepts_valid_language_tags">&#xA7;</a>accepts valid language tags</span><script data-source="
 try {
@@ -1890,6 +1913,7 @@ try {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_resolvedOptions().timeZone_defaults_to_the_host_environment"><td><span><a class="anchor" href="#test-DateTimeFormat_resolvedOptions().timeZone_defaults_to_the_host_environment">&#xA7;</a>resolvedOptions().timeZone defaults to the host environment</span><script data-source="
 var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -1962,6 +1986,7 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_accepts_IANA_timezone_names"><td><span><a class="anchor" href="#test-DateTimeFormat_accepts_IANA_timezone_names">&#xA7;</a>accepts IANA timezone names</span><script data-source="
 try {
@@ -2041,6 +2066,7 @@ try {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-String.prototype.localeCompare"><span><a class="anchor" href="#test-String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
@@ -2109,6 +2135,7 @@ try {
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios9" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios10" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape20" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="String.prototype.localeCompare" id="test-String.prototype.localeCompare_exists_on_String_prototype"><td><span><a class="anchor" href="#test-String.prototype.localeCompare_exists_on_String_prototype">&#xA7;</a>exists on String prototype</span><script data-source="
 return typeof String.prototype.localeCompare === &apos;function&apos;;
@@ -2180,6 +2207,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Number.prototype.toLocaleString"><span><a class="anchor" href="#test-Number.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.tolocalestring">Number.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
@@ -2248,6 +2276,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios9" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios10" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape20" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Number.prototype.toLocaleString" id="test-Number.prototype.toLocaleString_exists_on_Number_prototype"><td><span><a class="anchor" href="#test-Number.prototype.toLocaleString_exists_on_Number_prototype">&#xA7;</a>exists on Number prototype</span><script data-source="
 return typeof Number.prototype.toLocaleString === &apos;function&apos;;
@@ -2319,6 +2348,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Array.prototype.toLocaleString"><span><a class="anchor" href="#test-Array.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.tolocalestring">Array.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
@@ -2387,6 +2417,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios9" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios10" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape20" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.toLocaleString" id="test-Array.prototype.toLocaleString_exists_on_Array_prototype"><td><span><a class="anchor" href="#test-Array.prototype.toLocaleString_exists_on_Array_prototype">&#xA7;</a>exists on Array prototype</span><script data-source="
 return typeof Array.prototype.toLocaleString === &apos;function&apos;;
@@ -2458,6 +2489,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object.prototype.toLocaleString"><span><a class="anchor" href="#test-Object.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.tolocalestring">Object.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
@@ -2526,6 +2558,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios9" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios10" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape20" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype.toLocaleString" id="test-Object.prototype.toLocaleString_exists_on_Object_prototype"><td><span><a class="anchor" href="#test-Object.prototype.toLocaleString_exists_on_Object_prototype">&#xA7;</a>exists on Object prototype</span><script data-source="
 return typeof Object.prototype.toLocaleString === &apos;function&apos;;
@@ -2597,6 +2630,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleString"><span><a class="anchor" href="#test-Date.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocalestring">Date.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
@@ -2665,6 +2699,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios9" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios10" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape20" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleString" id="test-Date.prototype.toLocaleString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleString === &apos;function&apos;;
@@ -2736,6 +2771,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleDateString"><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaledatestring">Date.prototype.toLocaleDateString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
@@ -2804,6 +2840,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios9" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios10" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape20" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleDateString" id="test-Date.prototype.toLocaleDateString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
@@ -2875,6 +2912,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleTimeString"><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaletimestring">Date.prototype.toLocaleTimeString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
@@ -2943,6 +2981,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios9" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios10" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape20" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleTimeString" id="test-Date.prototype.toLocaleTimeString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
@@ -3014,6 +3053,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 </tbody>
     </table>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -183,12 +183,13 @@
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
 <th class="platform ios9 mobile" data-browser="ios9"><a href="#ios9" class="browser-name"><abbr title="iOS Safari">iOS 9</abbr></a></th>
 <th class="platform ios10 mobile" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10</abbr></a></th>
+<th class="platform duktape20 engine" data-browser="duktape20"><a href="#duktape20" class="browser-name"><abbr title="Duktape 2.0.x">DUK 20</abbr></a></th>
 </tr>
 
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="74">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="75">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-SIMD_(Single_Instruction,_Multiple_Data)"><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/">SIMD (Single Instruction, Multiple Data)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/57</td>
@@ -263,6 +264,7 @@
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/57</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/57</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/57</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/57</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>basic support <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD !== &apos;undefined&apos;;
@@ -340,6 +342,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Float32x4_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Float32x4_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Float32x4 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32x4" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4 === &apos;function&apos;;
@@ -417,6 +420,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Int32x4_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Int32x4_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Int32x4 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32x4" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int32x4 === &apos;function&apos;;
@@ -494,6 +498,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Int16x8_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Int16x8_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Int16x8 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16x8" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int16x8 === &apos;function&apos;;
@@ -571,6 +576,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Int8x16_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Int8x16_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Int8x16 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8x16" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int8x16 === &apos;function&apos;;
@@ -648,6 +654,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Uint32x4_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Uint32x4_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Uint32x4 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32x4" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Uint32x4 === &apos;function&apos;;
@@ -725,6 +732,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Uint16x8_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Uint16x8_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Uint16x8 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16x8" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Uint16x8 === &apos;function&apos;;
@@ -802,6 +810,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Uint8x16_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Uint8x16_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Uint8x16 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8x16" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Uint8x16 === &apos;function&apos;;
@@ -879,6 +888,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Bool32x4_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Bool32x4_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Bool32x4 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool32x4" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool32x4 === &apos;function&apos;;
@@ -956,6 +966,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Bool16x8_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Bool16x8_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Bool16x8 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool16x8" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool16x8 === &apos;function&apos;;
@@ -1033,6 +1044,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_Bool8x16_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_Bool8x16_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Bool8x16 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool8x16" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool8x16 === &apos;function&apos;;
@@ -1110,6 +1122,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.abs_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/abs_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.abs_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/abs_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.abs <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/abs" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.abs === &apos;function&apos;;
@@ -1187,6 +1200,7 @@ return typeof SIMD.Float32x4.abs === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.add_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.add_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.add <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/add" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.add === &apos;function&apos;;
@@ -1264,6 +1278,7 @@ return typeof SIMD.Float32x4.add === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%integerType%.addSaturate_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/addSaturate_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%integerType%.addSaturate_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/addSaturate_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%integerType%.addSaturate <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/addSaturate" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int16x8.addSaturate === &apos;function&apos;;
@@ -1341,6 +1356,7 @@ return typeof SIMD.Int16x8.addSaturate === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.and_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.and_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%booleanType%.and <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/and" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool16x8.and === &apos;function&apos;;
@@ -1418,6 +1434,7 @@ return typeof SIMD.Bool16x8.and === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.anyTrue_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/anyTrue_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.anyTrue_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/anyTrue_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%booleanType%.anyTrue <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/anyTrue" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool32x4.anyTrue === &apos;function&apos;;
@@ -1495,6 +1512,7 @@ return typeof SIMD.Bool32x4.anyTrue === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.allTrue_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/allTrue_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.allTrue_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/allTrue_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%booleanType%.allTrue <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/allTrue" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool32x4.allTrue === &apos;function&apos;;
@@ -1572,6 +1590,7 @@ return typeof SIMD.Bool32x4.allTrue === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.check_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/check_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.check_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/check_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.check <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/check" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.check === &apos;function&apos;;
@@ -1649,6 +1668,7 @@ return typeof SIMD.Float32x4.check === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.equal_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/equal_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.equal_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/equal_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.equal <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/equal" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.equal === &apos;function&apos;;
@@ -1726,6 +1746,7 @@ return typeof SIMD.Float32x4.equal === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.extractLane_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/extractLane_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.extractLane_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/extractLane_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.extractLane <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/extractLane" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.extractLane === &apos;function&apos;;
@@ -1803,6 +1824,7 @@ return typeof SIMD.Float32x4.extractLane === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.greaterThan_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThan_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.greaterThan_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThan_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.greaterThan <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThan" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.greaterThan === &apos;function&apos;;
@@ -1880,6 +1902,7 @@ return typeof SIMD.Float32x4.greaterThan === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.greaterThanOrEqual_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThanOrEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.greaterThanOrEqual_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThanOrEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.greaterThanOrEqual <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThanOrEqual" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.greaterThanOrEqual === &apos;function&apos;;
@@ -1957,6 +1980,7 @@ return typeof SIMD.Float32x4.greaterThanOrEqual === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.lessThan_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThan_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.lessThan_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThan_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.lessThan <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThan" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.lessThan === &apos;function&apos;;
@@ -2034,6 +2058,7 @@ return typeof SIMD.Float32x4.lessThan === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.lessThanOrEqual_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThanOrEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.lessThanOrEqual_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThanOrEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.lessThanOrEqual <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThanOrEqual" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.lessThanOrEqual === &apos;function&apos;;
@@ -2111,6 +2136,7 @@ return typeof SIMD.Float32x4.lessThanOrEqual === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.mul_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/mul_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.mul_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/mul_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.mul <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/mul" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.mul === &apos;function&apos;;
@@ -2188,6 +2214,7 @@ return typeof SIMD.Float32x4.mul === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.div_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/div_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.div_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/div_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.div <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/div" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.div === &apos;function&apos;;
@@ -2265,6 +2292,7 @@ return typeof SIMD.Float32x4.div === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.load <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.load === &apos;function&apos;;
@@ -2342,6 +2370,7 @@ return typeof SIMD.Float32x4.load === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load1_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load1_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.load1 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.load1 === &apos;function&apos;;
@@ -2419,6 +2448,7 @@ return typeof SIMD.Float32x4.load1 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load2_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load2_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.load2 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.load2 === &apos;function&apos;;
@@ -2496,6 +2526,7 @@ return typeof SIMD.Float32x4.load2 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load3_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load3_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.load3 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.load3 === &apos;function&apos;;
@@ -2573,6 +2604,7 @@ return typeof SIMD.Float32x4.load3 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.max_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/max_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.max_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/max_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.max <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/max" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.max === &apos;function&apos;;
@@ -2650,6 +2682,7 @@ return typeof SIMD.Float32x4.max === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.maxNum_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/maxNum_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.maxNum_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/maxNum_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.maxNum <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/maxNum" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.maxNum === &apos;function&apos;;
@@ -2727,6 +2760,7 @@ return typeof SIMD.Float32x4.maxNum === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.min_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/min_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.min_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/min_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.min <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/min" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.min === &apos;function&apos;;
@@ -2804,6 +2838,7 @@ return typeof SIMD.Float32x4.min === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.minNum_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/minNum_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.minNum_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/minNum_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.minNum <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/minNum" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.minNum === &apos;function&apos;;
@@ -2881,6 +2916,7 @@ return typeof SIMD.Float32x4.minNum === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.neg_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/neg_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.neg_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/neg_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.neg <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/neg" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.neg === &apos;function&apos;;
@@ -2958,6 +2994,7 @@ return typeof SIMD.Float32x4.neg === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.not_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/not_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.not_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/not_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%booleanType%.not <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/not" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool16x8.not === &apos;function&apos;;
@@ -3035,6 +3072,7 @@ return typeof SIMD.Bool16x8.not === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.notEqual_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/notEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.notEqual_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/notEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.notEqual <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/notEqual" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.notEqual === &apos;function&apos;;
@@ -3112,6 +3150,7 @@ return typeof SIMD.Float32x4.notEqual === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.or_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.or_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%booleanType%.or <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/or" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool16x8.or === &apos;function&apos;;
@@ -3189,6 +3228,7 @@ return typeof SIMD.Bool16x8.or === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.reciprocalApproximation_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalApproximation_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.reciprocalApproximation_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalApproximation_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.reciprocalApproximation <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalApproximation" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.reciprocalApproximation === &apos;function&apos;;
@@ -3266,6 +3306,7 @@ return typeof SIMD.Float32x4.reciprocalApproximation === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.reciprocalSqrtApproximation_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalSqrtApproximation_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.reciprocalSqrtApproximation_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalSqrtApproximation_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.reciprocalSqrtApproximation <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalSqrtApproximation" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.reciprocalSqrtApproximation === &apos;function&apos;;
@@ -3343,6 +3384,7 @@ return typeof SIMD.Float32x4.reciprocalSqrtApproximation === &apos;function&apos
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.replaceLane_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/replaceLane_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.replaceLane_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/replaceLane_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.replaceLane <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/replaceLane" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.replaceLane === &apos;function&apos;;
@@ -3420,6 +3462,7 @@ return typeof SIMD.Float32x4.replaceLane === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.select_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/select_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.select_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/select_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.select <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/select" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.select === &apos;function&apos;;
@@ -3497,6 +3540,7 @@ return typeof SIMD.Float32x4.select === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%integerType%.shiftLeftByScalar_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftLeftByScalar_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%integerType%.shiftLeftByScalar_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftLeftByScalar_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%integerType%.shiftLeftByScalar <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftLeftByScalar" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int32x4.shiftLeftByScalar === &apos;function&apos;;
@@ -3574,6 +3618,7 @@ return typeof SIMD.Int32x4.shiftLeftByScalar === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%integerType%.shiftRightByScalar_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftRightByScalar_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%integerType%.shiftRightByScalar_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftRightByScalar_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%integerType%.shiftRightByScalar <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftRightByScalar" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int32x4.shiftRightByScalar === &apos;function&apos;;
@@ -3651,6 +3696,7 @@ return typeof SIMD.Int32x4.shiftRightByScalar === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.shuffle_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shuffle_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.shuffle_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shuffle_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.shuffle <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shuffle" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.shuffle === &apos;function&apos;;
@@ -3728,6 +3774,7 @@ return typeof SIMD.Float32x4.shuffle === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.splat_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/splat_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.splat_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/splat_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.splat <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/splat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.splat === &apos;function&apos;;
@@ -3805,6 +3852,7 @@ return typeof SIMD.Float32x4.splat === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.sqrt_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sqrt_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.sqrt_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sqrt_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.sqrt <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sqrt" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.sqrt === &apos;function&apos;;
@@ -3882,6 +3930,7 @@ return typeof SIMD.Float32x4.sqrt === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.store <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.store === &apos;function&apos;;
@@ -3959,6 +4008,7 @@ return typeof SIMD.Float32x4.store === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store1_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store1_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.store1 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.store1 === &apos;function&apos;;
@@ -4036,6 +4086,7 @@ return typeof SIMD.Float32x4.store1 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store2_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store2_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.store2 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.store2 === &apos;function&apos;;
@@ -4113,6 +4164,7 @@ return typeof SIMD.Float32x4.store2 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store3_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store3_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.store3 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.store3 === &apos;function&apos;;
@@ -4190,6 +4242,7 @@ return typeof SIMD.Float32x4.store3 === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.sub_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.sub_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.sub <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sub" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.sub === &apos;function&apos;;
@@ -4267,6 +4320,7 @@ return typeof SIMD.Float32x4.sub === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%integerType%.subSaturate_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/subSaturate_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%integerType%.subSaturate_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/subSaturate_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%integerType%.subSaturate <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/subSaturate" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int16x8.subSaturate === &apos;function&apos;;
@@ -4344,6 +4398,7 @@ return typeof SIMD.Int16x8.subSaturate === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.swizzle_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/swizzle_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.swizzle_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/swizzle_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.swizzle <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/swizzle" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.swizzle === &apos;function&apos;;
@@ -4421,6 +4476,7 @@ return typeof SIMD.Float32x4.swizzle === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.xor_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%booleanType%.xor_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%booleanType%.xor <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/xor" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool16x8.xor === &apos;function&apos;;
@@ -4498,6 +4554,7 @@ return typeof SIMD.Bool16x8.xor === &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.fromTIMDBits"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.fromTIMDBits">&#xA7;</a>SIMD.%type%.fromTIMDBits</span><script data-source="
 return &apos;Float32x4,Int32x4,Int8x16,Uint32x4,Uint16x8,Uint8x16&apos;.split(&apos;,&apos;).every(function(type){
@@ -4577,6 +4634,7 @@ return &apos;Float32x4,Int32x4,Int8x16,Uint32x4,Uint16x8,Uint8x16&apos;.split(&a
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.fromTIMD"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.fromTIMD">&#xA7;</a>SIMD.%type%.fromTIMD</span><script data-source="
 return &apos;Float32x4,Uint32x4&apos;.split(&apos;,&apos;).every(function(type){
@@ -4656,6 +4714,7 @@ return &apos;Float32x4,Uint32x4&apos;.split(&apos;,&apos;).every(function(type){
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.25"><td id="test-object_rest_properties"><span><a class="anchor" href="#test-object_rest_properties">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-rest-spread">object rest properties</a></span><script data-source="
 var {a, ...rest} = {a: 1, b: 2, c: 3};
@@ -4734,6 +4793,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.5"><td id="test-object_spread_properties"><span><a class="anchor" href="#test-object_spread_properties">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-rest-spread">object spread properties</a></span><script data-source="
 var spread = {b: 2, c: 3};
@@ -4813,6 +4873,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a><a href="https://github.com/tc39/proposal-global">global</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -4887,6 +4948,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="global" id="test-global_global_global_property_is_global_object"><td><span><a class="anchor" href="#test-global_global_global_property_is_global_object">&#xA7;</a>&quot;global&quot; global property is global object</span><script data-source="
 var actualGlobal = Function(&apos;return this&apos;)();
@@ -4966,6 +5028,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="global" id="test-global_global_global_property_has_correct_property_descriptor"><td><span><a class="anchor" href="#test-global_global_global_property_has_correct_property_descriptor">&#xA7;</a>&quot;global&quot; global property has correct property descriptor</span><script data-source="
 var actualGlobal = Function(&apos;return this&apos;)();
@@ -5050,6 +5113,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Async_iteration"><span><a class="anchor" href="#test-Async_iteration">&#xA7;</a><a href="https://github.com/tc39/proposal-async-iteration">Async iteration</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -5124,6 +5188,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="Async_iteration" id="test-Async_iteration_async_generators"><td><span><a class="anchor" href="#test-Async_iteration_async_generators">&#xA7;</a>async generators</span><script data-source="
 async function*generator(){
@@ -5208,6 +5273,7 @@ iterator.next().then(function(step){
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Async_iteration" id="test-Async_iteration_for-await-of_loops"><td><span><a class="anchor" href="#test-Async_iteration_for-await-of_loops">&#xA7;</a>for-await-of loops</span><script data-source="
 var asyncIterable = {};
@@ -5302,6 +5368,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.25"><td id="test-RegExp_named_capture_groups"><span><a class="anchor" href="#test-RegExp_named_capture_groups">&#xA7;</a><a href="https://github.com/goyakin/es-regexp-named-groups">RegExp named capture groups</a></span><script data-source="
 var result = /(?&lt;year&gt;\d{4})-(?&lt;month&gt;\d{2})-(?&lt;day&gt;\d{2})/.exec(&apos;2016-03-11&apos;);
@@ -5386,10 +5453,12 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.25"><td id="test-RegExp_lookbehind"><span><a class="anchor" href="#test-RegExp_lookbehind">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-lookbehind">RegExp lookbehind</a></span><script data-source="
-return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&apos;);
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&apos;) &amp;&amp;
+       !/(?&lt;=a)b/.test(&apos;b&apos;);
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&\n       !/(?<=a)b/.test('b');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&\n       !/(?<=a)b/.test('b');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -5463,6 +5532,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.25"><td id="test-RegExp_Unicode_Property_Escapes"><span><a class="anchor" href="#test-RegExp_Unicode_Property_Escapes">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-unicode-property-escapes">RegExp Unicode Property Escapes</a></span><script data-source="
 const regexGreekSymbol = /\p{Script=Greek}/u;
@@ -5541,6 +5611,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Function.prototype.toString"><span><a class="anchor" href="#test-Function.prototype.toString">&#xA7;</a><a href="https://tc39.github.io/Function-prototype-toString-revision/">Function.prototype.toString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/7</td>
@@ -5615,6 +5686,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/7</td>
 <td class="tally" data-browser="ios9" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="ios10" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally" data-browser="duktape20" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString" id="test-Function.prototype.toString_functions_created_with_the_Function_constructor"><td><span><a class="anchor" href="#test-Function.prototype.toString_functions_created_with_the_Function_constructor">&#xA7;</a>functions created with the Function constructor</span><script data-source="
 var fn = Function(&apos;a&apos;, &apos; /\x2A a \x2A/ b, c /\x2A b \x2A/ //&apos;, &apos;/\x2A c \x2A/ ; /\x2A d \x2A/ //&apos;);
@@ -5694,6 +5766,7 @@ return fn + &apos;&apos; === str;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString" id="test-Function.prototype.toString_arrows"><td><span><a class="anchor" href="#test-Function.prototype.toString_arrows">&#xA7;</a>arrows</span><script data-source="
 var str = &apos;a =&gt; b&apos;;
@@ -5772,6 +5845,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString" id="test-Function.prototype.toString_[native_code]"><td><span><a class="anchor" href="#test-Function.prototype.toString_[native_code]">&#xA7;</a>[native code]</span><script data-source="
 const NATIVE_EVAL_RE = /\bfunction\b[\s\S]*\beval\b[\s\S]*\([\s\S]*\)[\s\S]*\{[\s\S]*\[[\s\S]*\bnative\b[\s\S]+\bcode\b[\s\S]*\][\s\S]*\}/;
@@ -5850,6 +5924,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString" id="test-Function.prototype.toString_class_expression_with_implicit_constructor"><td><span><a class="anchor" href="#test-Function.prototype.toString_class_expression_with_implicit_constructor">&#xA7;</a>class expression with implicit constructor</span><script data-source="
 var str = &apos;class A {}&apos;;
@@ -5928,6 +6003,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString" id="test-Function.prototype.toString_class_expression_with_explicit_constructor"><td><span><a class="anchor" href="#test-Function.prototype.toString_class_expression_with_explicit_constructor">&#xA7;</a>class expression with explicit constructor</span><script data-source="
 var str = &apos;class /\x2A a \x2A/ A /\x2A b \x2A/ extends /\x2A c \x2A/ function B(){} /\x2A d \x2A/ { /\x2A e \x2A/ constructor /\x2A f \x2A/ ( /\x2A g \x2A/ ) /\x2A h \x2A/ { /\x2A i \x2A/ ; /\x2A j \x2A/ } /\x2A k \x2A/ m /\x2A l \x2A/ ( /\x2A m \x2A/ ) /\x2A n \x2A/ { /\x2A o \x2A/ } /\x2A p \x2A/ }&apos;;
@@ -6006,6 +6082,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString" id="test-Function.prototype.toString_unicode_escape_sequences_in_identifiers"><td><span><a class="anchor" href="#test-Function.prototype.toString_unicode_escape_sequences_in_identifiers">&#xA7;</a>unicode escape sequences in identifiers</span><script data-source="
 var str = &apos;function \\u0061(\\u{62}, \\u0063) { \\u0062 = \\u{00063}; return b; }&apos;;
@@ -6084,6 +6161,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString" id="test-Function.prototype.toString_methods_and_computed_property_names"><td><span><a class="anchor" href="#test-Function.prototype.toString_methods_and_computed_property_names">&#xA7;</a>methods and computed property names</span><script data-source="
 var str = &apos;[ /\x2A a \x2A/ &quot;f&quot; /\x2A b \x2A/ ] /\x2A c \x2A/ ( /\x2A d \x2A/ ) /\x2A e \x2A/ { /\x2A f \x2A/ }&apos;;
@@ -6162,8 +6240,9 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr class="category"><td colspan="74">Draft (stage 2)</td>
+<tr class="category"><td colspan="75">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-function.sent"><span><a class="anchor" href="#test-function.sent">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">function.sent</a></span><script data-source="
 var result;
@@ -6247,6 +6326,7 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.5"><td id="test-class_decorators"><span><a class="anchor" href="#test-class_decorators">&#xA7;</a><a href="https://github.com/wycats/javascript-decorators">class decorators</a></span><script data-source="
 class A {
@@ -6332,6 +6412,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.5"><td id="test-class_properties"><span><a class="anchor" href="#test-class_properties">&#xA7;</a><a href="https://github.com/jeffmo/es-class-properties">class properties</a></span><script data-source="
 class C {
@@ -6413,6 +6494,7 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-string-left-right-trim">string trimming</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -6487,6 +6569,7 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="ios9" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="ios10" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/4</td>
 </tr>
 <tr class="subtest" data-parent="string_trimming" id="test-string_trimming_String.prototype.trimLeft_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-string_trimming_String.prototype.trimLeft_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.trimLeft <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
@@ -6564,6 +6647,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="string_trimming" id="test-string_trimming_String.prototype.trimRight_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-string_trimming_String.prototype.trimRight_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.trimRight <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
@@ -6641,6 +6725,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="string_trimming" id="test-string_trimming_String.prototype.trimStart"><td><span><a class="anchor" href="#test-string_trimming_String.prototype.trimStart">&#xA7;</a>String.prototype.trimStart</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
@@ -6718,6 +6803,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="string_trimming" id="test-string_trimming_String.prototype.trimEnd"><td><span><a class="anchor" href="#test-string_trimming_String.prototype.trimEnd">&#xA7;</a>String.prototype.trimEnd</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
@@ -6795,6 +6881,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-private_fields"><span><a class="anchor" href="#test-private_fields">&#xA7;</a><a href="https://github.com/zenparsing/es-private-fields">private fields</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -6869,6 +6956,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="private_fields" id="test-private_fields_basic_support"><td><span><a class="anchor" href="#test-private_fields_basic_support">&#xA7;</a>basic support</span><script data-source="
 class C {
@@ -6955,6 +7043,7 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="private_fields" id="test-private_fields_initializers"><td><span><a class="anchor" href="#test-private_fields_initializers">&#xA7;</a>initializers</span><script data-source="
 class C {
@@ -7038,8 +7127,9 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr class="category"><td colspan="74">Proposal (stage 1)</td>
+<tr class="category"><td colspan="75">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=strawman:do_expressions">do expressions</a></span><script data-source="
 return do {
@@ -7120,6 +7210,7 @@ return do {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Realms"><span><a class="anchor" href="#test-Realms">&#xA7;</a><a href="https://github.com/caridy/proposal-realms">Realms</a></span><script data-source="
 return typeof Realm === &quot;function&quot;
@@ -7200,6 +7291,7 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.125"><td id="test-Math_methods_for_64-bit_integers"><span><a class="anchor" href="#test-Math_methods_for_64-bit_integers">&#xA7;</a><a href="https://gist.github.com/BrendanEich/4294d5c212a6d2254703">Math methods for 64-bit integers</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -7274,6 +7366,7 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/4</td>
 </tr>
 <tr class="subtest" data-parent="Math_methods_for_64-bit_integers" id="test-Math_methods_for_64-bit_integers_Math.iaddh"><td><span><a class="anchor" href="#test-Math_methods_for_64-bit_integers_Math.iaddh">&#xA7;</a>Math.iaddh</span><script data-source="
 return Math.iaddh(0xffffffff, 1, 1, 1) === 3;
@@ -7351,6 +7444,7 @@ return Math.iaddh(0xffffffff, 1, 1, 1) === 3;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Math_methods_for_64-bit_integers" id="test-Math_methods_for_64-bit_integers_Math.isubh"><td><span><a class="anchor" href="#test-Math_methods_for_64-bit_integers_Math.isubh">&#xA7;</a>Math.isubh</span><script data-source="
 return Math.isubh(0, 4, 1, 1) === 2;
@@ -7428,6 +7522,7 @@ return Math.isubh(0, 4, 1, 1) === 2;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Math_methods_for_64-bit_integers" id="test-Math_methods_for_64-bit_integers_Math.imulh"><td><span><a class="anchor" href="#test-Math_methods_for_64-bit_integers_Math.imulh">&#xA7;</a>Math.imulh</span><script data-source="
 return Math.imulh(0xffffffff, 7) === -1;
@@ -7505,6 +7600,7 @@ return Math.imulh(0xffffffff, 7) === -1;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Math_methods_for_64-bit_integers" id="test-Math_methods_for_64-bit_integers_Math.umulh"><td><span><a class="anchor" href="#test-Math_methods_for_64-bit_integers_Math.umulh">&#xA7;</a>Math.umulh</span><script data-source="
 return Math.umulh(0xffffffff, 7) === 6;
@@ -7582,6 +7678,7 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Observable"><span><a class="anchor" href="#test-Observable">&#xA7;</a><a href="https://github.com/zenparsing/es-observable">Observable</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/8</td>
@@ -7656,6 +7753,7 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/8</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/8</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/8</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/8</td>
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_basic_support"><td><span><a class="anchor" href="#test-Observable_basic_support">&#xA7;</a>basic support</span><script data-source="
 return typeof Observable !== &apos;undefined&apos;;
@@ -7733,6 +7831,7 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Symbol.observable_well_known_symbol"><td><span><a class="anchor" href="#test-Observable_Symbol.observable_well_known_symbol">&#xA7;</a>Symbol.observable well known symbol</span><script data-source="
 return typeof Symbol.observable === &apos;symbol&apos;;
@@ -7810,6 +7909,7 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable.prototype.subscribe"><td><span><a class="anchor" href="#test-Observable_Observable.prototype.subscribe">&#xA7;</a>Observable.prototype.subscribe</span><script data-source="
 return &apos;subscribe&apos; in Observable.prototype;
@@ -7887,6 +7987,7 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable_constructor_behavior"><td><span><a class="anchor" href="#test-Observable_Observable_constructor_behavior">&#xA7;</a>Observable constructor behavior</span><script data-source="
 if(!(new Observable(function(){}) instanceof Observable))return false;
@@ -7974,6 +8075,7 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable.prototype.forEach"><td><span><a class="anchor" href="#test-Observable_Observable.prototype.forEach">&#xA7;</a>Observable.prototype.forEach</span><script data-source="
 var o = new Observable(function() { });
@@ -8052,6 +8154,7 @@ return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable.prototype[Symbol.observable]"><td><span><a class="anchor" href="#test-Observable_Observable.prototype[Symbol.observable]">&#xA7;</a>Observable.prototype[Symbol.observable]</span><script data-source="
 var o = new Observable(function() { });
@@ -8130,6 +8233,7 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable.of"><td><span><a class="anchor" href="#test-Observable_Observable.of">&#xA7;</a>Observable.of</span><script data-source="
 return Observable.of(1, 2, 3) instanceof Observable;
@@ -8207,6 +8311,7 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable.from"><td><span><a class="anchor" href="#test-Observable_Observable.from">&#xA7;</a>Observable.from</span><script data-source="
 return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable.from(new Set([1, 2, 3])) instanceof Observable);
@@ -8284,6 +8389,7 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.matchAll"><span><a class="anchor" href="#test-String.prototype.matchAll">&#xA7;</a><a href="https://github.com/tc39/String.prototype.matchAll">String.prototype.matchAll</a></span><script data-source="
 var iterator = &apos;11a2bb&apos;.matchAll(/(\d)(\D)/);
@@ -8371,6 +8477,7 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-weak_references"><span><a class="anchor" href="#test-weak_references">&#xA7;</a><a href="https://github.com/tc39/proposal-weakrefs">weak references</a></span><script data-source="
 var O = {};
@@ -8452,6 +8559,7 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.5"><td id="test-frozen_realms"><span><a class="anchor" href="#test-frozen_realms">&#xA7;</a><a href="https://github.com/FUDCo/frozen-realms">frozen realms</a></span><script data-source="
 return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
@@ -8530,8 +8638,9 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr class="category"><td colspan="74">Strawman (stage 0)</td>
+<tr class="category"><td colspan="75">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -8606,6 +8715,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="bind_(::)_operator" id="test-bind_(::)_operator_binary_form"><td><span><a class="anchor" href="#test-bind_(::)_operator_binary_form">&#xA7;</a>binary form</span><script data-source="
 function foo() { this.garply += &quot;foo&quot;; return this; }
@@ -8685,6 +8795,7 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="bind_(::)_operator" id="test-bind_(::)_operator_unary_form"><td><span><a class="anchor" href="#test-bind_(::)_operator_unary_form">&#xA7;</a>unary form</span><script data-source="
 var obj = { garply: &quot;bar&quot;, foo: function() { this.garply += &quot;foo&quot;; return this; } };
@@ -8763,6 +8874,7 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="test-String.prototype.at"><span><a class="anchor" href="#test-String.prototype.at">&#xA7;</a><a href="https://github.com/mathiasbynens/String.prototype.at">String.prototype.at</a></span><script data-source="
 return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
@@ -8840,6 +8952,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-additional_meta_properties"><span><a class="anchor" href="#test-additional_meta_properties">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/ES7MetaProps.md">additional meta properties</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -8914,6 +9027,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 </tr>
 <tr class="subtest" data-parent="additional_meta_properties" id="test-additional_meta_properties_function.callee"><td><span><a class="anchor" href="#test-additional_meta_properties_function.callee">&#xA7;</a>function.callee</span><script data-source="
 var f = _ =&gt; function.callee === f;
@@ -8992,6 +9106,7 @@ return f();
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="additional_meta_properties" id="test-additional_meta_properties_function.count"><td><span><a class="anchor" href="#test-additional_meta_properties_function.count">&#xA7;</a>function.count</span><script data-source="
 return (_ =&gt; function.count)(1, 2, 3) === 3;
@@ -9069,6 +9184,7 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="additional_meta_properties" id="test-additional_meta_properties_function.arguments"><td><span><a class="anchor" href="#test-additional_meta_properties_function.arguments">&#xA7;</a>function.arguments</span><script data-source="
 var arr =  (_ =&gt; function.arguments)(1, 2, 3);
@@ -9151,6 +9267,7 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="test-method_parameter_decorators"><span><a class="anchor" href="#test-method_parameter_decorators">&#xA7;</a><a href="https://docs.google.com/document/d/1Qpkqf_8NzAwfD8LdnqPjXAQ2wwh8BBUGynhn-ZlCWT0">method parameter decorators</a></span><script data-source="
 var target, key, index;
@@ -9239,6 +9356,7 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="test-function_expression_decorators"><span><a class="anchor" href="#test-function_expression_decorators">&#xA7;</a><a href="https://docs.google.com/document/d/1ikxIP5-RVYq6d_f8lAvf3pKC00W78ueyp-xIZ6q67uU/edit?pref=2&amp;pli=1#">function expression decorators</a></span><script data-source="
 function inverse(f){
@@ -9323,6 +9441,7 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.25"><td id="test-Reflect.isCallable_/_Reflect.isConstructor"><span><a class="anchor" href="#test-Reflect.isCallable_/_Reflect.isConstructor">&#xA7;</a><a href="https://github.com/caitp/TC39-Proposals/blob/master/tc39-reflect-isconstructor-iscallable.md">Reflect.isCallable / Reflect.isConstructor</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -9397,6 +9516,7 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="Reflect.isCallable_/_Reflect.isConstructor" id="test-Reflect.isCallable_/_Reflect.isConstructor_Reflect.isCallable"><td><span><a class="anchor" href="#test-Reflect.isCallable_/_Reflect.isConstructor_Reflect.isCallable">&#xA7;</a>Reflect.isCallable</span><script data-source="
 return Reflect.isCallable(function(){})
@@ -9476,6 +9596,7 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Reflect.isCallable_/_Reflect.isConstructor" id="test-Reflect.isCallable_/_Reflect.isConstructor_Reflect.isConstructor"><td><span><a class="anchor" href="#test-Reflect.isCallable_/_Reflect.isConstructor_Reflect.isConstructor">&#xA7;</a>Reflect.isConstructor</span><script data-source="
 return Reflect.isConstructor(function(){})
@@ -9555,6 +9676,7 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="1"><td id="test-zones"><span><a class="anchor" href="#test-zones">&#xA7;</a><a href="https://github.com/domenic/zones">zones</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -9629,6 +9751,7 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone"><td><span><a class="anchor" href="#test-zones_Zone">&#xA7;</a>Zone</span><script data-source="
 return typeof Zone == &apos;function&apos;;
@@ -9706,6 +9829,7 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.current"><td><span><a class="anchor" href="#test-zones_Zone.current">&#xA7;</a>Zone.current</span><script data-source="
 return &apos;current&apos; in Zone;
@@ -9783,6 +9907,7 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.name"><td><span><a class="anchor" href="#test-zones_Zone.prototype.name">&#xA7;</a>Zone.prototype.name</span><script data-source="
 return &apos;name&apos; in Zone.prototype;
@@ -9860,6 +9985,7 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.parent"><td><span><a class="anchor" href="#test-zones_Zone.prototype.parent">&#xA7;</a>Zone.prototype.parent</span><script data-source="
 return &apos;parent&apos; in Zone.prototype;
@@ -9937,6 +10063,7 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.fork"><td><span><a class="anchor" href="#test-zones_Zone.prototype.fork">&#xA7;</a>Zone.prototype.fork</span><script data-source="
 return typeof Zone.prototype.fork == &apos;function&apos;;
@@ -10014,6 +10141,7 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.run"><td><span><a class="anchor" href="#test-zones_Zone.prototype.run">&#xA7;</a>Zone.prototype.run</span><script data-source="
 return typeof Zone.prototype.run == &apos;function&apos;;
@@ -10091,6 +10219,7 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.wrap"><td><span><a class="anchor" href="#test-zones_Zone.prototype.wrap">&#xA7;</a>Zone.prototype.wrap</span><script data-source="
 return typeof Zone.prototype.wrap == &apos;function&apos;;
@@ -10168,6 +10297,7 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr significance="0.5" class="optional-feature"><td id="test-asap"><span><a class="anchor" href="#test-asap">&#xA7;</a><a href="https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-09/sept-25.md#510-globalasap-for-enqueuing-a-microtask">asap</a></span><script data-source="
 var passed = false;
@@ -10248,6 +10378,7 @@ passed = true;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-syntactic_tail_calls"><span><a class="anchor" href="#test-syntactic_tail_calls">&#xA7;</a><a href="https://github.com/tc39/proposal-ptc-syntax">syntactic tail calls</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -10322,6 +10453,7 @@ passed = true;
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="syntactic_tail_calls" id="test-syntactic_tail_calls_direct_recursion"><td><span><a class="anchor" href="#test-syntactic_tail_calls_direct_recursion">&#xA7;</a>direct recursion</span><script data-source="
 &quot;use strict&quot;;
@@ -10405,6 +10537,7 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="syntactic_tail_calls" id="test-syntactic_tail_calls_mutual_recursion"><td><span><a class="anchor" href="#test-syntactic_tail_calls_mutual_recursion">&#xA7;</a>mutual recursion</span><script data-source="
 &quot;use strict&quot;;
@@ -10495,8 +10628,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="74">Pre-strawman</td>
+<tr class="category"><td colspan="75">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -10571,6 +10705,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.defineMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.defineMetadata">&#xA7;</a>Reflect.defineMetadata</span><script data-source="
 return typeof Reflect.defineMetadata == &apos;function&apos;;
@@ -10648,6 +10783,7 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.hasMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.hasMetadata">&#xA7;</a>Reflect.hasMetadata</span><script data-source="
 return typeof Reflect.hasMetadata == &apos;function&apos;;
@@ -10725,6 +10861,7 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.hasOwnMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.hasOwnMetadata">&#xA7;</a>Reflect.hasOwnMetadata</span><script data-source="
 return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
@@ -10802,6 +10939,7 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.getMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.getMetadata">&#xA7;</a>Reflect.getMetadata</span><script data-source="
 return typeof Reflect.getMetadata == &apos;function&apos;;
@@ -10879,6 +11017,7 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.getOwnMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.getOwnMetadata">&#xA7;</a>Reflect.getOwnMetadata</span><script data-source="
 return typeof Reflect.getOwnMetadata == &apos;function&apos;;
@@ -10956,6 +11095,7 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.getMetadataKeys"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.getMetadataKeys">&#xA7;</a>Reflect.getMetadataKeys</span><script data-source="
 return typeof Reflect.getMetadataKeys == &apos;function&apos;;
@@ -11033,6 +11173,7 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.getOwnMetadataKeys"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.getOwnMetadataKeys">&#xA7;</a>Reflect.getOwnMetadataKeys</span><script data-source="
 return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
@@ -11110,6 +11251,7 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.deleteMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.deleteMetadata">&#xA7;</a>Reflect.deleteMetadata</span><script data-source="
 return typeof Reflect.deleteMetadata == &apos;function&apos;;
@@ -11187,6 +11329,7 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.metadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.metadata">&#xA7;</a>Reflect.metadata</span><script data-source="
 return typeof Reflect.metadata == &apos;function&apos;;
@@ -11264,6 +11407,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape20" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 </tbody>
     </table>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -166,6 +166,7 @@
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
 <th class="platform ios9 mobile" data-browser="ios9"><a href="#ios9" class="browser-name"><abbr title="iOS Safari">iOS 9</abbr></a></th>
 <th class="platform ios10 mobile" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10</abbr></a></th>
+<th class="platform duktape20 engine" data-browser="duktape20"><a href="#duktape20" class="browser-name"><abbr title="Duktape 2.0.x">DUK 20</abbr></a></th>
 </tr>
 
         </thead>
@@ -235,6 +236,7 @@
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios9" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape20" data-tally="0">0/4</td>
 </tr>
 <tr class="subtest" data-parent="decompilation" id="test-decompilation_uneval,_existence_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-decompilation_uneval,_existence_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>uneval, existence <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof uneval == &apos;function&apos;;
@@ -303,6 +305,7 @@ return typeof uneval == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="decompilation" id="test-decompilation_built-in_toSource_methods_a_href=_https://developer.mozilla.org/en-US/search?q=tosource_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-decompilation_built-in_toSource_methods_a_href=_https://developer.mozilla.org/en-US/search?q=tosource_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>built-in &quot;toSource&quot; methods <a href="https://developer.mozilla.org/en-US/search?q=tosource" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;toSource&apos; in Object.prototype
@@ -379,6 +382,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="decompilation" id="test-decompilation_toSource_method_as_hook_for_uneval"><td><span><a class="anchor" href="#test-decompilation_toSource_method_as_hook_for_uneval">&#xA7;</a>&quot;toSource&quot; method as hook for uneval</span><script data-source="
 return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;pwnd!&quot;;
@@ -447,6 +451,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr class="subtest" data-parent="decompilation" id="test-decompilation_eval(uneval(value))_is_functionally_equivalent_to_value"><td><span><a class="anchor" href="#test-decompilation_eval(uneval(value))_is_functionally_equivalent_to_value">&#xA7;</a>eval(uneval(value)) is functionally equivalent to value</span><script data-source="
 
@@ -604,6 +609,7 @@ return true;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-optional_scope_argument_of_eval"><span><a class="anchor" href="#test-optional_scope_argument_of_eval">&#xA7;</a>optional &quot;scope&quot; argument of &quot;eval&quot;</span><script data-source="
 var x = 1;
@@ -673,8 +679,9 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -745,6 +752,7 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-function_arity_property"><span><a class="anchor" href="#test-function_arity_property">&#xA7;</a>function &quot;arity&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arity" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return (function () {}).arity === 0 &amp;&amp;
@@ -819,6 +827,7 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-function_arguments_property"><span><a class="anchor" href="#test-function_arguments_property">&#xA7;</a>function &quot;arguments&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 function f(a, b) {
@@ -895,6 +904,7 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Function.prototype.isGenerator"><span><a class="anchor" href="#test-Function.prototype.isGenerator">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/isGenerator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Function.prototype.isGenerator == &apos;function&apos;;
@@ -965,8 +975,9 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -1036,6 +1047,7 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-__count__"><span><a class="anchor" href="#test-__count__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/count" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof ({}).__count__ === &apos;number&apos; &amp;&amp;
@@ -1108,6 +1120,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-__parent__"><span><a class="anchor" href="#test-__parent__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/Parent" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof ({}).__parent__ !== &apos;undefined&apos;;
@@ -1178,6 +1191,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-__noSuchMethod__"><span><a class="anchor" href="#test-__noSuchMethod__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/noSuchMethod" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 var o = { }, executed = false;
@@ -1258,6 +1272,7 @@ return executed;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Array_generics"><span><a class="anchor" href="#test-Array_generics">&#xA7;</a>Array generics</span><script data-source="function () {
 return typeof Array.slice === &apos;function&apos; &amp;&amp; Array.slice(&apos;abc&apos;).length === 3;
@@ -1328,6 +1343,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-String_generics"><span><a class="anchor" href="#test-String_generics">&#xA7;</a>String generics</span><script data-source="function () {
 return typeof String.slice === &apos;function&apos; &amp;&amp; String.slice(123, 1) === &quot;23&quot;;
@@ -1398,8 +1414,9 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -1470,6 +1487,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.5"><td id="test-Array_comprehensions_(ES_draft_style)"><span><a class="anchor" href="#test-Array_comprehensions_(ES_draft_style)">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions (ES draft style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
@@ -1538,6 +1556,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Expression_closures"><span><a class="anchor" href="#test-Expression_closures">&#xA7;</a>Expression closures <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Expression_closures" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return (function(x)x)(1) === 1;
@@ -1606,6 +1625,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-ECMAScript_for_XML_(E4X)"><span><a class="anchor" href="#test-ECMAScript_for_XML_(E4X)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X">ECMAScript for XML (E4X)</a> <a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof &lt;foo/&gt; === &quot;xml&quot;;
@@ -1674,6 +1694,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-for_each..in_loops"><span><a class="anchor" href="#test-for_each..in_loops">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in">&quot;for each..in&quot; loops</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var str = &apos;&apos;;
@@ -1746,6 +1767,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Sharp_variables"><span><a class="anchor" href="#test-Sharp_variables">&#xA7;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a> <a href="https://developer.mozilla.org/en-US/docs/Archive/Web/Sharp_variables_in_JavaScript" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var arr = #1=[1, #1#, 3];
@@ -1815,8 +1837,9 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -1917,6 +1940,7 @@ catch(e) {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-__iterator__"><span><a class="anchor" href="#test-__iterator__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">__iterator__</a></span><script data-source="function () {
 try {
@@ -2025,6 +2049,7 @@ catch(e) {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Generators_(JS_1.8)"><span><a class="anchor" href="#test-Generators_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generators">Generators (JS 1.8)</a></span><script type="application/javascript;version=1.8" data-source="global.test((function () {
 try {
@@ -2132,6 +2157,7 @@ global.test((function () {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Generator_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Generator_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_expressions">Generator comprehensions (JS 1.8 style)</a></span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -2202,6 +2228,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="0.5"><td id="test-Generator_comprehensions_(ES_draft_style)"><span><a class="anchor" href="#test-Generator_comprehensions_(ES_draft_style)">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Generator comprehensions (ES draft style)</a></span><script data-source="
 var iterator = (for (a of [1,2]) a + 4);
@@ -2277,8 +2304,9 @@ return passed;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -2363,6 +2391,7 @@ try {
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-RegExp_lastMatch"><span><a class="anchor" href="#test-RegExp_lastMatch">&#xA7;</a>RegExp &quot;lastMatch&quot; <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 var re = /\w/;
@@ -2437,6 +2466,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-RegExp.$1-$9"><span><a class="anchor" href="#test-RegExp.$1-$9">&#xA7;</a>RegExp.$1-$9 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 for (var i = 1; i &lt; 10; i++) {
@@ -2513,6 +2543,7 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Callable_RegExp"><span><a class="anchor" href="#test-Callable_RegExp">&#xA7;</a>Callable RegExp</span><script data-source="
 return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
@@ -2581,10 +2612,12 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-RegExp_named_groups"><span><a class="anchor" href="#test-RegExp_named_groups">&#xA7;</a>RegExp named groups</span><script data-source="
-return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
+       !/(?P&lt;name&gt;a)(?P=name)/.test(&quot;&quot;)
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nreturn /(?P<name>a)(?P=name)/.test(\"aa\") &&\n       !/(?P<name>a)(?P=name)/.test(\"\")\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?P<name>a)(?P=name)/.test(\"aa\") &&\n       !/(?P<name>a)(?P=name)/.test(\"\")\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
@@ -2649,8 +2682,9 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.trimLeft"><span><a class="anchor" href="#test-String.prototype.trimLeft">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft">String.prototype.trimLeft</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.trimLeft === &apos;function&apos; }">test(
 function () { return typeof String.prototype.trimLeft === 'function' }())</script></td>
@@ -2717,6 +2751,7 @@ function () { return typeof String.prototype.trimLeft === 'function' }())</scrip
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-String.prototype.trimRight"><span><a class="anchor" href="#test-String.prototype.trimRight">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight">String.prototype.trimRight</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.trimRight === &apos;function&apos; }">test(
 function () { return typeof String.prototype.trimRight === 'function' }())</script></td>
@@ -2783,6 +2818,7 @@ function () { return typeof String.prototype.trimRight === 'function' }())</scri
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
@@ -2849,6 +2885,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-String.prototype.replace_flags"><span><a class="anchor" href="#test-String.prototype.replace_flags">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace">String.prototype.replace flags</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Firefox-specific_notes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return &apos;foofoo&apos;.replace(&apos;foo&apos;, &apos;bar&apos;, &apos;g&apos;) === &apos;barbar&apos; }">test(
 function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</script></td>
@@ -2915,8 +2952,9 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
@@ -2983,6 +3021,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Date.parse_produces_NaN_for_invalid_dates"><span><a class="anchor" href="#test-Date.parse_produces_NaN_for_invalid_dates">&#xA7;</a>Date.parse produces NaN for invalid dates</span><script data-source="function () {
 var brokenOnFirefox = !isNaN(Date.parse(&apos;2012-04-04T24:00:00.500Z&apos;));
@@ -3059,8 +3098,9 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
@@ -3127,6 +3167,7 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.unwatch"><span><a class="anchor" href="#test-Object.prototype.unwatch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch">Object.prototype.unwatch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.unwatch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.unwatch == 'function' }())</script></td>
@@ -3193,6 +3234,7 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.eval"><span><a class="anchor" href="#test-Object.prototype.eval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/eval">Object.prototype.eval</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/eval" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.eval == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.eval == 'function' }())</script></td>
@@ -3259,6 +3301,7 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#test-Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/observe" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Object.observe == &apos;function&apos;;
@@ -3327,8 +3370,9 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -3407,6 +3451,7 @@ try {
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr significance="1"><td id="test-error_lineNumber"><span><a class="anchor" href="#test-error_lineNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber">error &quot;lineNumber&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;lineNumber&apos; in new Error();
@@ -3477,6 +3522,7 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr significance="1"><td id="test-error_columnNumber"><span><a class="anchor" href="#test-error_columnNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber">error &quot;columnNumber&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;columnNumber&apos; in new Error();
@@ -3547,6 +3593,7 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
 <tr significance="1"><td id="test-error_fileName"><span><a class="anchor" href="#test-error_fileName">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName">error &quot;fileName&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;fileName&apos; in new Error();
@@ -3617,6 +3664,7 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="yes" data-browser="duktape20">Yes</td>
 </tr>
 <tr significance="1"><td id="test-error_description"><span><a class="anchor" href="#test-error_description">&#xA7;</a><a href="http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx">error &quot;description&quot;</a></span><script data-source="function () {
 return &apos;description&apos; in new Error();
@@ -3687,8 +3735,9 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
+<td class="no" data-browser="duktape20">No</td>
 </tr>
-<tr><th colspan="66" class="separator"></th>
+<tr><th colspan="67" class="separator"></th>
 </tr>
 </tbody>
       </table>


### PR DESCRIPTION
Add initial ES5 and ES6 results for Duktape 2.0.

Also adds `duktape.js` which runs the tests using `./duk` and reports discrepancies between `data-*.js` results and actual results so that the data files can be fixed manually. (I'm not sure this is the correct process; it's a bit awkward for initial results but incremental updates should be easy enough.)

I'm new to compat-table so let me know if I've misunderstood something. Based on previous pulls it seems both data and HTML files are updated by each pull.

- [x] Use fs.readdir() to read in the tests
- [ ] Enable all tests, populate results (TBD: false vs. missing?)