### PR TITLE
Fix a layout issue that breaks in Firefox

### DIFF
--- a/master.css
+++ b/master.css
@@ -440,6 +440,7 @@ label[for="sort"] {
     position: absolute; top: -15px; right: 0px; font-size: 11px;
     transition-property: top;
     transition-duration: .5s;
+    line-height: 15px;
 }
 .num-features b {
     font-weight: bold;


### PR DESCRIPTION
There's a rounding issue in Firefox which causes the first pixel row of the table header is obscured by the "% complete" box.  This patch is a workaround.

More details at https://github.com/webcompat/web-bugs/issues/5874.