### PR TITLE
Fix typo in node version for math.asinh

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -15913,7 +15913,7 @@ exports.tests = [
         chrome34: "flagged",
         chrome38: true,
         safari7_1: true,
-        node_012: true,
+        node0_12: true,
         xs6: true,
         jxa: true,
         duktape2_0: false,


### PR DESCRIPTION
Noticed this after regenerating data in https://github.com/babel/babel-preset-env/pull/323