### PR TITLE
Updating the test for RegExp.prototype[Symbol.search] on the ES6 tab

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -8776,8 +8776,6 @@ exports.tests = [
         firefox55: true,
         chrome51: false,
         chrome56: true,
-        xs6: true,       // needs checking
-        safari10: true,  // needs checking
         duktape20: false,
       },
     },

--- a/data-es6.js
+++ b/data-es6.js
@@ -8768,15 +8768,16 @@ exports.tests = [
         var get = [];
         var p = new Proxy({ exec: function() { return null; } }, { get: function(o, k) { get.push(k); return o[k]; }});
         RegExp.prototype[Symbol.search].call(p);
-        return get + '' === "lastIndex,exec";
+        return get + '' === "lastIndex,exec,lastIndex";
       */},
       res: {
-        edge14: "flagged",
-        firefox49: true,
-        chrome51: true,
-        chrome56: false,
-        xs6: true,
-        safari10: true,
+        edge14: false,
+        firefox49: false,
+        firefox55: true,
+        chrome51: false,
+        chrome56: true,
+        xs6: true,       // needs checking
+        safari10: true,  // needs checking
         duktape20: false,
       },
     },

--- a/data-es6.js
+++ b/data-es6.js
@@ -8770,6 +8770,8 @@ exports.tests = [
         RegExp.prototype[Symbol.search].call(p);
         return get + '' === "lastIndex,exec,lastIndex";
       */},
+      note_id: "regexp-prototype-symbolsearch",
+      note_html: "The specification for this feature was <a href='https://github.com/tc39/ecma262/pull/627'>updated</a> after ES6 was published.  This test reflects the updated spec, which is implemented by the latest browsers.",
       res: {
         edge14: false,
         firefox49: false,


### PR DESCRIPTION
According to [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1362379#c1), the specification has changed and the results are wrong.

I have updated the test itself and the results for Firefox 49-55, Chrome 51-59 and Edge 13-14, but I was unable to test for Safari10 and XS6.  If someone can re-run the tests on these and post the results here soon, I'll update the patch accordingly.  Or this can be done in a follow-up patch.