### PR TITLE
Adding Edge 16 Preview, fixing flagged links

### DIFF
--- a/data-common.json
+++ b/data-common.json
@@ -23,6 +23,13 @@
       "note_html": "TypeScript <code>async</code> / <code>await</code> requires native generators support."
     }
   },
+  "edge": {
+    "experimental": {
+      "val": "flagged",
+      "note_id": "edge-experimental-flag",
+      "note_html": "Flagged features have to be enabled via \"Enable experimental Javascript features\" setting under about:flags"
+    }
+  },
   "firefox": {
     "sharedmem": {
       "val": "flagged",

--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -4,6 +4,7 @@ var babel = common.babel;
 var typescript = common.typescript;
 var firefox = common.firefox;
 var chrome = common.chrome;
+var edge = common.edge;
 
 exports.name = 'ES2016+';
 exports.target_file = 'es2016plus/index.html';
@@ -27,7 +28,7 @@ exports.tests = [
           babel: true,
           closure: true,
           typescript: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge14: true,
           firefox42: firefox.nightly,
           firefox52: true,
@@ -49,7 +50,7 @@ exports.tests = [
           babel: true,
           closure: true,
           typescript: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge14: true,
           firefox48: firefox.nightly,
           firefox52: true,
@@ -312,7 +313,7 @@ exports.tests = [
           typescript: typescript.corejs,
           es7shim: true,
           firefox48: true,
-          edge14: "flagged",
+          edge14: edge.experimental,
           edge15: true,
           chrome52: "flagged",
           chrome57: true,
@@ -338,7 +339,7 @@ exports.tests = [
           typescript: typescript.corejs,
           es7shim: true,
           firefox48: true,
-          edge14: "flagged",
+          edge14: edge.experimental,
           edge15: true,
           chrome52: "flagged",
           chrome57: true,
@@ -429,7 +430,7 @@ exports.tests = [
           typescript: typescript.asyncawait,
           chrome52: "flagged",
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -460,7 +461,7 @@ exports.tests = [
           typescript: null,
           chrome52: null,
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -482,7 +483,7 @@ exports.tests = [
           chrome52: null,
           chrome55: true,
           edge13: false,
-          edge14: "flagged",
+          edge14: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -503,7 +504,7 @@ exports.tests = [
           typescript: null,
           chrome52: null,
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -531,7 +532,7 @@ exports.tests = [
           typescript: typescript.asyncawait,
           chrome52: "flagged",
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -560,7 +561,7 @@ exports.tests = [
           typescript: null,
           chrome52: null,
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -581,7 +582,7 @@ exports.tests = [
           typescript: null,
           chrome52: null,
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -607,7 +608,7 @@ exports.tests = [
           typescript: null,
           chrome52: null,
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -628,7 +629,7 @@ exports.tests = [
           typescript: null,
           chrome52: null,
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -659,7 +660,7 @@ exports.tests = [
           typescript: null,
           chrome52: null,
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -690,7 +691,7 @@ exports.tests = [
           typescript: null,
           chrome52: null,
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -719,7 +720,7 @@ exports.tests = [
           typescript: false, // still buggy output
           chrome52: "flagged",
           chrome55: true,
-          edge13: "flagged",
+          edge13: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -743,7 +744,7 @@ exports.tests = [
           chrome52: null,
           chrome55: true,
           edge13: false,
-          edge14: "flagged",
+          edge14: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -793,7 +794,7 @@ exports.tests = [
           chrome52: null,
           chrome55: true,
           edge13: false,
-          edge14: "flagged",
+          edge14: edge.experimental,
           edge15: true,
           firefox52: true,
           safari10_1: true,
@@ -816,7 +817,8 @@ exports.tests = [
          return typeof SharedArrayBuffer === 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -835,7 +837,8 @@ exports.tests = [
          return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox52: firefox.developer,
           firefox53: firefox.sharedmem,
           firefox55: true,
@@ -853,7 +856,8 @@ exports.tests = [
          return 'byteLength' in SharedArrayBuffer.prototype;
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -873,7 +877,8 @@ exports.tests = [
          return typeof SharedArrayBuffer.prototype.slice === 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox52: firefox.developer,
           firefox53: firefox.sharedmem,
           firefox55: true,
@@ -890,7 +895,8 @@ exports.tests = [
          return SharedArrayBuffer.prototype[Symbol.toStringTag] === 'SharedArrayBuffer';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox52: firefox.developer,
           firefox53: firefox.sharedmem,
           chrome48: chrome.sharedmem,
@@ -909,7 +915,8 @@ exports.tests = [
          return typeof Atomics.add == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -929,7 +936,8 @@ exports.tests = [
          return typeof Atomics.and == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -949,7 +957,8 @@ exports.tests = [
          return typeof Atomics.compareExchange == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -969,7 +978,8 @@ exports.tests = [
          return typeof Atomics.exchange == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -989,7 +999,8 @@ exports.tests = [
          return typeof Atomics.wait == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox48: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -1009,7 +1020,8 @@ exports.tests = [
          return typeof Atomics.wake == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox48: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -1029,7 +1041,8 @@ exports.tests = [
          return typeof Atomics.isLockFree == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -1049,7 +1062,8 @@ exports.tests = [
          return typeof Atomics.load == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -1069,7 +1083,8 @@ exports.tests = [
          return typeof Atomics.or == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -1089,7 +1104,8 @@ exports.tests = [
          return typeof Atomics.store == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -1109,7 +1125,8 @@ exports.tests = [
          return typeof Atomics.sub == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -1129,7 +1146,8 @@ exports.tests = [
          return typeof Atomics.xor == 'function';
          */},
         res: {
-          edge15: "flagged",
+          edge15: edge.experimental,
+          edge16: true,
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
           firefox53: firefox.sharedmem,
@@ -1265,7 +1283,7 @@ exports.tests = [
     res: {
       babel: true,
       closure: true,
-      edge13: "flagged",
+      edge13: edge.experimental,
       edge14: true,
       firefox47: true,
       safari10_1: true,
@@ -1295,7 +1313,7 @@ exports.tests = [
     res: {
       babel: true,
       closure: true,
-      edge13: "flagged",
+      edge13: edge.experimental,
       edge14: true,
       firefox47: true,
       typescript: true,

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -3,6 +3,7 @@ var common = require('./data-common');
 var typescript = common.typescript;
 var firefox = common.firefox;
 var chrome = common.chrome;
+var edge = common.edge;
 
 exports.name = 'ES Next';
 exports.target_file = 'esnext/index.html';
@@ -102,7 +103,7 @@ exports.tests = [
         return typeof SIMD !== 'undefined';
       */},
       res: {
-        edge12: "flagged",
+        edge12: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -116,7 +117,7 @@ exports.tests = [
         return typeof SIMD.Float32x4 === 'function';
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -130,7 +131,7 @@ exports.tests = [
         return typeof SIMD.Int32x4 === 'function';
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -146,7 +147,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -158,7 +159,7 @@ exports.tests = [
         return typeof SIMD.Int8x16 === 'function';
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -174,7 +175,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -188,7 +189,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -202,7 +203,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -216,7 +217,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -230,7 +231,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -244,7 +245,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -258,7 +259,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -274,7 +275,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -292,7 +293,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -308,7 +309,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -324,7 +325,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -340,7 +341,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -354,7 +355,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -370,7 +371,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -386,7 +387,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -402,7 +403,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -418,7 +419,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -434,7 +435,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -450,7 +451,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -466,7 +467,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -482,7 +483,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -500,7 +501,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -515,7 +516,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -530,7 +531,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -545,7 +546,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -559,7 +560,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -577,7 +578,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         edge15: false,
         duktape2_0: false,
       }
@@ -592,7 +593,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -610,7 +611,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         edge15: false,
         duktape2_0: false,
       }
@@ -625,7 +626,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -643,7 +644,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -657,7 +658,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -675,7 +676,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -691,7 +692,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -707,7 +708,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -721,7 +722,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -737,7 +738,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -755,7 +756,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -771,7 +772,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -785,7 +786,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -801,7 +802,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -817,7 +818,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -833,7 +834,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -848,7 +849,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -863,7 +864,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -878,7 +879,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -894,7 +895,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -910,7 +911,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -926,7 +927,7 @@ exports.tests = [
         });
       */},
       res: {
-        edge13: "flagged",
+        edge13: edge.experimental,
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
         duktape2_0: false,
@@ -944,7 +945,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -960,7 +961,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     },
@@ -974,7 +975,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         chrome37: chrome.simd,
-        edge14: "flagged",
+        edge14: edge.experimental,
         duktape2_0: false,
       }
     }
@@ -1100,7 +1101,6 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
-        ie7: false,
         edge12: true,
         firefox2: false,
         firefox3_5: true,
@@ -1134,7 +1134,6 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
-        ie7: false,
         edge12: true,
         firefox2: false,
         firefox3_5: true,

--- a/environments.json
+++ b/environments.json
@@ -144,11 +144,11 @@
     "family": "Chakra",
     "short": "IE 7",
     "release": "2006-10-18",
-    "obsolete": "very",
+    "obsolete": true,
     "test_suites": [
       "es5",
       "es6",
-      "esintl",
+      "esnext",
       "non-standard"
     ]
   },
@@ -157,12 +157,11 @@
     "family": "Chakra",
     "short": "IE 8",
     "release": "2009-03-19",
-    "retire": "2016-01-12",
-    "obsolete": "very",
+    "obsolete": true,
     "test_suites": [
       "es5",
       "es6",
-      "esintl",
+      "esnext",
       "non-standard"
     ]
   },
@@ -171,15 +170,13 @@
     "family": "Chakra",
     "short": "IE 9",
     "release": "2011-03-14",
-    "retire": "2016-01-12",
-    "obsolete": "very"
+    "obsolete": true
   },
   "ie10": {
     "full": "Internet Explorer",
     "family": "Chakra",
     "short": "IE 10",
     "release": "2012-10-26",
-    "retire": "2016-01-12",
     "obsolete": true
   },
   "ie11": {

--- a/environments.json
+++ b/environments.json
@@ -144,11 +144,11 @@
     "family": "Chakra",
     "short": "IE 7",
     "release": "2006-10-18",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es5",
       "es6",
-      "esnext",
+      "esintl",
       "non-standard"
     ]
   },
@@ -157,11 +157,12 @@
     "family": "Chakra",
     "short": "IE 8",
     "release": "2009-03-19",
-    "obsolete": true,
+    "retire": "2016-01-12",
+    "obsolete": "very",
     "test_suites": [
       "es5",
       "es6",
-      "esnext",
+      "esintl",
       "non-standard"
     ]
   },
@@ -170,13 +171,15 @@
     "family": "Chakra",
     "short": "IE 9",
     "release": "2011-03-14",
-    "obsolete": true
+    "retire": "2016-01-12",
+    "obsolete": "very"
   },
   "ie10": {
     "full": "Internet Explorer",
     "family": "Chakra",
     "short": "IE 10",
     "release": "2012-10-26",
+    "retire": "2016-01-12",
     "obsolete": true
   },
   "ie11": {
@@ -191,30 +194,34 @@
     "family": "Chakra",
     "short": "Edge 12",
     "release": "2015-07-15",
-    "obsolete": true,
-    "note_id": "edge-experimental-flag",
-    "note_html": "Flagged features have to be enabled via \"Enable experimental Javascript features\" setting under about:flags"
+    "obsolete": true
   },
   "edge13": {
     "full": "Microsoft Edge",
     "family": "Chakra",
     "short": "Edge 13",
     "release": "2015-11-05",
-    "obsolete": true,
-    "note_id": "edge-experimental-flag"
+    "obsolete": true
   },
   "edge14": {
     "full": "Microsoft Edge",
     "family": "Chakra",
     "short": "Edge 14",
     "release": "2016-08-02",
-    "note_id": "edge-experimental-flag"
+    "obsolete": false
   },
   "edge15": {
     "full": "Microsoft Edge",
     "family": "Chakra",
     "short": "Edge 15",
-    "note_id": "edge-experimental-flag"
+    "release": "2017-04-11",
+    "obsolete": false
+  },
+  "edge16": {
+    "full": "Microsoft Edge",
+    "family": "Chakra",
+    "short": "Edge 16 Preview",
+    "unstable": true
   },
   "firefox1": {
     "full": "Firefox",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -110,6 +110,7 @@
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20161024">Closure</abbr></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
+<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
@@ -168,7 +169,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="60">2016 features</td>
+      <tr class="category"><td colspan="61">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -176,6 +177,7 @@
 <td class="tally" data-browser="closure" data-tally="1">3/3</td>
 <td class="tally" data-browser="typescript" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
@@ -239,6 +241,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -302,6 +305,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -370,6 +374,7 @@ return true;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -430,6 +435,7 @@ return true;
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
@@ -497,6 +503,7 @@ return [1, 2, 3].includes(1)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -582,6 +589,7 @@ return 24;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -650,6 +658,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -704,7 +713,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="60">2016 misc</td>
+<tr class="category"><td colspan="61">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -722,6 +731,7 @@ return true;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -798,6 +808,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -866,6 +877,7 @@ return true;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -930,6 +942,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -995,6 +1008,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1065,6 +1079,7 @@ return passed;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1137,6 +1152,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1191,7 +1207,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="60">2017 features</td>
+<tr class="category"><td colspan="61">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1199,6 +1215,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
@@ -1265,6 +1282,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1335,6 +1353,7 @@ return Array.isArray(e)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1406,6 +1425,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1472,6 +1492,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1532,6 +1553,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
@@ -1600,6 +1622,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1668,6 +1691,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1728,6 +1752,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
@@ -1791,6 +1816,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1854,6 +1880,7 @@ return Math.min(1,2,3,) === 1;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1914,6 +1941,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="closure" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally" data-browser="typescript" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/15</td>
@@ -1988,6 +2016,7 @@ p.then(function(result) {
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2062,6 +2091,7 @@ p.catch(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2126,6 +2156,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2190,6 +2221,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2260,6 +2292,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2332,6 +2365,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2396,6 +2430,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2465,6 +2500,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2529,6 +2565,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2603,6 +2640,7 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2677,6 +2715,7 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2749,6 +2788,7 @@ p.then(function(result) {
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2815,6 +2855,7 @@ return passed;
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2878,6 +2919,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2950,6 +2992,7 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3010,6 +3053,7 @@ p.then(function(result) {
 <td class="tally" data-browser="closure" data-tally="0">0/17</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/17</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/17</td>
@@ -3073,6 +3117,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3136,6 +3181,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3199,6 +3245,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3262,6 +3309,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3325,6 +3373,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3388,6 +3437,7 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3451,6 +3501,7 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3514,6 +3565,7 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3577,6 +3629,7 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3640,6 +3693,7 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3703,6 +3757,7 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3766,6 +3821,7 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3829,6 +3885,7 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3892,6 +3949,7 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3955,6 +4013,7 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4018,6 +4077,7 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4081,6 +4141,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4135,7 +4196,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="60">2017 misc</td>
+<tr class="category"><td colspan="61">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -4151,6 +4212,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4217,6 +4279,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4283,6 +4346,7 @@ return (function(){
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4337,7 +4401,7 @@ return (function(){
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="60">2017 annex b</td>
+<tr class="category"><td colspan="61">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -4345,6 +4409,7 @@ return (function(){
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
@@ -4413,6 +4478,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4482,6 +4548,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4551,6 +4618,7 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4619,6 +4687,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4688,6 +4757,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4757,6 +4827,7 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4827,6 +4898,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4897,6 +4969,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4968,6 +5041,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5036,6 +5110,7 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5103,6 +5178,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5173,6 +5249,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5243,6 +5320,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5314,6 +5392,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5382,6 +5461,7 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5449,6 +5529,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5509,6 +5590,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
@@ -5576,6 +5658,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5643,6 +5726,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5715,6 +5799,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5787,6 +5872,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5851,6 +5937,7 @@ return i === 0;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5905,7 +5992,7 @@ return i === 0;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="60">2018 features</td>
+<tr class="category"><td colspan="61">2018 features</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -5923,6 +6010,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -110,13 +110,13 @@
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20161024">Closure</abbr></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
-<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
-<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
-<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
-<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
+<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
+<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
+<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a></th>
+<th class="platform edge16 desktop unstable" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16 Preview</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox47 desktop obsolete" data-browser="firefox47"><a href="#firefox47" class="browser-name"><abbr title="Firefox">FF 47</abbr></a></th>
 <th class="platform firefox48 desktop obsolete" data-browser="firefox48"><a href="#firefox48" class="browser-name"><abbr title="Firefox">FF 48</abbr></a></th>
@@ -147,15 +147,15 @@
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 32">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
-<th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node6_5 engine" data-browser="node6_5"><a href="#node6_5" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node7_6 engine" data-browser="node7_6"><a href="#node7_6" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node6_5 engine" data-browser="node6_5"><a href="#node6_5" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node7_6 engine" data-browser="node7_6"><a href="#node7_6" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform duktape2_0 engine" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -176,13 +176,13 @@
 <td class="tally" data-browser="closure" data-tally="1">3/3</td>
 <td class="tally" data-browser="typescript" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.6666666666666666">0/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/3</td>
@@ -239,13 +239,13 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -302,13 +302,13 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -370,13 +370,13 @@ return true;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -430,13 +430,13 @@ return true;
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">3/3</td>
@@ -497,13 +497,13 @@ return [1, 2, 3].includes(1)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -582,13 +582,13 @@ return 24;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -650,13 +650,13 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -722,13 +722,13 @@ return true;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -798,13 +798,13 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -866,13 +866,13 @@ return true;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -930,13 +930,13 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -995,13 +995,13 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1065,13 +1065,13 @@ return passed;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1137,13 +1137,13 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1199,13 +1199,13 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -1265,13 +1265,13 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1335,13 +1335,13 @@ return Array.isArray(e)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1406,13 +1406,13 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1472,13 +1472,13 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1532,13 +1532,13 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">2/2</td>
@@ -1600,13 +1600,13 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1668,13 +1668,13 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1728,13 +1728,13 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/2</td>
@@ -1791,13 +1791,13 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1854,13 +1854,13 @@ return Math.min(1,2,3,) === 1;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1914,13 +1914,13 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="closure" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally" data-browser="typescript" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.7333333333333333">0/15</td>
 <td class="tally" data-browser="edge14" data-tally="0" data-flagged-tally="0.9333333333333333">0/15</td>
 <td class="tally" data-browser="edge15" data-tally="1">15/15</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">15/15</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/15</td>
@@ -1988,13 +1988,13 @@ p.then(function(result) {
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2062,13 +2062,13 @@ p.catch(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2126,13 +2126,13 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2190,13 +2190,13 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2260,13 +2260,13 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2332,13 +2332,13 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2396,13 +2396,13 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2465,13 +2465,13 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2529,13 +2529,13 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2603,13 +2603,13 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2677,13 +2677,13 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2749,13 +2749,13 @@ p.then(function(result) {
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2815,13 +2815,13 @@ return passed;
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2878,13 +2878,13 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2950,13 +2950,13 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -3010,13 +3010,13 @@ p.then(function(result) {
 <td class="tally" data-browser="closure" data-tally="0">0/17</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/17</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/17</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/17</td>
 <td class="tally" data-browser="edge15" data-tally="0" data-flagged-tally="1">0/17</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">17/17</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/17</td>
@@ -3073,13 +3073,13 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3136,13 +3136,13 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -3199,13 +3199,13 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3262,13 +3262,13 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -3325,13 +3325,13 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -3388,13 +3388,13 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3451,13 +3451,13 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3514,13 +3514,13 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3577,13 +3577,13 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3640,13 +3640,13 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3703,13 +3703,13 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3766,13 +3766,13 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3829,13 +3829,13 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3892,13 +3892,13 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3955,13 +3955,13 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4018,13 +4018,13 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4081,13 +4081,13 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4151,13 +4151,13 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4217,13 +4217,13 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4283,13 +4283,13 @@ return (function(){
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4345,13 +4345,13 @@ return (function(){
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally" data-browser="edge14" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally" data-browser="edge15" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally" data-browser="firefox45" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">16/16</td>
@@ -4413,13 +4413,13 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4482,13 +4482,13 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4551,13 +4551,13 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4619,13 +4619,13 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4688,13 +4688,13 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4757,13 +4757,13 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4827,13 +4827,13 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4897,13 +4897,13 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4968,13 +4968,13 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5036,13 +5036,13 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5103,13 +5103,13 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5173,13 +5173,13 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5243,13 +5243,13 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5314,13 +5314,13 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5382,13 +5382,13 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5449,13 +5449,13 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5509,13 +5509,13 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5576,13 +5576,13 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5643,13 +5643,13 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5715,13 +5715,13 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5787,13 +5787,13 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5851,13 +5851,13 @@ return i === 0;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5923,13 +5923,13 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5981,7 +5981,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="babel-optional-note">  <sup>[2]</sup> Flagged features require an optional transformer setting.</p><p id="edge-experimental-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p><p id="harmony-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="firefox-nightly-note">  <sup>[5]</sup> The feature is enabled by default only in Firefox Nightly.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>, or when a native ES6 host is used.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="strict-fn-non-strict-params-note">  <sup>[9]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[12]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[13]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="typescript-async-await-note">  <sup>[14]</sup> TypeScript <code>async</code> / <code>await</code> requires native generators support.</p><p id="firefox-developer-note">  <sup>[15]</sup> The feature is enabled by default only in Firefox Developer and Firefox Nightly.</p><p id="firefox-sharedmem-note">  <sup>[16]</sup> The feature have to be enabled via &quot;javascript.options.shared_memory&quot; setting under about:config.  It is enabled by default in Firefox Developer and Firefox Nightly.</p><p id="chrome-sharedmem-note">  <sup>[17]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under about:flags</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="babel-optional-note">  <sup>[2]</sup> Flagged features require an optional transformer setting.</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="edge-experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p><p id="firefox-nightly-note">  <sup>[5]</sup> The feature is enabled by default only in Firefox Nightly.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>, or when a native ES6 host is used.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="strict-fn-non-strict-params-note">  <sup>[9]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[12]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[13]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="typescript-async-await-note">  <sup>[14]</sup> TypeScript <code>async</code> / <code>await</code> requires native generators support.</p><p id="firefox-developer-note">  <sup>[15]</sup> The feature is enabled by default only in Firefox Developer and Firefox Nightly.</p><p id="firefox-sharedmem-note">  <sup>[16]</sup> The feature have to be enabled via &quot;javascript.options.shared_memory&quot; setting under about:config.  It is enabled by default in Firefox Developer and Firefox Nightly.</p><p id="chrome-sharedmem-note">  <sup>[17]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under about:flags</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/es5/index.html
+++ b/es5/index.html
@@ -116,15 +116,13 @@
 <th class="platform konq49 desktop obsolete" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></a></th>
 <th class="platform konq413 desktop obsolete" data-browser="konq413"><a href="#konq413" class="browser-name"><abbr title="Konqueror 4.13">Konq 4.13</abbr></a></th>
 <th class="platform konq414 desktop" data-browser="konq414"><a href="#konq414" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr></a><a href="#khtml-note"><sup>[2]</sup></a></th>
-<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
-<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
-<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
-<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
-<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
-<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
+<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
+<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
+<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a></th>
+<th class="platform edge16 desktop unstable" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16 Preview</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox47 desktop obsolete" data-browser="firefox47"><a href="#firefox47" class="browser-name"><abbr title="Firefox">FF 47</abbr></a></th>
 <th class="platform firefox48 desktop obsolete" data-browser="firefox48"><a href="#firefox48" class="browser-name"><abbr title="Firefox">FF 48</abbr></a></th>
@@ -181,15 +179,13 @@
 <td class="tally obsolete" data-browser="konq49" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="konq414" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">5/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">5/5</td>
@@ -245,15 +241,13 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -311,15 +305,13 @@ return value === 1;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -375,15 +367,13 @@ return { a: true, }.a === true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -439,15 +429,13 @@ return [1,].length === 1;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -503,15 +491,13 @@ return ({ if: 1 }).if === 1;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -557,7 +543,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="62" class="separator"></th>
+<tr><th colspan="60" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -566,15 +552,13 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="konq49" data-tally="0.23076923076923078" style="background-color:hsl(27,75%,50%)">3/13</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">13/13</td>
 <td class="tally" data-browser="konq414" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0.15384615384615385" style="background-color:hsl(18,79%,50%)">2/13</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">13/13</td>
 <td class="tally" data-browser="ie11" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge14" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge15" data-tally="1">13/13</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">13/13</td>
 <td class="tally" data-browser="firefox45" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">13/13</td>
@@ -632,15 +616,13 @@ return typeof Object.create == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -698,15 +680,13 @@ return typeof Object.defineProperty == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="yes obsolete" data-browser="ie8">Yes<a href="#define-property-ie-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -764,15 +744,13 @@ return typeof Object.defineProperties == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -830,15 +808,13 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -896,15 +872,13 @@ return typeof Object.keys == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -962,15 +936,13 @@ return typeof Object.seal == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1028,15 +1000,13 @@ return typeof Object.freeze == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1094,15 +1064,13 @@ return typeof Object.preventExtensions == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1160,15 +1128,13 @@ return typeof Object.isSealed == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1226,15 +1192,13 @@ return typeof Object.isFrozen == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1292,15 +1256,13 @@ return typeof Object.isExtensible == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1358,15 +1320,13 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="yes obsolete" data-browser="ie8">Yes<a href="#get-own-property-descriptor-ie-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1424,15 +1384,13 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1485,15 +1443,13 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally obsolete" data-browser="konq49" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="konq414" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">12/12</td>
 <td class="tally" data-browser="ie11" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">12/12</td>
 <td class="tally" data-browser="edge14" data-tally="1">12/12</td>
 <td class="tally" data-browser="edge15" data-tally="1">12/12</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">12/12</td>
 <td class="tally" data-browser="firefox45" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">12/12</td>
@@ -1551,15 +1507,13 @@ return typeof Array.isArray == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1617,15 +1571,13 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1683,15 +1635,13 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1743,21 +1693,19 @@ return typeof Array.prototype.every == &apos;function&apos;;
 function () {
 return typeof Array.prototype.every == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1809,21 +1757,19 @@ return typeof Array.prototype.some == &apos;function&apos;;
 function () {
 return typeof Array.prototype.some == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1875,21 +1821,19 @@ return typeof Array.prototype.forEach == &apos;function&apos;;
 function () {
 return typeof Array.prototype.forEach == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1941,21 +1885,19 @@ return typeof Array.prototype.map == &apos;function&apos;;
 function () {
 return typeof Array.prototype.map == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2007,21 +1949,19 @@ return typeof Array.prototype.filter == &apos;function&apos;;
 function () {
 return typeof Array.prototype.filter == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2073,21 +2013,19 @@ return typeof Array.prototype.reduce == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduce == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2139,21 +2077,19 @@ return typeof Array.prototype.reduceRight == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduceRight == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2251,15 +2187,13 @@ return true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2327,15 +2261,13 @@ try {
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2388,15 +2320,13 @@ try {
 <td class="tally obsolete" data-browser="konq49" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">2/2</td>
 <td class="tally" data-browser="konq414" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">2/2</td>
@@ -2454,15 +2384,13 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2520,15 +2448,13 @@ return typeof String.prototype.trim == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2581,15 +2507,13 @@ return typeof String.prototype.trim == 'function';
 <td class="tally obsolete" data-browser="konq49" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">3/3</td>
@@ -2647,15 +2571,13 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2713,15 +2635,13 @@ return typeof Date.now == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2787,15 +2707,13 @@ try {
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2809,7 +2727,7 @@ try {
 <td class="yes unstable" data-browser="firefox56">Yes</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
-<td class="yes obsolete" data-browser="opera12">Yes<a href="#Date.prototype.toJSON-OP11_60-OP11_64-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="opera12">Yes<a href="#Date.prototype.toJSON-OP11_60-OP11_64-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome51">Yes</td>
 <td class="yes obsolete" data-browser="chrome52">Yes</td>
@@ -2853,15 +2771,13 @@ return typeof Function.prototype.bind == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2919,15 +2835,13 @@ return typeof JSON == 'object';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2973,7 +2887,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="62" class="separator"></th>
+<tr><th colspan="60" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -2982,15 +2896,13 @@ return typeof JSON == 'object';
 <td class="tally obsolete" data-browser="konq49" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">3/3</td>
@@ -3049,15 +2961,13 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3116,15 +3026,13 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3183,15 +3091,13 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3244,15 +3150,13 @@ return result;
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="ie11" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge14" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge15" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">8/8</td>
 <td class="tally" data-browser="firefox45" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">8/8</td>
@@ -3310,15 +3214,13 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3376,15 +3278,13 @@ return parseInt('010') === 10;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3440,15 +3340,13 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3504,15 +3402,13 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3569,15 +3465,13 @@ return _\u200c\u200d;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3635,15 +3529,13 @@ return true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3707,15 +3599,13 @@ return result;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3777,15 +3667,13 @@ catch(e) {
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3838,15 +3726,13 @@ catch(e) {
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0">0/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">19/19</td>
 <td class="tally" data-browser="ie11" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">19/19</td>
 <td class="tally" data-browser="edge14" data-tally="1">19/19</td>
 <td class="tally" data-browser="edge15" data-tally="1">19/19</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">19/19</td>
 <td class="tally" data-browser="firefox45" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">19/19</td>
@@ -3907,15 +3793,13 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3972,15 +3856,13 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="edge12">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="edge12">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4039,15 +3921,13 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4120,15 +4000,13 @@ return test(String, &apos;&apos;)
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4187,15 +4065,13 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4252,15 +4128,13 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4321,15 +4195,13 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4390,15 +4262,13 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4461,15 +4331,13 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4529,15 +4397,13 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4595,15 +4461,13 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4662,15 +4526,13 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4733,15 +4595,13 @@ return (function(x){
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4798,15 +4658,13 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4863,15 +4721,13 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4928,15 +4784,13 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4993,15 +4847,13 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5058,15 +4910,13 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5123,15 +4973,13 @@ return typeof foo === &apos;function&apos;;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5181,7 +5029,7 @@ return typeof foo === &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="khtml-note">  <sup>[2]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="edge-experimental-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p><p id="define-property-ie-note">  <sup>[4]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="get-own-property-descriptor-ie-note">  <sup>[5]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="sparse_arrays-note">  <sup>[6]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[7]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="strict-mode-ie10-note">  <sup>[8]</sup> IE10 PP2 fails this test.</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="khtml-note">  <sup>[2]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="sparse_arrays-note">  <sup>[3]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[4]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="strict-mode-ie10-note">  <sup>[5]</sup> IE10 PP2 fails this test.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/es5/index.html
+++ b/es5/index.html
@@ -116,6 +116,9 @@
 <th class="platform konq49 desktop obsolete" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></a></th>
 <th class="platform konq413 desktop obsolete" data-browser="konq413"><a href="#konq413" class="browser-name"><abbr title="Konqueror 4.13">Konq 4.13</abbr></a></th>
 <th class="platform konq414 desktop" data-browser="konq414"><a href="#konq414" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr></a><a href="#khtml-note"><sup>[2]</sup></a></th>
+<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
+<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
+<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
@@ -179,6 +182,9 @@
 <td class="tally obsolete" data-browser="konq49" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="konq414" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">5/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
@@ -241,6 +247,9 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -305,6 +314,9 @@ return value === 1;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -367,6 +379,9 @@ return { a: true, }.a === true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -429,6 +444,9 @@ return [1,].length === 1;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -491,6 +509,9 @@ return ({ if: 1 }).if === 1;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -543,7 +564,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="60" class="separator"></th>
+<tr><th colspan="63" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -552,6 +573,9 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="konq49" data-tally="0.23076923076923078" style="background-color:hsl(27,75%,50%)">3/13</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">13/13</td>
 <td class="tally" data-browser="konq414" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/13</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0.15384615384615385" style="background-color:hsl(18,79%,50%)">2/13</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">13/13</td>
 <td class="tally" data-browser="ie11" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">13/13</td>
@@ -616,6 +640,9 @@ return typeof Object.create == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -680,6 +707,9 @@ return typeof Object.defineProperty == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="yes obsolete" data-browser="ie8">Yes<a href="#define-property-ie-note"><sup>[3]</sup></a></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -744,6 +774,9 @@ return typeof Object.defineProperties == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -808,6 +841,9 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -872,6 +908,9 @@ return typeof Object.keys == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -936,6 +975,9 @@ return typeof Object.seal == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1000,6 +1042,9 @@ return typeof Object.freeze == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1064,6 +1109,9 @@ return typeof Object.preventExtensions == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1128,6 +1176,9 @@ return typeof Object.isSealed == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1192,6 +1243,9 @@ return typeof Object.isFrozen == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1256,6 +1310,9 @@ return typeof Object.isExtensible == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1320,6 +1377,9 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="yes obsolete" data-browser="ie8">Yes<a href="#get-own-property-descriptor-ie-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1384,6 +1444,9 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1443,6 +1506,9 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally obsolete" data-browser="konq49" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="konq414" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">12/12</td>
 <td class="tally" data-browser="ie11" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">12/12</td>
@@ -1507,6 +1573,9 @@ return typeof Array.isArray == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1571,6 +1640,9 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1635,6 +1707,9 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1693,12 +1768,15 @@ return typeof Array.prototype.every == &apos;function&apos;;
 function () {
 return typeof Array.prototype.every == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1757,12 +1835,15 @@ return typeof Array.prototype.some == &apos;function&apos;;
 function () {
 return typeof Array.prototype.some == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1821,12 +1902,15 @@ return typeof Array.prototype.forEach == &apos;function&apos;;
 function () {
 return typeof Array.prototype.forEach == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1885,12 +1969,15 @@ return typeof Array.prototype.map == &apos;function&apos;;
 function () {
 return typeof Array.prototype.map == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1949,12 +2036,15 @@ return typeof Array.prototype.filter == &apos;function&apos;;
 function () {
 return typeof Array.prototype.filter == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2013,12 +2103,15 @@ return typeof Array.prototype.reduce == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduce == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2077,12 +2170,15 @@ return typeof Array.prototype.reduceRight == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduceRight == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2187,6 +2283,9 @@ return true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2261,6 +2360,9 @@ try {
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2320,6 +2422,9 @@ try {
 <td class="tally obsolete" data-browser="konq49" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">2/2</td>
 <td class="tally" data-browser="konq414" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
@@ -2384,6 +2489,9 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2448,6 +2556,9 @@ return typeof String.prototype.trim == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2507,6 +2618,9 @@ return typeof String.prototype.trim == 'function';
 <td class="tally obsolete" data-browser="konq49" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
@@ -2571,6 +2685,9 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2635,6 +2752,9 @@ return typeof Date.now == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2707,6 +2827,9 @@ try {
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2727,7 +2850,7 @@ try {
 <td class="yes unstable" data-browser="firefox56">Yes</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
-<td class="yes obsolete" data-browser="opera12">Yes<a href="#Date.prototype.toJSON-OP11_60-OP11_64-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="opera12">Yes<a href="#Date.prototype.toJSON-OP11_60-OP11_64-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome51">Yes</td>
 <td class="yes obsolete" data-browser="chrome52">Yes</td>
@@ -2771,6 +2894,9 @@ return typeof Function.prototype.bind == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2835,6 +2961,9 @@ return typeof JSON == 'object';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2887,7 +3016,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="60" class="separator"></th>
+<tr><th colspan="63" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -2896,6 +3025,9 @@ return typeof JSON == 'object';
 <td class="tally obsolete" data-browser="konq49" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
@@ -2961,6 +3093,9 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3026,6 +3161,9 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3091,6 +3229,9 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3150,6 +3291,9 @@ return result;
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="ie11" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -3214,6 +3358,9 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie7">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3278,6 +3425,9 @@ return parseInt('010') === 10;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3340,6 +3490,9 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie7">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3402,6 +3555,9 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie7">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3465,6 +3621,9 @@ return _\u200c\u200d;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3529,6 +3688,9 @@ return true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie7">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3599,6 +3761,9 @@ return result;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie7">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3667,6 +3832,9 @@ catch(e) {
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie7">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3726,6 +3894,9 @@ catch(e) {
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0">0/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">19/19</td>
 <td class="tally" data-browser="ie11" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">19/19</td>
@@ -3793,6 +3964,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3856,13 +4030,16 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="edge12">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes unstable" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="edge12">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3921,6 +4098,9 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4000,6 +4180,9 @@ return test(String, &apos;&apos;)
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4065,6 +4248,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4128,6 +4314,9 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4195,6 +4384,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4262,6 +4454,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4331,6 +4526,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4397,6 +4595,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4461,6 +4662,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4526,6 +4730,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4595,6 +4802,9 @@ return (function(x){
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4658,6 +4868,9 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4721,6 +4934,9 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4784,6 +5000,9 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4847,6 +5066,9 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4910,6 +5132,9 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4973,6 +5198,9 @@ return typeof foo === &apos;function&apos;;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5029,7 +5257,7 @@ return typeof foo === &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="khtml-note">  <sup>[2]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="sparse_arrays-note">  <sup>[3]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[4]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="strict-mode-ie10-note">  <sup>[5]</sup> IE10 PP2 fails this test.</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="khtml-note">  <sup>[2]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="define-property-ie-note">  <sup>[3]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="get-own-property-descriptor-ie-note">  <sup>[4]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="sparse_arrays-note">  <sup>[5]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[6]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="strict-mode-ie10-note">  <sup>[7]</sup> IE10 PP2 fails this test.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/es6/index.html
+++ b/es6/index.html
@@ -149,15 +149,13 @@
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es6shim compiler" data-browser="es6shim"><a href="#es6shim" class="browser-name"><abbr title="es6-shim">es6-shim</abbr></a></th>
 <th class="platform konq414 desktop" data-browser="konq414"><a href="#konq414" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr></a><a href="#khtml-note"><sup>[3]</sup></a></th>
-<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
-<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
-<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[4]</sup></a></th>
-<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[4]</sup></a></th>
-<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[4]</sup></a></th>
-<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[4]</sup></a></th>
+<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
+<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
+<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a></th>
+<th class="platform edge16 desktop unstable" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16 Preview</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox47 desktop obsolete" data-browser="firefox47"><a href="#firefox47" class="browser-name"><abbr title="Firefox">FF 47</abbr></a></th>
 <th class="platform firefox48 desktop obsolete" data-browser="firefox48"><a href="#firefox48" class="browser-name"><abbr title="Firefox">FF 48</abbr></a></th>
@@ -194,15 +192,15 @@
 <th class="platform ejs engine unstable" data-browser="ejs"><a href="#ejs" class="browser-name"><abbr title="Echo JS">Echo JS</abbr></a></th>
 <th class="platform xs6 engine" data-browser="xs6"><a href="#xs6" class="browser-name"><abbr title="Kinoma XS6">XS6</abbr></a></th>
 <th class="platform jxa engine" data-browser="jxa"><a href="#jxa" class="browser-name"><abbr title="JavaScript Automation for OS X">JXA</abbr></a></th>
-<th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
-<th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
-<th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
-<th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
-<th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
-<th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
-<th class="platform node6_5 engine" data-browser="node6_5"><a href="#node6_5" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
-<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
-<th class="platform node7_6 engine" data-browser="node7_6"><a href="#node7_6" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
+<th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node6_5 engine" data-browser="node6_5"><a href="#node6_5" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node7_6 engine" data-browser="node7_6"><a href="#node7_6" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform duktape2_0 engine" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -215,7 +213,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="71">Optimisation</td>
+      <tr class="category"><td colspan="69">Optimisation</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#test-proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/2</td>
@@ -226,15 +224,13 @@
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge15" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/2</td>
@@ -299,22 +295,20 @@ return (function f(n){
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
-<td class="no flagged" data-browser="tr">Flag<a href="#tr-tco-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="tr">Flag<a href="#tr-tco-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -386,22 +380,20 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
-<td class="no flagged" data-browser="tr">Flag<a href="#tr-tco-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="tr">Flag<a href="#tr-tco-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -455,7 +447,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="71">Syntax</td>
+<tr class="category"><td colspan="69">Syntax</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-default_function_parameters"><span><a class="anchor" href="#test-default_function_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">default function parameters</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -466,15 +458,13 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally" data-browser="typescript" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/7</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.8571428571428571">0/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="1">0/7</td>
 <td class="tally" data-browser="edge14" data-tally="1">7/7</td>
 <td class="tally" data-browser="edge15" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">7/7</td>
 <td class="tally" data-browser="firefox45" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -540,15 +530,13 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -614,15 +602,13 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -688,15 +674,13 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -769,15 +753,13 @@ return (function (a = &quot;baz&quot;, b = &quot;qux&quot;, c = &quot;quux&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -853,15 +835,13 @@ return (function(x = 1) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -932,15 +912,13 @@ return (function(a=function(){
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1005,18 +983,16 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1079,15 +1055,13 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">5/5</td>
@@ -1155,15 +1129,13 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1229,15 +1201,13 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1311,15 +1281,13 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1391,15 +1359,13 @@ return (function (...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1467,15 +1433,13 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1538,15 +1502,13 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.26666666666666666" style="background-color:hsl(32,74%,50%)">4/15</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/15</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="0.9333333333333333">12/15</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">15/15</td>
 <td class="tally" data-browser="edge14" data-tally="1">15/15</td>
 <td class="tally" data-browser="edge15" data-tally="1">15/15</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">15/15</td>
 <td class="tally" data-browser="firefox45" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">15/15</td>
@@ -1612,15 +1574,13 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1686,15 +1646,13 @@ return [...[1, 2, 3]][2] === 3;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1761,15 +1719,13 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1836,15 +1792,13 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1910,15 +1864,13 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1984,15 +1936,13 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2058,15 +2008,13 @@ return Array(...&quot;&#x20BB7;&#x20BB6;&quot;)[0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2132,15 +2080,13 @@ return [...&quot;&#x20BB7;&#x20BB6;&quot;][0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2207,15 +2153,13 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2282,15 +2226,13 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2349,7 +2291,7 @@ var iterable = global.__createIterableObject([1, 2, 3]);
 return Math.max(...iterable) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([1, 2, 3]);\nreturn Math.max(...iterable) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nvar iterable = global.__createIterableObject([1, 2, 3]);\nreturn Math.max(...iterable) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
@@ -2357,15 +2299,13 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2424,7 +2364,7 @@ var iterable = global.__createIterableObject([&quot;b&quot;, &quot;c&quot;, &quo
 return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([\"b\", \"c\", \"d\"]);\nreturn [\"a\", ...iterable, \"e\"][3] === \"d\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\nvar iterable = global.__createIterableObject([\"b\", \"c\", \"d\"]);\nreturn [\"a\", ...iterable, \"e\"][3] === \"d\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
@@ -2432,15 +2372,13 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2499,7 +2437,7 @@ var iterable = global.__createIterableObject([1, 2, 3]);
 return Math.max(...Object.create(iterable)) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([1, 2, 3]);\nreturn Math.max(...Object.create(iterable)) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nvar iterable = global.__createIterableObject([1, 2, 3]);\nreturn Math.max(...Object.create(iterable)) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
@@ -2507,15 +2445,13 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2574,7 +2510,7 @@ var iterable = global.__createIterableObject([&quot;b&quot;, &quot;c&quot;, &quo
 return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([\"b\", \"c\", \"d\"]);\nreturn [\"a\", ...Object.create(iterable), \"e\"][3] === \"d\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nvar iterable = global.__createIterableObject([\"b\", \"c\", \"d\"]);\nreturn [\"a\", ...Object.create(iterable), \"e\"][3] === \"d\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
@@ -2582,15 +2518,13 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2660,15 +2594,13 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2731,15 +2663,13 @@ try {
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge15" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox45" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">6/6</td>
@@ -2806,15 +2736,13 @@ return ({ [x]: 1 }).y === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2881,15 +2809,13 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2955,26 +2881,24 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
-<td class="yes" data-browser="firefox45">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox47">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox48">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox49">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox51">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="firefox52">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox53">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="firefox54">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes unstable" data-browser="firefox55">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
-<td class="yes unstable" data-browser="firefox56">Yes<a href="#ff-shorthand-methods-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
+<td class="yes" data-browser="firefox45">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox47">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox48">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox49">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox50">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox51">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox53">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="firefox54">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes unstable" data-browser="firefox55">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
+<td class="yes unstable" data-browser="firefox56">Yes<a href="#ff-shorthand-methods-note"><sup>[8]</sup></a></td>
 <td class="no obsolete" data-browser="opera12">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome51">Yes</td>
@@ -3029,15 +2953,13 @@ return ({ &quot;foo bar&quot;() { return 4; } })[&quot;foo bar&quot;]() === 4;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3104,15 +3026,13 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3185,15 +3105,13 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3256,15 +3174,13 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/9</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/9</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.7777777777777778">6/9</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally" data-browser="edge14" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally" data-browser="edge15" data-tally="1">9/9</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">9/9</td>
 <td class="tally" data-browser="firefox45" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
@@ -3332,15 +3248,13 @@ for (var item of arr)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3410,15 +3324,13 @@ return count === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3487,15 +3399,13 @@ return str === &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3564,15 +3474,13 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3643,15 +3551,13 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3714,7 +3620,7 @@ for (var item of iterable) {
 return result === &quot;123&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\nvar result = \"\";\nvar iterable = global.__createIterableObject([1, 2, 3]);\nfor (var item of iterable) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\nvar result = \"\";\nvar iterable = global.__createIterableObject([1, 2, 3]);\nfor (var item of iterable) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
@@ -3722,15 +3628,13 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3793,7 +3697,7 @@ for (var item of Object.create(iterable)) {
 return result === &quot;123&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\nvar result = \"\";\nvar iterable = global.__createIterableObject([1, 2, 3]);\nfor (var item of Object.create(iterable)) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\nvar result = \"\";\nvar iterable = global.__createIterableObject([1, 2, 3]);\nfor (var item of Object.create(iterable)) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
@@ -3801,15 +3705,13 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3880,15 +3782,13 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -3961,15 +3861,13 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4032,15 +3930,13 @@ return closed;
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">4/4</td>
@@ -4106,15 +4002,13 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4180,15 +4074,13 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4251,18 +4143,16 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4325,18 +4215,16 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4399,15 +4287,13 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">5/5</td>
@@ -4475,15 +4361,13 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4553,15 +4437,13 @@ return `${a}` === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4638,15 +4520,13 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4714,15 +4594,13 @@ return (function(parts) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4793,15 +4671,13 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4864,15 +4740,13 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.4" style="background-color:hsl(48,68%,50%)" data-flagged-tally="0.8">2/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox45" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">5/5</td>
@@ -4937,18 +4811,16 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5014,18 +4886,16 @@ return result === &apos;yy&apos; &amp;&amp; re.lastIndex === 5;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5088,18 +4958,16 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5162,18 +5030,16 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5236,18 +5102,16 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5310,15 +5174,13 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="tally" data-browser="typescript" data-tally="0.6818181818181818" style="background-color:hsl(81,56%,50%)">15/22</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/22</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/22</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/22</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/22</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/22</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.9090909090909091">0/22</td>
 <td class="tally" data-browser="edge14" data-tally="0.9545454545454546" style="background-color:hsl(114,44%,50%)">21/22</td>
 <td class="tally" data-browser="edge15" data-tally="1">22/22</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">22/22</td>
 <td class="tally" data-browser="firefox45" data-tally="0.8636363636363636" style="background-color:hsl(103,48%,50%)">19/22</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.9545454545454546" style="background-color:hsl(114,44%,50%)">21/22</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.9545454545454546" style="background-color:hsl(114,44%,50%)">21/22</td>
@@ -5385,15 +5247,13 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5460,15 +5320,13 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5535,15 +5393,13 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5610,15 +5466,13 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5685,15 +5539,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5760,15 +5612,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5835,15 +5685,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5914,15 +5762,13 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5989,15 +5835,13 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6064,15 +5908,13 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6141,15 +5983,13 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6216,15 +6056,13 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6304,15 +6142,13 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6380,15 +6216,13 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6455,15 +6289,13 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6532,15 +6364,13 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6608,15 +6438,13 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6684,15 +6512,13 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6766,15 +6592,13 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6843,15 +6667,13 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -6920,15 +6742,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7003,15 +6823,13 @@ return a === 1 &amp;&amp; b === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7074,15 +6892,13 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally" data-browser="typescript" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.9583333333333334">0/24</td>
 <td class="tally" data-browser="edge14" data-tally="0.9583333333333334" style="background-color:hsl(115,43%,50%)">23/24</td>
 <td class="tally" data-browser="edge15" data-tally="1">24/24</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">24/24</td>
 <td class="tally" data-browser="firefox45" data-tally="0.875" style="background-color:hsl(105,47%,50%)">21/24</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.9583333333333334" style="background-color:hsl(115,43%,50%)">23/24</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.9583333333333334" style="background-color:hsl(115,43%,50%)">23/24</td>
@@ -7150,15 +6966,13 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7226,15 +7040,13 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7302,15 +7114,13 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7378,15 +7188,13 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7454,15 +7262,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7530,15 +7336,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7606,15 +7410,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7686,15 +7488,13 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -7761,15 +7561,13 @@ return ([a, b] = iterable) === iterable;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7837,15 +7635,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7913,15 +7709,13 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -7989,15 +7783,13 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8067,15 +7859,13 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8143,15 +7933,13 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8218,15 +8006,13 @@ return ({a,b} = obj) === obj;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8299,15 +8085,13 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8375,15 +8159,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8464,15 +8246,13 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8540,15 +8320,13 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8618,15 +8396,13 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8696,15 +8472,13 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8772,15 +8546,13 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8848,15 +8620,13 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8926,15 +8696,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -8997,15 +8765,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally" data-browser="typescript" data-tally="0.6521739130434783" style="background-color:hsl(78,57%,50%)">15/23</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/23</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/23</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/23</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/23</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/23</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.9565217391304348">0/23</td>
 <td class="tally" data-browser="edge14" data-tally="0.9565217391304348" style="background-color:hsl(114,43%,50%)">22/23</td>
 <td class="tally" data-browser="edge15" data-tally="1">23/23</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">23/23</td>
 <td class="tally" data-browser="firefox45" data-tally="0.782608695652174" style="background-color:hsl(93,51%,50%)">18/23</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.8260869565217391" style="background-color:hsl(99,49%,50%)">19/23</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.8260869565217391" style="background-color:hsl(99,49%,50%)">19/23</td>
@@ -9073,15 +8839,13 @@ return function([a, , [b], c]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9149,15 +8913,13 @@ return function([a, , b]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9225,15 +8987,13 @@ return function([a, b, c]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9301,15 +9061,13 @@ return function([c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9377,15 +9135,13 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9453,15 +9209,13 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9529,15 +9283,13 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9608,15 +9360,13 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -9684,15 +9434,13 @@ return function([a,]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9760,15 +9508,13 @@ return function({c, x:d, e}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9837,15 +9583,13 @@ return function({toFixed}, {slice}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9913,15 +9657,13 @@ return function({a,}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -9995,15 +9737,13 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -10072,15 +9812,13 @@ return function({ [qux]: grault }) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -10149,15 +9887,13 @@ return function([e, {x:f, g}], {h, x:[i]}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -10226,15 +9962,13 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -10300,18 +10034,16 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -10377,15 +10109,13 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -10454,15 +10184,13 @@ return function([a, ...b], [c, ...d]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -10530,15 +10258,13 @@ return function ([],{}){
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -10608,15 +10334,13 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5},
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -10687,15 +10411,13 @@ return (function({a=function(){
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -10760,18 +10482,16 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -10834,15 +10554,13 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -10908,15 +10626,13 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -10983,15 +10699,13 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -11054,15 +10768,13 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">2/2</td>
@@ -11135,15 +10847,13 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -11218,15 +10928,13 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -11280,7 +10988,7 @@ try {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="71">Bindings</td>
+<tr class="category"><td colspan="69">Bindings</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-const"><span><a class="anchor" href="#test-const">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">const</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
@@ -11291,15 +10999,13 @@ try {
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/16</td>
 <td class="tally" data-browser="konq414" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally" data-browser="edge14" data-tally="1">16/16</td>
 <td class="tally" data-browser="edge15" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">16/16</td>
 <td class="tally" data-browser="firefox45" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
@@ -11366,15 +11072,13 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -11442,15 +11146,13 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -11521,15 +11223,13 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -11600,15 +11300,13 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -11676,15 +11374,13 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -11754,15 +11450,13 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -11832,15 +11526,13 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -11910,15 +11602,13 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -11986,15 +11676,13 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12063,15 +11751,13 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12143,15 +11829,13 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12223,15 +11907,13 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12300,15 +11982,13 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12379,15 +12059,13 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -12458,15 +12136,13 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -12537,15 +12213,13 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12608,15 +12282,13 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="edge14" data-tally="1">12/12</td>
 <td class="tally" data-browser="edge15" data-tally="1">12/12</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">12/12</td>
 <td class="tally" data-browser="firefox45" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
@@ -12683,15 +12355,13 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12759,15 +12429,13 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12838,15 +12506,13 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12914,15 +12580,13 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -12992,15 +12656,13 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -13077,15 +12739,13 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -13153,15 +12813,13 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -13230,15 +12888,13 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -13310,15 +12966,13 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -13387,15 +13041,13 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -13466,15 +13118,13 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -13552,15 +13202,13 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -13614,7 +13262,7 @@ return passed;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr significance="0.25"><td id="test-block-level_function_declaration"><span><a class="anchor" href="#test-block-level_function_declaration">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[11]</sup></a></span><script data-source="
+<tr significance="0.25"><td id="test-block-level_function_declaration"><span><a class="anchor" href="#test-block-level_function_declaration">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[10]</sup></a></span><script data-source="
 &apos;use strict&apos;;
 if (f() !== 1) return false;
 function f() { return 1; }
@@ -13635,15 +13283,13 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -13697,7 +13343,7 @@ return true;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="71">Functions</td>
+<tr class="category"><td colspan="69">Functions</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-arrow_functions"><span><a class="anchor" href="#test-arrow_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions">arrow functions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
@@ -13708,15 +13354,13 @@ return true;
 <td class="tally" data-browser="typescript" data-tally="0.6923076923076923" style="background-color:hsl(83,55%,50%)">9/13</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/13</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/13</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)" data-flagged-tally="0.7692307692307693">8/13</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge14" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge15" data-tally="1">13/13</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">13/13</td>
 <td class="tally" data-browser="firefox45" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">13/13</td>
@@ -13782,15 +13426,13 @@ return (() =&gt; 5)() === 5;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -13857,15 +13499,13 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -13932,15 +13572,13 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14008,15 +13646,13 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14084,15 +13720,13 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14160,15 +13794,13 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14235,15 +13867,13 @@ return f(6) === 5;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14311,15 +13941,13 @@ return (() =&gt; {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14387,15 +14015,13 @@ return (() =&gt; {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14462,15 +14088,13 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14549,15 +14173,13 @@ return new C instanceof C &amp;&amp; received === &apos;foo&apos;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14634,15 +14256,13 @@ return arrow() === &quot;quux&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14711,15 +14331,13 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14782,15 +14400,13 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="tally" data-browser="typescript" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.875">0/24</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">24/24</td>
 <td class="tally" data-browser="edge14" data-tally="1">24/24</td>
 <td class="tally" data-browser="edge15" data-tally="1">24/24</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">24/24</td>
 <td class="tally" data-browser="firefox45" data-tally="1">24/24</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">24/24</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">24/24</td>
@@ -14857,15 +14473,13 @@ return typeof C === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -14937,15 +14551,13 @@ return C === c1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15011,15 +14623,13 @@ return typeof class C {} === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15085,15 +14695,13 @@ return typeof class {} === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15163,15 +14771,13 @@ return C.prototype.constructor === C
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15241,15 +14847,13 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15319,15 +14923,13 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15398,15 +15000,13 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15480,15 +15080,13 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15558,15 +15156,13 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15637,15 +15233,13 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15717,15 +15311,13 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15797,15 +15389,13 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15877,15 +15467,13 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -15957,15 +15545,13 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16036,15 +15622,13 @@ return C === undefined &amp;&amp; M();
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16116,15 +15700,13 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16194,15 +15776,13 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16271,15 +15851,13 @@ return (0,C.method)();
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16351,15 +15929,13 @@ catch(e) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16420,23 +15996,21 @@ return new C() instanceof B
   &amp;&amp; B.isPrototypeOf(C);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("211");try{return Function("asyncTestPassed","\nclass B {}\nclass C extends B {}\nreturn new C() instanceof B\n  && B.isPrototypeOf(C);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("211");return Function("asyncTestPassed","'use strict';"+"\nclass B {}\nclass C extends B {}\nreturn new C() instanceof B\n  && B.isPrototypeOf(C);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[13]</sup></a></td>
-<td class="no obsolete" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[13]</sup></a></td>
-<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[12]</sup></a></td>
+<td class="no obsolete" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16497,23 +16071,21 @@ return new C() instanceof B
   &amp;&amp; B.isPrototypeOf(C);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("212");try{return Function("asyncTestPassed","\nvar B;\nclass C extends (B = class {}) {}\nreturn new C() instanceof B\n  && B.isPrototypeOf(C);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("212");return Function("asyncTestPassed","'use strict';"+"\nvar B;\nclass C extends (B = class {}) {}\nreturn new C() instanceof B\n  && B.isPrototypeOf(C);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[13]</sup></a></td>
-<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16583,15 +16155,13 @@ return Function.prototype.isPrototypeOf(C)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16669,15 +16239,13 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16740,15 +16308,13 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.75">0/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge14" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge15" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">8/8</td>
 <td class="tally" data-browser="firefox45" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">8/8</td>
@@ -16822,15 +16388,13 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16902,15 +16466,13 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -16983,15 +16545,13 @@ return new C().quux(&quot;bar&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17063,15 +16623,13 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17145,15 +16703,13 @@ return obj.qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17227,15 +16783,13 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17311,15 +16865,13 @@ return obj.qux() === &quot;barley&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17397,15 +16949,13 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17468,15 +17018,13 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0">0/27</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/27</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/27</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/27</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/27</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/27</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.9259259259259259">0/27</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">27/27</td>
 <td class="tally" data-browser="edge14" data-tally="1">27/27</td>
 <td class="tally" data-browser="edge15" data-tally="1">27/27</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">27/27</td>
 <td class="tally" data-browser="firefox45" data-tally="0.9259259259259259" style="background-color:hsl(111,45%,50%)">25/27</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.9259259259259259" style="background-color:hsl(111,45%,50%)">25/27</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.9259259259259259" style="background-color:hsl(111,45%,50%)">25/27</td>
@@ -17546,21 +17094,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17630,21 +17176,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17714,21 +17258,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17802,15 +17344,13 @@ catch (e) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17878,21 +17418,19 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -17961,21 +17499,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18048,21 +17584,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18140,15 +17674,13 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18219,21 +17751,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18303,21 +17833,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18384,21 +17912,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18467,21 +17993,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18550,21 +18074,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18633,21 +18155,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18716,21 +18236,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18801,21 +18319,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18886,21 +18402,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -18971,21 +18485,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -19063,15 +18575,13 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -19147,21 +18657,19 @@ return closed === &apos;ab&apos;;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -19236,21 +18744,19 @@ return closed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -19322,21 +18828,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -19408,21 +18912,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -19495,21 +18997,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -19581,21 +19081,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -19668,21 +19166,19 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -19751,21 +19247,19 @@ try {
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -19819,7 +19313,7 @@ try {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="71">Built-ins</td>
+<tr class="category"><td colspan="69">Built-ins</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-typed_arrays"><span><a class="anchor" href="#test-typed_arrays">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects">typed arrays</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/46</td>
@@ -19830,15 +19324,13 @@ try {
 <td class="tally" data-browser="typescript" data-tally="0.9782608695652174" style="background-color:hsl(117,42%,50%)">45/46</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/46</td>
 <td class="tally" data-browser="konq414" data-tally="0.17391304347826086" style="background-color:hsl(20,78%,50%)">8/46</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/46</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/46</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/46</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally" data-browser="ie11" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9130434782608695" style="background-color:hsl(109,45%,50%)">42/46</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9565217391304348" style="background-color:hsl(114,43%,50%)">44/46</td>
 <td class="tally" data-browser="edge14" data-tally="1">46/46</td>
 <td class="tally" data-browser="edge15" data-tally="1">46/46</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">46/46</td>
 <td class="tally" data-browser="firefox45" data-tally="0.9130434782608695" style="background-color:hsl(109,45%,50%)">42/46</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.9347826086956522" style="background-color:hsl(112,44%,50%)">43/46</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.9782608695652174" style="background-color:hsl(117,42%,50%)">45/46</td>
@@ -19903,18 +19395,16 @@ return view[0] === -0x80;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -19979,18 +19469,16 @@ return view[0] === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20055,18 +19543,16 @@ return view[0] === 0xFF;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20131,18 +19617,16 @@ return view[0] === -0x8000;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20207,18 +19691,16 @@ return view[0] === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20283,18 +19765,16 @@ return view[0] === -0x80000000;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20359,18 +19839,16 @@ return view[0] === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20435,18 +19913,16 @@ return view[0] === 0.10000000149011612;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20511,18 +19987,16 @@ return view[0] === 0.1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20588,18 +20062,16 @@ return view.getInt8(0) === -0x80;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20665,18 +20137,16 @@ return view.getUint8(0) === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20742,18 +20212,16 @@ return view.getInt16(0) === -0x8000;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20819,18 +20287,16 @@ return view.getUint16(0) === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20896,18 +20362,16 @@ return view.getInt32(0) === -0x80000000;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -20973,18 +20437,16 @@ return view.getUint32(0) === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21050,18 +20512,16 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21127,18 +20587,16 @@ return view.getFloat64(0) === 0.1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21201,18 +20659,16 @@ return typeof ArrayBuffer[Symbol.species] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21298,18 +20754,16 @@ return constructors.every(function (constructor) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21387,18 +20841,16 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -21487,15 +20939,13 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21566,18 +21016,16 @@ typeof Float64Array.from === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21648,18 +21096,16 @@ typeof Float64Array.of === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21730,18 +21176,16 @@ typeof Float64Array.prototype.subarray === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21812,18 +21256,16 @@ typeof Float64Array.prototype.join === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21894,18 +21336,16 @@ typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -21976,18 +21416,16 @@ typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22058,18 +21496,16 @@ typeof Float64Array.prototype.slice === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22140,18 +21576,16 @@ typeof Float64Array.prototype.every === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22222,18 +21656,16 @@ typeof Float64Array.prototype.filter === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22304,18 +21736,16 @@ typeof Float64Array.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22386,18 +21816,16 @@ typeof Float64Array.prototype.map === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22468,18 +21896,16 @@ typeof Float64Array.prototype.reduce === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22550,18 +21976,16 @@ typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22632,18 +22056,16 @@ typeof Float64Array.prototype.reverse === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22714,18 +22136,16 @@ typeof Float64Array.prototype.some === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22796,18 +22216,16 @@ typeof Float64Array.prototype.sort === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22878,18 +22296,16 @@ typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -22960,18 +22376,16 @@ typeof Float64Array.prototype.find === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23042,18 +22456,16 @@ typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23124,18 +22536,16 @@ typeof Float64Array.prototype.fill === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23206,18 +22616,16 @@ typeof Float64Array.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23288,18 +22696,16 @@ typeof Float64Array.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23370,18 +22776,16 @@ typeof Float64Array.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23452,18 +22856,16 @@ typeof Float64Array.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23534,18 +22936,16 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23608,15 +23008,13 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally" data-browser="typescript" data-tally="1">19/19</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally" data-browser="edge14" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally" data-browser="edge15" data-tally="1">19/19</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">19/19</td>
 <td class="tally" data-browser="firefox45" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
@@ -23684,18 +23082,16 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23763,18 +23159,16 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23843,18 +23237,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -23918,18 +23310,16 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24002,18 +23392,16 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24083,18 +23471,16 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -24158,18 +23544,16 @@ return map.set(0, 0) === map;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24238,18 +23622,16 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24317,18 +23699,16 @@ return map.size === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24391,18 +23771,16 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24465,18 +23843,16 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24539,18 +23915,16 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24613,18 +23987,16 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24687,18 +24059,16 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24761,18 +24131,16 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24835,18 +24203,16 @@ return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -24916,18 +24282,16 @@ catch(e) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25000,18 +24364,16 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25075,18 +24437,16 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25149,15 +24509,13 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally" data-browser="typescript" data-tally="1">19/19</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally" data-browser="edge14" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally" data-browser="edge15" data-tally="1">19/19</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">19/19</td>
 <td class="tally" data-browser="firefox45" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
@@ -25226,18 +24584,16 @@ return set.has(123);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25304,18 +24660,16 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25384,18 +24738,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25459,18 +24811,16 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25543,18 +24893,16 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25627,18 +24975,16 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -25702,18 +25048,16 @@ return set.add(0) === set;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25782,18 +25126,16 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25863,18 +25205,16 @@ return set.size === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -25937,18 +25277,16 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26011,18 +25349,16 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26085,18 +25421,16 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26159,18 +25493,16 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26233,18 +25565,16 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26307,18 +25637,16 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26381,18 +25709,16 @@ return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26462,18 +25788,16 @@ catch(e) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26546,18 +25870,16 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26621,18 +25943,16 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26695,15 +26015,13 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally" data-browser="typescript" data-tally="1">12/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">6/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="edge14" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="edge15" data-tally="1">12/12</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">12/12</td>
 <td class="tally" data-browser="firefox45" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
@@ -26771,18 +26089,16 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26850,18 +26166,16 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -26930,18 +26244,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27005,18 +26317,16 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27089,18 +26399,16 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27166,18 +26474,16 @@ return m.get(f) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27247,18 +26553,16 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -27323,18 +26627,16 @@ return weakmap.set(key, 0) === weakmap;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27397,18 +26699,16 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27478,18 +26778,16 @@ return m.has(key);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27555,18 +26853,16 @@ return m.has(1) === false
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27636,18 +26932,16 @@ catch(e) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27710,15 +27004,13 @@ catch(e) {
 <td class="tally" data-browser="typescript" data-tally="1">11/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally" data-browser="edge14" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally" data-browser="edge15" data-tally="1">11/11</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">11/11</td>
 <td class="tally" data-browser="firefox45" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
@@ -27787,18 +27079,16 @@ return weakset.has(obj1);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27864,18 +27154,16 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -27944,18 +27232,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28019,18 +27305,16 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28103,18 +27387,16 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28184,18 +27466,16 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -28260,18 +27540,16 @@ return weakset.add(obj) === weakset;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28334,18 +27612,16 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28415,18 +27691,16 @@ return s.has(key);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28491,18 +27765,16 @@ return s.has(1) === false
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28572,18 +27844,16 @@ catch(e) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28637,7 +27907,7 @@ catch(e) {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="supertest" significance="1"><td id="test-Proxy"><span><a class="anchor" href="#test-Proxy">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-enumerate-note"><sup>[16]</sup></a></span></td>
+<tr class="supertest" significance="1"><td id="test-Proxy"><span><a class="anchor" href="#test-Proxy">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-enumerate-note"><sup>[15]</sup></a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/34</td>
 <td class="tally" data-browser="tr" data-tally="0">0/34</td>
 <td class="tally" data-browser="babel" data-tally="0">0/34</td>
@@ -28646,15 +27916,13 @@ catch(e) {
 <td class="tally" data-browser="typescript" data-tally="0">0/34</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/34</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/34</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/34</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/34</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/34</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/34</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/34</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">34/34</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">34/34</td>
 <td class="tally" data-browser="edge14" data-tally="1">34/34</td>
 <td class="tally" data-browser="edge15" data-tally="1">34/34</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">34/34</td>
 <td class="tally" data-browser="firefox45" data-tally="0.8823529411764706" style="background-color:hsl(105,47%,50%)">30/34</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.8823529411764706" style="background-color:hsl(105,47%,50%)">30/34</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.8823529411764706" style="background-color:hsl(105,47%,50%)">30/34</td>
@@ -28723,18 +27991,16 @@ try {
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28798,18 +28064,16 @@ return !Proxy.hasOwnProperty(&apos;prototype&apos;);
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28878,18 +28142,16 @@ return proxy.foo === 5;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -28958,18 +28220,16 @@ return proxy.foo === 5;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29059,18 +28319,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29141,18 +28399,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29223,18 +28479,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29324,18 +28578,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29405,18 +28657,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29486,18 +28736,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29584,18 +28832,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29665,18 +28911,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29754,18 +28998,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29841,18 +29083,16 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -29965,18 +29205,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -30051,18 +29289,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -30153,18 +29389,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -30234,18 +29468,16 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -30321,18 +29553,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -30407,18 +29637,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -30496,18 +29724,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -30579,18 +29805,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -30674,18 +29898,16 @@ return true;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -30758,18 +29980,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -30845,18 +30065,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -30928,18 +30146,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31032,18 +30248,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31116,18 +30330,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31203,18 +30415,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31285,18 +30495,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31382,18 +30590,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31464,18 +30670,16 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31538,18 +30742,16 @@ return Array.isArray(new Proxy([], {}));
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31612,18 +30814,16 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31677,7 +30877,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="test-Reflect"><span><a class="anchor" href="#test-Reflect">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-reflection">Reflect</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#reflect-enumerate-note"><sup>[17]</sup></a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-Reflect"><span><a class="anchor" href="#test-Reflect">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-reflection">Reflect</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#reflect-enumerate-note"><sup>[16]</sup></a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/20</td>
 <td class="tally" data-browser="tr" data-tally="0">0/20</td>
 <td class="tally" data-browser="babel" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
@@ -31686,15 +30886,13 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="tally" data-browser="typescript" data-tally="0.9" style="background-color:hsl(108,46%,50%)">18/20</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/20</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/20</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/20</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/20</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.65" style="background-color:hsl(78,57%,50%)">13/20</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">20/20</td>
 <td class="tally" data-browser="edge14" data-tally="1">20/20</td>
 <td class="tally" data-browser="edge15" data-tally="1">20/20</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">20/20</td>
 <td class="tally" data-browser="firefox45" data-tally="1">20/20</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.95" style="background-color:hsl(114,44%,50%)">19/20</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.95" style="background-color:hsl(114,44%,50%)">19/20</td>
@@ -31757,18 +30955,16 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31833,18 +31029,16 @@ return obj.quux === 654;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31907,18 +31101,16 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -31983,18 +31175,16 @@ return !(&quot;bar&quot; in obj);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32060,18 +31250,16 @@ return desc.value === 789 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32137,18 +31325,16 @@ return obj.foo === 123 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32211,18 +31397,16 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32284,21 +31468,19 @@ return obj instanceof Array;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="closure">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="closure">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32362,18 +31544,16 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32438,18 +31618,16 @@ return !Object.isExtensible(obj);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32516,18 +31694,16 @@ return Reflect.ownKeys(obj).sort() + &apos;&apos; === &quot;A,B&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32598,18 +31774,16 @@ return keys.indexOf(s2) &gt;-1 &amp;&amp; keys.indexOf(s3) &gt;-1 &amp;&amp; key
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32672,18 +31846,16 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32748,18 +31920,16 @@ return Reflect.construct(function(a, b, c) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32826,18 +31996,16 @@ return Reflect.construct(function(a, b, c) {
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32902,18 +32070,16 @@ return obj.y === 1 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -32979,18 +32145,16 @@ return obj.length === 3 &amp;&amp; obj instanceof F;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33056,18 +32220,16 @@ return RegExp.prototype.exec.call(obj, &quot;foobarbaz&quot;)[0] === &quot;baz&q
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -33132,18 +32294,16 @@ return obj() === 2 &amp;&amp; obj instanceof F;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33225,18 +32385,16 @@ function check() {
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33299,15 +32457,13 @@ function check() {
 <td class="tally" data-browser="typescript" data-tally="1">8/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge14" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge15" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">8/8</td>
 <td class="tally" data-browser="firefox45" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">8/8</td>
@@ -33391,18 +32547,16 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33471,18 +32625,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33550,18 +32702,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33638,18 +32788,16 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33726,18 +32874,16 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33814,18 +32960,16 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33902,18 +33046,16 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -33977,18 +33119,16 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34051,15 +33191,13 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="tally" data-browser="typescript" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">8/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">2/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">12/12</td>
 <td class="tally" data-browser="edge14" data-tally="1">12/12</td>
 <td class="tally" data-browser="edge15" data-tally="1">12/12</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">12/12</td>
 <td class="tally" data-browser="firefox45" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">12/12</td>
@@ -34126,18 +33264,16 @@ return object[symbol] === value;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34200,18 +33336,16 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34286,18 +33420,16 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34369,18 +33501,16 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34448,18 +33578,16 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34535,18 +33663,16 @@ return true;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34609,18 +33735,16 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34688,18 +33812,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34769,18 +33891,16 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34846,18 +33966,16 @@ return JSON.stringify(object) === &apos;{}&apos; &amp;&amp; JSON.stringify(array
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -34933,18 +34051,16 @@ return testSymbolObject(objSym) &amp;&amp; testSymbolObject(symNoToJSON);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35009,18 +34125,16 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35074,7 +34188,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="test-well-known_symbols"><span><a class="anchor" href="#test-well-known_symbols">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols">well-known symbols</a><a href="#symbol-iterator-functionality-note"><sup>[18]</sup></a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-well-known_symbols"><span><a class="anchor" href="#test-well-known_symbols">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols">well-known symbols</a><a href="#symbol-iterator-functionality-note"><sup>[17]</sup></a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/26</td>
 <td class="tally" data-browser="tr" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
 <td class="tally" data-browser="babel" data-tally="0.5384615384615384" style="background-color:hsl(64,62%,50%)" data-flagged-tally="0.5769230769230769">14/26</td>
@@ -35083,15 +34197,13 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="0.5769230769230769" style="background-color:hsl(69,60%,50%)">15/26</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/26</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/26</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.11538461538461539" style="background-color:hsl(13,80%,50%)">3/26</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.34615384615384615" style="background-color:hsl(41,70%,50%)">9/26</td>
 <td class="tally" data-browser="edge14" data-tally="0.38461538461538464" style="background-color:hsl(46,69%,50%)" data-flagged-tally="0.7307692307692307">10/26</td>
 <td class="tally" data-browser="edge15" data-tally="0.6538461538461539" style="background-color:hsl(78,57%,50%)" data-flagged-tally="1">17/26</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0.6538461538461539" style="background-color:hsl(78,57%,50%)" data-flagged-tally="1">17/26</td>
 <td class="tally" data-browser="firefox45" data-tally="0.3076923076923077" style="background-color:hsl(36,72%,50%)">8/26</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.34615384615384615" style="background-color:hsl(41,70%,50%)">9/26</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">16/26</td>
@@ -35161,18 +34273,16 @@ return passed;
 <td class="no flagged" data-browser="babel">Flag</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -35238,18 +34348,16 @@ return a[0] === b;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35312,18 +34420,16 @@ return &quot;iterator&quot; in Symbol;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35392,15 +34498,13 @@ return (function() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35463,18 +34567,16 @@ return &quot;species&quot; in Symbol;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35545,15 +34647,13 @@ return Array.prototype.concat.call(obj, []).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35624,15 +34724,13 @@ return Array.prototype.filter.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35703,15 +34801,13 @@ return Array.prototype.map.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35782,15 +34878,13 @@ return Array.prototype.slice.call(obj, 0).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35861,15 +34955,13 @@ return Array.prototype.splice.call(obj, 0).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -35943,15 +35035,13 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -36018,18 +35108,16 @@ return promise.then(function(){}) instanceof FakePromise2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -36096,18 +35184,16 @@ return &apos;&apos;.replace(O) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -36174,18 +35260,16 @@ return &apos;&apos;.search(O) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -36252,18 +35336,16 @@ return &apos;&apos;.split(O) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -36330,18 +35412,16 @@ return &apos;&apos;.match(O) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -36408,18 +35488,16 @@ return RegExp(re) !== re &amp;&amp; RegExp(foo) === foo;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -36488,18 +35566,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -36568,18 +35644,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -36648,18 +35722,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -36731,18 +35803,16 @@ return passed === 3;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -36807,18 +35877,16 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -36898,18 +35966,16 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -36996,18 +36062,16 @@ passed = passed
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -37072,18 +36136,16 @@ return Math[s] === &quot;Math&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -37150,18 +36212,16 @@ with (a) {
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -37195,7 +36255,7 @@ with (a) {
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
 <td class="no" data-browser="phantom">No</td>
-<td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[18]</sup></a></td>
 <td class="yes" data-browser="xs6">Yes</td>
 <td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -37215,7 +36275,7 @@ with (a) {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="71">Built-in extensions</td>
+<tr class="category"><td colspan="69">Built-in extensions</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/4</td>
@@ -37226,15 +36286,13 @@ with (a) {
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="konq414" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">4/4</td>
@@ -37298,18 +36356,16 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -37374,18 +36430,16 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -37456,18 +36510,16 @@ return result[0] === sym
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -37527,21 +36579,19 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="closure">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="closure">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -37604,15 +36654,13 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="tally" data-browser="typescript" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/17</td>
 <td class="tally" data-browser="konq414" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)" data-flagged-tally="1">8/17</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)" data-flagged-tally="0.8823529411764706">14/17</td>
 <td class="tally" data-browser="edge14" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)" data-flagged-tally="1">16/17</td>
 <td class="tally" data-browser="edge15" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)" data-flagged-tally="1">16/17</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)" data-flagged-tally="1">16/17</td>
 <td class="tally" data-browser="firefox45" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
@@ -37677,18 +36725,16 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -37752,18 +36798,16 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -37829,15 +36873,13 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -37905,15 +36947,13 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -37981,15 +37021,13 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -38059,15 +37097,13 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -38136,15 +37172,13 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -38211,15 +37245,13 @@ return o.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -38283,18 +37315,16 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -38368,15 +37398,13 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -38439,21 +37467,19 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -38514,21 +37540,19 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -38593,21 +37617,19 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -38677,15 +37699,13 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -38752,15 +37772,13 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -38827,15 +37845,13 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -38904,15 +37920,13 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -38975,15 +37989,13 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es6shim" data-tally="1">2/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">2/2</td>
@@ -39046,18 +38058,16 @@ return typeof String.raw === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39120,18 +38130,16 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39194,15 +38202,13 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">10/10</td>
 <td class="tally" data-browser="edge14" data-tally="1">10/10</td>
 <td class="tally" data-browser="edge15" data-tally="1">10/10</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">10/10</td>
 <td class="tally" data-browser="firefox45" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">10/10</td>
@@ -39265,18 +38271,16 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39344,15 +38348,13 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39416,18 +38418,16 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39491,18 +38491,16 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39569,18 +38567,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39644,18 +38640,16 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39722,18 +38716,16 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39797,18 +38789,16 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39871,18 +38861,16 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -39955,18 +38943,16 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -40029,15 +39015,13 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally" data-browser="edge14" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="1">1/6</td>
 <td class="tally" data-browser="edge15" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="1">1/6</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="1">1/6</td>
 <td class="tally" data-browser="firefox45" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -40100,18 +39084,16 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -40174,18 +39156,16 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -40248,18 +39228,16 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -40322,18 +39300,16 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -40396,18 +39372,16 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -40471,18 +39445,16 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -40545,15 +39517,13 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally" data-browser="typescript" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)" data-flagged-tally="0.8181818181818182">7/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally" data-browser="edge14" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally" data-browser="edge15" data-tally="1">11/11</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">11/11</td>
 <td class="tally" data-browser="firefox45" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">11/11</td>
@@ -40616,18 +39586,16 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -40691,18 +39659,16 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -40766,18 +39732,16 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -40841,18 +39805,16 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -40917,18 +39879,16 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, functio
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -40994,18 +39954,16 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41071,18 +40029,16 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41148,18 +40104,16 @@ return Array.from(Object.create(iterable), function(e, i) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41229,18 +40183,16 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41304,18 +40256,16 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41379,18 +40329,16 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41453,15 +40401,13 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">10/10</td>
 <td class="tally" data-browser="edge14" data-tally="1">10/10</td>
 <td class="tally" data-browser="edge15" data-tally="1">10/10</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">10/10</td>
 <td class="tally" data-browser="firefox45" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">10/10</td>
@@ -41524,18 +40470,16 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41598,18 +40542,16 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41672,18 +40614,16 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41746,18 +40686,16 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41820,18 +40758,16 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -41894,29 +40830,27 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
-<td class="no" data-browser="firefox45">No<a href="#array-prototype-iterator-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox47">No<a href="#array-prototype-iterator-note"><sup>[21]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
+<td class="no" data-browser="firefox45">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox47">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
-<td class="no obsolete" data-browser="firefox49">No<a href="#array-prototype-values-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#array-prototype-values-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox51">No<a href="#array-prototype-values-note"><sup>[22]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#array-prototype-values-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox53">No<a href="#array-prototype-values-note"><sup>[22]</sup></a></td>
-<td class="no" data-browser="firefox54">No<a href="#array-prototype-values-note"><sup>[22]</sup></a></td>
-<td class="no unstable" data-browser="firefox55">No<a href="#array-prototype-values-note"><sup>[22]</sup></a></td>
-<td class="no unstable" data-browser="firefox56">No<a href="#array-prototype-values-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox49">No<a href="#array-prototype-values-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox50">No<a href="#array-prototype-values-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox51">No<a href="#array-prototype-values-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#array-prototype-values-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox53">No<a href="#array-prototype-values-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="firefox54">No<a href="#array-prototype-values-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="firefox55">No<a href="#array-prototype-values-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="firefox56">No<a href="#array-prototype-values-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="opera12">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome51">Yes</td>
@@ -41947,7 +40881,7 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="yes obsolete" data-browser="iojs">Yes</td>
 <td class="no" data-browser="node4">No</td>
 <td class="no obsolete" data-browser="node5">No</td>
-<td class="no obsolete" data-browser="node6">No<a href="#array-prototype-iterator-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
 <td class="yes" data-browser="node6_5">Yes</td>
 <td class="no obsolete" data-browser="node7">No</td>
 <td class="no" data-browser="node7_6">No</td>
@@ -41968,18 +40902,16 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42042,18 +40974,16 @@ return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42126,18 +41056,16 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42208,18 +41136,16 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42282,15 +41208,13 @@ return true;
 <td class="tally" data-browser="typescript" data-tally="1">7/7</td>
 <td class="tally" data-browser="es6shim" data-tally="1">7/7</td>
 <td class="tally" data-browser="konq414" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">7/7</td>
 <td class="tally" data-browser="edge14" data-tally="1">7/7</td>
 <td class="tally" data-browser="edge15" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">7/7</td>
 <td class="tally" data-browser="firefox45" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">7/7</td>
@@ -42353,18 +41277,16 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42427,18 +41349,16 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42501,18 +41421,16 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42575,18 +41493,16 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42649,18 +41565,16 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42723,18 +41637,16 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42797,18 +41709,16 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -42871,15 +41781,13 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="tally" data-browser="typescript" data-tally="1">17/17</td>
 <td class="tally" data-browser="es6shim" data-tally="1">17/17</td>
 <td class="tally" data-browser="konq414" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">17/17</td>
 <td class="tally" data-browser="edge14" data-tally="1">17/17</td>
 <td class="tally" data-browser="edge15" data-tally="1">17/17</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">17/17</td>
 <td class="tally" data-browser="firefox45" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">17/17</td>
@@ -42942,18 +41850,16 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43016,18 +41922,16 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43090,18 +41994,16 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43164,18 +42066,16 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43238,18 +42138,16 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43312,18 +42210,16 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43386,18 +42282,16 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43460,18 +42354,16 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43534,18 +42426,16 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43608,18 +42498,16 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43682,18 +42570,16 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43756,18 +42642,16 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43830,18 +42714,16 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43904,18 +42786,16 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -43978,18 +42858,16 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44052,18 +42930,16 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44129,18 +43005,16 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44206,18 +43080,16 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44271,7 +43143,7 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="71">Subclassing</td>
+<tr class="category"><td colspan="69">Subclassing</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array_is_subclassable"><span><a class="anchor" href="#test-Array_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-array-constructor">Array is subclassable</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/11</td>
@@ -44282,15 +43154,13 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.2727272727272727">0/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">11/11</td>
 <td class="tally" data-browser="edge14" data-tally="1">11/11</td>
 <td class="tally" data-browser="edge15" data-tally="1">11/11</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">11/11</td>
 <td class="tally" data-browser="firefox45" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)">6/11</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)">6/11</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">11/11</td>
@@ -44361,15 +43231,13 @@ return len1 === 0 &amp;&amp; len2 === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44439,15 +43307,13 @@ return c.length === 1 &amp;&amp; !(2 in c);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44509,21 +43375,19 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44590,15 +43454,13 @@ return Array.isArray(new C());
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44666,15 +43528,13 @@ return c.concat(1) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44742,15 +43602,13 @@ return c.filter(Boolean) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44818,15 +43676,13 @@ return c.map(Boolean) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44895,15 +43751,13 @@ return c.slice(1,2) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -44972,15 +43826,13 @@ return c.splice(1,2) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45040,22 +43892,20 @@ return C.from({ length: 0 }) instanceof C;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("573");try{return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("573");return Function("asyncTestPassed","'use strict';"+"\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45115,22 +43965,20 @@ return C.of(0) instanceof C;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("574");try{return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("574");return Function("asyncTestPassed","'use strict';"+"\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45193,15 +44041,13 @@ return C.of(0) instanceof C;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.25">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">4/4</td>
@@ -45269,15 +44115,13 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45339,21 +44183,19 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45421,15 +44263,13 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45497,15 +44337,13 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45568,15 +44406,13 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.16666666666666666">0/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge15" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox45" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">6/6</td>
@@ -45644,15 +44480,13 @@ return c() === &apos;foo&apos;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45714,21 +44548,19 @@ return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getProt
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45797,15 +44629,13 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45873,15 +44703,13 @@ return c.call({bar:1}, 2) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -45949,15 +44777,13 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46025,15 +44851,13 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46096,15 +44920,13 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">4/4</td>
@@ -46192,15 +45014,13 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46268,15 +45088,13 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46357,15 +45175,13 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46446,15 +45262,13 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46517,15 +45331,13 @@ function check() {
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge15" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox45" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">6/6</td>
@@ -46595,15 +45407,13 @@ return c instanceof Boolean
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46673,15 +45483,13 @@ return c instanceof Number
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46753,15 +45561,13 @@ return c instanceof String
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46831,15 +45637,13 @@ return c instanceof Error
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46911,15 +45715,13 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -46992,15 +45794,13 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -47054,7 +45854,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="71">Misc</td>
+<tr class="category"><td colspan="69">Misc</td>
 </tr>
 <tr class="supertest" significance="0.125"><td id="test-prototype_of_bound_functions"><span><a class="anchor" href="#test-prototype_of_bound_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-boundfunctioncreate">prototype of bound functions</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/5</td>
@@ -47065,15 +45865,13 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">5/5</td>
@@ -47152,15 +45950,13 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -47239,15 +46035,13 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -47326,15 +46120,13 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -47413,15 +46205,13 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -47498,15 +46288,13 @@ return correctProtoBound(function(){})
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -47569,15 +46357,13 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="typescript" data-tally="0">0/36</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/36</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/36</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/36</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/36</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/36</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.3888888888888889" style="background-color:hsl(46,68%,50%)" data-flagged-tally="0.4166666666666667">14/36</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5277777777777778" style="background-color:hsl(63,62%,50%)">19/36</td>
 <td class="tally" data-browser="edge14" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)" data-flagged-tally="0.75">20/36</td>
 <td class="tally" data-browser="edge15" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.9722222222222222">24/36</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.9722222222222222">24/36</td>
 <td class="tally" data-browser="firefox45" data-tally="0.6111111111111112" style="background-color:hsl(73,59%,50%)">22/36</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">24/36</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.75" style="background-color:hsl(90,53%,50%)">27/36</td>
@@ -47647,15 +46433,13 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -47725,15 +46509,13 @@ return get + &apos;&apos; === &quot;length,0,1&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -47804,15 +46586,13 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -47885,15 +46665,13 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -47927,7 +46705,7 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
 <td class="no" data-browser="phantom">No</td>
-<td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[18]</sup></a></td>
 <td class="yes" data-browser="xs6">Yes</td>
 <td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -47963,15 +46741,13 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48041,15 +46817,13 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48130,15 +46904,13 @@ return get + &apos;&apos; === &quot;done,value,done,value&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48216,15 +46988,13 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48294,15 +47064,13 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48372,15 +47140,13 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48450,15 +47216,13 @@ return get + &apos;&apos; === &quot;length,name&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48528,15 +47292,13 @@ return get + &apos;&apos; === &quot;name,message&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48607,15 +47369,13 @@ return get + &apos;&apos; === &quot;raw,length,0,1&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48687,15 +47447,13 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48765,15 +47523,13 @@ return get + &apos;&apos; === &quot;global,ignoreCase,multiline,unicode,sticky&q
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48843,15 +47599,13 @@ return get + &apos;&apos; === &quot;exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -48921,15 +47675,13 @@ return get + &apos;&apos; === &quot;source,flags&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -49001,15 +47753,13 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -49081,15 +47831,13 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -49159,15 +47907,13 @@ return get + &apos;&apos; === &quot;lastIndex,exec,lastIndex&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -49239,15 +47985,13 @@ return get + &apos;&apos; === &quot;constructor,flags,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -49317,15 +48061,13 @@ return get[0] === Symbol.iterator &amp;&amp; get.slice(1) + &apos;&apos; === &qu
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -49402,15 +48144,13 @@ return get[0] === &quot;constructor&quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -49493,15 +48233,13 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -49571,15 +48309,13 @@ return get + &apos;&apos; === &quot;length,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -49649,15 +48385,13 @@ return get + &apos;&apos; === &quot;length,0,4,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -49727,15 +48461,13 @@ return get + &apos;&apos; === &quot;length,0,1,2,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -49806,15 +48538,13 @@ return get + &apos;&apos; === &quot;length,constructor,1,2,3,length,constructor,
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -49884,15 +48614,13 @@ return get + &apos;&apos; === &quot;join&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -49962,15 +48690,13 @@ return get + &apos;&apos; === &quot;toJSON&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -50040,15 +48766,13 @@ return get + &apos;&apos; === &quot;then&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -50120,15 +48844,13 @@ return get[0] === Symbol.match &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -50200,15 +48922,13 @@ return get[0] === Symbol.replace &amp;&amp; get[1] === Symbol.toPrimitive &amp;&
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -50280,15 +49000,13 @@ return get[0] === Symbol.search &amp;&amp; get[1] === Symbol.toPrimitive &amp;&a
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -50360,15 +49078,13 @@ return get[0] === Symbol.split &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -50439,15 +49155,13 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -50510,15 +49224,13 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">11/11</td>
 <td class="tally" data-browser="edge14" data-tally="1">11/11</td>
 <td class="tally" data-browser="edge15" data-tally="1">11/11</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">11/11</td>
 <td class="tally" data-browser="firefox45" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">11/11</td>
@@ -50588,15 +49300,13 @@ return set + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -50666,15 +49376,13 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -50744,15 +49452,13 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -50822,15 +49528,13 @@ return set + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -50900,15 +49604,13 @@ return set + &apos;&apos; === &quot;3,4,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -50978,15 +49680,13 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51056,15 +49756,13 @@ return set + &apos;&apos; === &quot;0,1,2,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51134,15 +49832,13 @@ return set + &apos;&apos; === &quot;3,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51212,15 +49908,13 @@ return set + &apos;&apos; === &quot;0,2,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51290,15 +49984,13 @@ return set + &apos;&apos; === &quot;3,2,1,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51368,15 +50060,13 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51439,15 +50129,13 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">2/2</td>
@@ -51517,15 +50205,13 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51595,15 +50281,13 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51666,15 +50350,13 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge15" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox45" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">6/6</td>
@@ -51744,15 +50426,13 @@ return del + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51822,15 +50502,13 @@ return del + &apos;&apos; === &quot;2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51900,15 +50578,13 @@ return del + &apos;&apos; === &quot;0,4,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -51978,15 +50654,13 @@ return del + &apos;&apos; === &quot;0,2,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52056,15 +50730,13 @@ return del + &apos;&apos; === &quot;3,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52134,15 +50806,13 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52205,15 +50875,13 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">4/4</td>
@@ -52284,15 +50952,13 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52363,15 +51029,13 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52442,15 +51106,13 @@ return gopd + &apos;&apos; === &quot;garply&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52521,15 +51183,13 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52592,15 +51252,13 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/3</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">3/3</td>
@@ -52670,15 +51328,13 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52748,15 +51404,13 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52826,15 +51480,13 @@ return ownKeysCalled === 2;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -52897,15 +51549,13 @@ return ownKeysCalled === 2;
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="1">10/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">10/10</td>
 <td class="tally" data-browser="edge14" data-tally="1">10/10</td>
 <td class="tally" data-browser="edge15" data-tally="1">10/10</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">10/10</td>
 <td class="tally" data-browser="firefox45" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">10/10</td>
@@ -52968,18 +51618,16 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53042,18 +51690,16 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53118,18 +51764,16 @@ return s.length === 2 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53192,18 +51836,16 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53266,18 +51908,16 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53340,18 +51980,16 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53414,18 +52052,16 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53488,18 +52124,16 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53562,18 +52196,16 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53637,18 +52269,16 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53711,15 +52341,13 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">7/7</td>
 <td class="tally" data-browser="edge14" data-tally="1">7/7</td>
 <td class="tally" data-browser="edge15" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">7/7</td>
 <td class="tally" data-browser="firefox45" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">7/7</td>
@@ -53817,15 +52445,13 @@ return Object.keys(obj).join(&apos;&apos;) === forInOrder;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -53911,15 +52537,13 @@ return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1A
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54010,15 +52634,13 @@ return result === &quot;012349 DB-1ACEFGHIJKLMNOPQRST&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54105,15 +52727,13 @@ return JSON.stringify(obj) ===
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="edge15">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54187,15 +52807,13 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[23]</sup></a></td>
-<td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[23]</sup></a></td>
-<td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[23]</sup></a></td>
-<td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[23]</sup></a></td>
-<td class="yes" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[23]</sup></a></td>
-<td class="yes" data-browser="edge15">Yes<a href="#ie_property_order-note"><sup>[23]</sup></a></td>
+<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
+<td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
+<td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
+<td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
+<td class="yes" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
+<td class="yes" data-browser="edge15">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54275,21 +52893,19 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 </script></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#forin-order-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="closure">No<a href="#forin-order-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
+<td class="no" data-browser="closure">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#forin-order-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="es6shim">No<a href="#forin-order-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
+<td class="no" data-browser="es6shim">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54367,18 +52983,16 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54441,15 +53055,13 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td class="tally" data-browser="konq414" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally" data-browser="ie11" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="edge14" data-tally="0.7" style="background-color:hsl(84,55%,50%)" data-flagged-tally="0.9">7/10</td>
 <td class="tally" data-browser="edge15" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="1">8/10</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="1">8/10</td>
 <td class="tally" data-browser="firefox45" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
@@ -54520,15 +53132,13 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54595,15 +53205,13 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54669,15 +53277,13 @@ do {} while (false) return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54749,15 +53355,13 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -54828,15 +53432,13 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54899,18 +53501,16 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -54973,18 +53573,16 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55047,18 +53645,16 @@ return RegExp.prototype.toString.call({source: &apos;foo&apos;, flags: &apos;bar
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="jsx">No</td>
-<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55137,15 +53733,13 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged unstable" data-browser="edge16">Flag</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -55219,15 +53813,13 @@ return false;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55281,9 +53873,9 @@ return false;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="71">Annex b</td>
+<tr class="category"><td colspan="69">Annex b</td>
 </tr>
-<tr class="supertest optional-feature" significance="0.125"><td id="test-non-strict_function_semantics"><span><a class="anchor" href="#test-non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[25]</sup></a></span></td>
+<tr class="supertest optional-feature" significance="0.125"><td id="test-non-strict_function_semantics"><span><a class="anchor" href="#test-non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[24]</sup></a></span></td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -55292,15 +53884,13 @@ return false;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally" data-browser="konq414" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">3/3</td>
@@ -55380,15 +53970,13 @@ return passed;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55458,15 +54046,13 @@ return foo() === 2;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55539,15 +54125,13 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55601,7 +54185,7 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="supertest optional-feature" significance="0.125"><td id="test-__proto___in_object_literals"><span><a class="anchor" href="#test-__proto___in_object_literals">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto#Specifications" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proto-in-object-literals-note"><sup>[26]</sup></a></span></td>
+<tr class="supertest optional-feature" significance="0.125"><td id="test-__proto___in_object_literals"><span><a class="anchor" href="#test-__proto___in_object_literals">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto#Specifications" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proto-in-object-literals-note"><sup>[25]</sup></a></span></td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
@@ -55610,15 +54194,13 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">5/5</td>
@@ -55685,15 +54267,13 @@ return { __proto__ : [] } instanceof Array
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55764,15 +54344,13 @@ catch(e) {
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55842,15 +54420,13 @@ return !({ [a] : [] } instanceof Array);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55920,15 +54496,13 @@ return !({ __proto__ } instanceof Array);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -55997,15 +54571,13 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56068,15 +54640,13 @@ return !({ __proto__(){} } instanceof Function);
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge15" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox45" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">6/6</td>
@@ -56143,15 +54713,13 @@ return (new A()).__proto__ === A.prototype;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56219,15 +54787,13 @@ return o instanceof Array;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56295,15 +54861,13 @@ return Object.getPrototypeOf(o) !== p;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56369,15 +54933,13 @@ return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56450,15 +55012,13 @@ return (desc
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56524,15 +55084,13 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56595,15 +55153,13 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="ie11" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">3/3</td>
@@ -56673,18 +55229,16 @@ return true;
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56754,18 +55308,16 @@ return true;
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56834,18 +55386,16 @@ return true;
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -56908,15 +55458,13 @@ return true;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">2/2</td>
@@ -56986,15 +55534,13 @@ return rx.test(&apos;b&apos;);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57061,15 +55607,13 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57132,15 +55676,13 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">8/8</td>
 <td class="tally" data-browser="ie11" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge14" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge15" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">8/8</td>
 <td class="tally" data-browser="firefox45" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">8/8</td>
@@ -57206,15 +55748,13 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57281,15 +55821,13 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57355,15 +55893,13 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57430,15 +55966,13 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57505,15 +56039,13 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57580,15 +56112,13 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57655,15 +56185,13 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57730,15 +56258,13 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57807,15 +56333,13 @@ return a === 3;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -57877,7 +56401,7 @@ return a === 3;
         <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
       </div>
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="babel-optional-note">  <sup>[2]</sup> Flagged features require an optional transformer setting.</p><p id="khtml-note">  <sup>[3]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="edge-experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p><p id="harmony-flag-note">  <sup>[5]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[6]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="typescript-es6-note">  <sup>[7]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="compiler-iterable-note">  <sup>[8]</sup> This compiler requires generic iterables have either a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ff-shorthand-methods-note">  <sup>[9]</sup> Firefox incorrectly produces an error in strict mode if the method is named <code>&quot;arguments&quot;</code>, <code>&quot;eval&quot;</code>, or <code>&quot;delete&quot;</code>.</p><p id="typescript-core-js-note">  <sup>[10]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>, or when a native ES6 host is used.</p><p id="block-level-function-note">  <sup>[11]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="compiler-proto-note">  <sup>[12]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[13]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[14]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="babel-regenerator-note">  <sup>[15]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="proxy-enumerate-note">  <sup>[16]</sup> The 2015 version of the specification also specifies an <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-enumerate">&quot;enumerate&quot; handler</a>, which was removed in the 2016 version.</p><p id="reflect-enumerate-note">  <sup>[17]</sup> The 2015 version of the specification also specifies <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-reflect.enumerate">Reflect.enumerate</a>, which was removed in the 2016 version.</p><p id="symbol-iterator-functionality-note">  <sup>[18]</sup> Functionality for <code>Symbol.iterator</code> is tested by the &quot;generic iterators&quot; subtests for the <a href="#test-spread_(...)_operator">spread (...) operator</a>, <a href="#test-for..of_loops">for..of loops</a>, <a href="#test-destructuring">destructuring</a>, <a href="#test-generators">yield *</a>, and <a href="#test-Array_static_methods">Array.from</a>.</p><p id="ejs-no-with-note">  <sup>[19]</sup> <code>with</code> is not supported in ejs</p><p id="name-configurable-note">  <sup>[20]</sup> Requires function <code>&quot;name&quot;</code> properties to be natively configurable</p><p id="array-prototype-iterator-note">  <sup>[21]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="array-prototype-values-note">  <sup>[22]</sup> The feature is enabled by default only in Firefox Nightly due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1299593">compatibility issue</a>.</p><p id="ie_property_order-note">  <sup>[23]</sup> Unlike other engines, Chakra sorts properties removed by <code>delete</code>, then recreated by assignment, to their original creation positions, not their latest positions.</p><p id="forin-order-note">  <sup>[24]</sup> This uses native for-in enumeration order, rather than the correct order.</p><p id="hoisted-block-functions-note">  <sup>[25]</sup> The 2015 version of the specification contains <a href="https://esdiscuss.org/topic/block-level-function-declarations-web-legacy-compatibility-bug">multiple bugs</a> for hoisted block-level function declaration semantics, which these tests disregard.</p><p id="proto-in-object-literals-note">  <sup>[26]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="babel-optional-note">  <sup>[2]</sup> Flagged features require an optional transformer setting.</p><p id="khtml-note">  <sup>[3]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[5]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="typescript-es6-note">  <sup>[6]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="compiler-iterable-note">  <sup>[7]</sup> This compiler requires generic iterables have either a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ff-shorthand-methods-note">  <sup>[8]</sup> Firefox incorrectly produces an error in strict mode if the method is named <code>&quot;arguments&quot;</code>, <code>&quot;eval&quot;</code>, or <code>&quot;delete&quot;</code>.</p><p id="typescript-core-js-note">  <sup>[9]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>, or when a native ES6 host is used.</p><p id="block-level-function-note">  <sup>[10]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="compiler-proto-note">  <sup>[11]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[12]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[13]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="proxy-enumerate-note">  <sup>[15]</sup> The 2015 version of the specification also specifies an <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-enumerate">&quot;enumerate&quot; handler</a>, which was removed in the 2016 version.</p><p id="reflect-enumerate-note">  <sup>[16]</sup> The 2015 version of the specification also specifies <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-reflect.enumerate">Reflect.enumerate</a>, which was removed in the 2016 version.</p><p id="symbol-iterator-functionality-note">  <sup>[17]</sup> Functionality for <code>Symbol.iterator</code> is tested by the &quot;generic iterators&quot; subtests for the <a href="#test-spread_(...)_operator">spread (...) operator</a>, <a href="#test-for..of_loops">for..of loops</a>, <a href="#test-destructuring">destructuring</a>, <a href="#test-generators">yield *</a>, and <a href="#test-Array_static_methods">Array.from</a>.</p><p id="ejs-no-with-note">  <sup>[18]</sup> <code>with</code> is not supported in ejs</p><p id="name-configurable-note">  <sup>[19]</sup> Requires function <code>&quot;name&quot;</code> properties to be natively configurable</p><p id="array-prototype-iterator-note">  <sup>[20]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="array-prototype-values-note">  <sup>[21]</sup> The feature is enabled by default only in Firefox Nightly due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1299593">compatibility issue</a>.</p><p id="ie_property_order-note">  <sup>[22]</sup> Unlike other engines, Chakra sorts properties removed by <code>delete</code>, then recreated by assignment, to their original creation positions, not their latest positions.</p><p id="forin-order-note">  <sup>[23]</sup> This uses native for-in enumeration order, rather than the correct order.</p><p id="hoisted-block-functions-note">  <sup>[24]</sup> The 2015 version of the specification contains <a href="https://esdiscuss.org/topic/block-level-function-declarations-web-legacy-compatibility-bug">multiple bugs</a> for hoisted block-level function declaration semantics, which these tests disregard.</p><p id="proto-in-object-literals-note">  <sup>[25]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/es6/index.html
+++ b/es6/index.html
@@ -149,6 +149,9 @@
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es6shim compiler" data-browser="es6shim"><a href="#es6shim" class="browser-name"><abbr title="es6-shim">es6-shim</abbr></a></th>
 <th class="platform konq414 desktop" data-browser="konq414"><a href="#konq414" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr></a><a href="#khtml-note"><sup>[3]</sup></a></th>
+<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
+<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
+<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
@@ -213,7 +216,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="69">Optimisation</td>
+      <tr class="category"><td colspan="72">Optimisation</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#test-proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/2</td>
@@ -224,6 +227,9 @@
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
@@ -302,6 +308,9 @@ return (function f(n){
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -387,6 +396,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -447,7 +459,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="69">Syntax</td>
+<tr class="category"><td colspan="72">Syntax</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-default_function_parameters"><span><a class="anchor" href="#test-default_function_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">default function parameters</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -458,6 +470,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally" data-browser="typescript" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/7</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.8571428571428571">0/7</td>
@@ -530,6 +545,9 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -602,6 +620,9 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -674,6 +695,9 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -753,6 +777,9 @@ return (function (a = &quot;baz&quot;, b = &quot;qux&quot;, c = &quot;quux&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -835,6 +862,9 @@ return (function(x = 1) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -912,6 +942,9 @@ return (function(a=function(){
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -986,6 +1019,9 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -1055,6 +1091,9 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
@@ -1129,6 +1168,9 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1201,6 +1243,9 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1281,6 +1326,9 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1359,6 +1407,9 @@ return (function (...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1433,6 +1484,9 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1502,6 +1556,9 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.26666666666666666" style="background-color:hsl(32,74%,50%)">4/15</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/15</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="0.9333333333333333">12/15</td>
@@ -1574,6 +1631,9 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1646,6 +1706,9 @@ return [...[1, 2, 3]][2] === 3;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1719,6 +1782,9 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1792,6 +1858,9 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1864,6 +1933,9 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1936,6 +2008,9 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2008,6 +2083,9 @@ return Array(...&quot;&#x20BB7;&#x20BB6;&quot;)[0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2080,6 +2158,9 @@ return [...&quot;&#x20BB7;&#x20BB6;&quot;][0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2153,6 +2234,9 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -2226,6 +2310,9 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -2299,6 +2386,9 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2372,6 +2462,9 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2445,6 +2538,9 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2518,6 +2614,9 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2594,6 +2693,9 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2663,6 +2765,9 @@ try {
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
@@ -2736,6 +2841,9 @@ return ({ [x]: 1 }).y === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2809,6 +2917,9 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2881,6 +2992,9 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2953,6 +3067,9 @@ return ({ &quot;foo bar&quot;() { return 4; } })[&quot;foo bar&quot;]() === 4;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3026,6 +3143,9 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3105,6 +3225,9 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3174,6 +3297,9 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/9</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/9</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.7777777777777778">6/9</td>
@@ -3248,6 +3374,9 @@ for (var item of arr)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3324,6 +3453,9 @@ return count === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3399,6 +3531,9 @@ return str === &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3474,6 +3609,9 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3551,6 +3689,9 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -3628,6 +3769,9 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3705,6 +3849,9 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -3782,6 +3929,9 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3861,6 +4011,9 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3930,6 +4083,9 @@ return closed;
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
@@ -4002,6 +4158,9 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4074,6 +4233,9 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4146,6 +4308,9 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4218,6 +4383,9 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4287,6 +4455,9 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
@@ -4361,6 +4532,9 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4437,6 +4611,9 @@ return `${a}` === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4520,6 +4697,9 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4594,6 +4774,9 @@ return (function(parts) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4671,6 +4854,9 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4740,6 +4926,9 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.4" style="background-color:hsl(48,68%,50%)" data-flagged-tally="0.8">2/5</td>
@@ -4814,6 +5003,9 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -4889,6 +5081,9 @@ return result === &apos;yy&apos; &amp;&amp; re.lastIndex === 5;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -4961,6 +5156,9 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5033,6 +5231,9 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5105,6 +5306,9 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5174,6 +5378,9 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="tally" data-browser="typescript" data-tally="0.6818181818181818" style="background-color:hsl(81,56%,50%)">15/22</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/22</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/22</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/22</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/22</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/22</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/22</td>
@@ -5247,6 +5454,9 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5320,6 +5530,9 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5393,6 +5606,9 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5466,6 +5682,9 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5539,6 +5758,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5612,6 +5834,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5685,6 +5910,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5762,6 +5990,9 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5835,6 +6066,9 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5908,6 +6142,9 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5983,6 +6220,9 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6056,6 +6296,9 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6142,6 +6385,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6216,6 +6462,9 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6289,6 +6538,9 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6364,6 +6616,9 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6438,6 +6693,9 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6512,6 +6770,9 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6592,6 +6853,9 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6667,6 +6931,9 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6742,6 +7009,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6823,6 +7093,9 @@ return a === 1 &amp;&amp; b === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6892,6 +7165,9 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally" data-browser="typescript" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/24</td>
@@ -6966,6 +7242,9 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7040,6 +7319,9 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7114,6 +7396,9 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7188,6 +7473,9 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7262,6 +7550,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7336,6 +7627,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7410,6 +7704,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7488,6 +7785,9 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7561,6 +7861,9 @@ return ([a, b] = iterable) === iterable;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7635,6 +7938,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7709,6 +8015,9 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7783,6 +8092,9 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7859,6 +8171,9 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -7933,6 +8248,9 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8006,6 +8324,9 @@ return ({a,b} = obj) === obj;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8085,6 +8406,9 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8159,6 +8483,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8246,6 +8573,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8320,6 +8650,9 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8396,6 +8729,9 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8472,6 +8808,9 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8546,6 +8885,9 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8620,6 +8962,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8696,6 +9041,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8765,6 +9113,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally" data-browser="typescript" data-tally="0.6521739130434783" style="background-color:hsl(78,57%,50%)">15/23</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/23</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/23</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/23</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/23</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/23</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/23</td>
@@ -8839,6 +9190,9 @@ return function([a, , [b], c]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8913,6 +9267,9 @@ return function([a, , b]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -8987,6 +9344,9 @@ return function([a, b, c]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9061,6 +9421,9 @@ return function([c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9135,6 +9498,9 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9209,6 +9575,9 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9283,6 +9652,9 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9360,6 +9732,9 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9434,6 +9809,9 @@ return function([a,]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9508,6 +9886,9 @@ return function({c, x:d, e}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9583,6 +9964,9 @@ return function({toFixed}, {slice}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9657,6 +10041,9 @@ return function({a,}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9737,6 +10124,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9812,6 +10202,9 @@ return function({ [qux]: grault }) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9887,6 +10280,9 @@ return function([e, {x:f, g}], {h, x:[i]}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -9962,6 +10358,9 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10037,6 +10436,9 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10109,6 +10511,9 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10184,6 +10589,9 @@ return function([a, ...b], [c, ...d]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10258,6 +10666,9 @@ return function ([],{}){
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10334,6 +10745,9 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5},
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10411,6 +10825,9 @@ return (function({a=function(){
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10485,6 +10902,9 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10554,6 +10974,9 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
@@ -10626,6 +11049,9 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -10699,6 +11125,9 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -10768,6 +11197,9 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
@@ -10847,6 +11279,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10928,6 +11363,9 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -10988,7 +11426,7 @@ try {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="69">Bindings</td>
+<tr class="category"><td colspan="72">Bindings</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-const"><span><a class="anchor" href="#test-const">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">const</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
@@ -10999,6 +11437,9 @@ try {
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/16</td>
 <td class="tally" data-browser="konq414" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
@@ -11072,6 +11513,9 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11146,6 +11590,9 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11223,6 +11670,9 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11300,6 +11750,9 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11374,6 +11827,9 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11450,6 +11906,9 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -11526,6 +11985,9 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -11602,6 +12064,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11676,6 +12141,9 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11751,6 +12219,9 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11829,6 +12300,9 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11907,6 +12381,9 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -11982,6 +12459,9 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -12059,6 +12539,9 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -12136,6 +12619,9 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -12213,6 +12699,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -12282,6 +12771,9 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
@@ -12355,6 +12847,9 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -12429,6 +12924,9 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -12506,6 +13004,9 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -12580,6 +13081,9 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -12656,6 +13160,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -12739,6 +13246,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -12813,6 +13323,9 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -12888,6 +13401,9 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -12966,6 +13482,9 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13041,6 +13560,9 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13118,6 +13640,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13202,6 +13727,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -13283,6 +13811,9 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13343,7 +13874,7 @@ return true;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="69">Functions</td>
+<tr class="category"><td colspan="72">Functions</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-arrow_functions"><span><a class="anchor" href="#test-arrow_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions">arrow functions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
@@ -13354,6 +13885,9 @@ return true;
 <td class="tally" data-browser="typescript" data-tally="0.6923076923076923" style="background-color:hsl(83,55%,50%)">9/13</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/13</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/13</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/13</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/13</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/13</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)" data-flagged-tally="0.7692307692307693">8/13</td>
@@ -13426,6 +13960,9 @@ return (() =&gt; 5)() === 5;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13499,6 +14036,9 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13572,6 +14112,9 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13646,6 +14189,9 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13720,6 +14266,9 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13794,6 +14343,9 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13867,6 +14419,9 @@ return f(6) === 5;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -13941,6 +14496,9 @@ return (() =&gt; {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -14015,6 +14573,9 @@ return (() =&gt; {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -14088,6 +14649,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -14173,6 +14737,9 @@ return new C instanceof C &amp;&amp; received === &apos;foo&apos;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -14256,6 +14823,9 @@ return arrow() === &quot;quux&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -14331,6 +14901,9 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -14400,6 +14973,9 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="tally" data-browser="typescript" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.875">0/24</td>
@@ -14473,6 +15049,9 @@ return typeof C === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -14551,6 +15130,9 @@ return C === c1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -14623,6 +15205,9 @@ return typeof class C {} === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -14695,6 +15280,9 @@ return typeof class {} === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -14771,6 +15359,9 @@ return C.prototype.constructor === C
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -14847,6 +15438,9 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -14923,6 +15517,9 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15000,6 +15597,9 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15080,6 +15680,9 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15156,6 +15759,9 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15233,6 +15839,9 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15311,6 +15920,9 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15389,6 +16001,9 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15467,6 +16082,9 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15545,6 +16163,9 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15622,6 +16243,9 @@ return C === undefined &amp;&amp; M();
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15700,6 +16324,9 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15776,6 +16403,9 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -15851,6 +16481,9 @@ return (0,C.method)();
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -15929,6 +16562,9 @@ catch(e) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -16004,6 +16640,9 @@ return new C() instanceof B
 <td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -16079,6 +16718,9 @@ return new C() instanceof B
 <td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -16155,6 +16797,9 @@ return Function.prototype.isPrototypeOf(C)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -16239,6 +16884,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -16308,6 +16956,9 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.75">0/8</td>
@@ -16388,6 +17039,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -16466,6 +17120,9 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -16545,6 +17202,9 @@ return new C().quux(&quot;bar&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -16623,6 +17283,9 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -16703,6 +17366,9 @@ return obj.qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -16783,6 +17449,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -16865,6 +17534,9 @@ return obj.qux() === &quot;barley&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -16949,6 +17621,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -17018,6 +17693,9 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0">0/27</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/27</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/27</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/27</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/27</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/27</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.9259259259259259">0/27</td>
@@ -17100,6 +17778,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17182,6 +17863,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17264,6 +17948,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17344,6 +18031,9 @@ catch (e) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -17424,6 +18114,9 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17505,6 +18198,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17590,6 +18286,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17674,6 +18373,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17757,6 +18459,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17839,6 +18544,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17918,6 +18626,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -17999,6 +18710,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18080,6 +18794,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18161,6 +18878,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18242,6 +18962,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18325,6 +19048,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18408,6 +19134,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18491,6 +19220,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18575,6 +19307,9 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18663,6 +19398,9 @@ return closed === &apos;ab&apos;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18750,6 +19488,9 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -18834,6 +19575,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -18918,6 +19662,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -19003,6 +19750,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -19087,6 +19837,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -19172,6 +19925,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -19253,6 +20009,9 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -19313,7 +20072,7 @@ try {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="69">Built-ins</td>
+<tr class="category"><td colspan="72">Built-ins</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-typed_arrays"><span><a class="anchor" href="#test-typed_arrays">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects">typed arrays</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/46</td>
@@ -19324,6 +20083,9 @@ try {
 <td class="tally" data-browser="typescript" data-tally="0.9782608695652174" style="background-color:hsl(117,42%,50%)">45/46</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/46</td>
 <td class="tally" data-browser="konq414" data-tally="0.17391304347826086" style="background-color:hsl(20,78%,50%)">8/46</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/46</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/46</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/46</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally" data-browser="ie11" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9130434782608695" style="background-color:hsl(109,45%,50%)">42/46</td>
@@ -19398,6 +20160,9 @@ return view[0] === -0x80;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -19472,6 +20237,9 @@ return view[0] === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -19546,6 +20314,9 @@ return view[0] === 0xFF;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -19620,6 +20391,9 @@ return view[0] === -0x8000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -19694,6 +20468,9 @@ return view[0] === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -19768,6 +20545,9 @@ return view[0] === -0x80000000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -19842,6 +20622,9 @@ return view[0] === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -19916,6 +20699,9 @@ return view[0] === 0.10000000149011612;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -19990,6 +20776,9 @@ return view[0] === 0.1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -20065,6 +20854,9 @@ return view.getInt8(0) === -0x80;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -20140,6 +20932,9 @@ return view.getUint8(0) === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -20215,6 +21010,9 @@ return view.getInt16(0) === -0x8000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -20290,6 +21088,9 @@ return view.getUint16(0) === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -20365,6 +21166,9 @@ return view.getInt32(0) === -0x80000000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -20440,6 +21244,9 @@ return view.getUint32(0) === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -20515,6 +21322,9 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -20590,6 +21400,9 @@ return view.getFloat64(0) === 0.1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -20662,6 +21475,9 @@ return typeof ArrayBuffer[Symbol.species] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -20757,6 +21573,9 @@ return constructors.every(function (constructor) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -20844,6 +21663,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -20939,6 +21761,9 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21019,6 +21844,9 @@ typeof Float64Array.from === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21099,6 +21927,9 @@ typeof Float64Array.of === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21179,6 +22010,9 @@ typeof Float64Array.prototype.subarray === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21259,6 +22093,9 @@ typeof Float64Array.prototype.join === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21339,6 +22176,9 @@ typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21419,6 +22259,9 @@ typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21499,6 +22342,9 @@ typeof Float64Array.prototype.slice === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21579,6 +22425,9 @@ typeof Float64Array.prototype.every === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21659,6 +22508,9 @@ typeof Float64Array.prototype.filter === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21739,6 +22591,9 @@ typeof Float64Array.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21819,6 +22674,9 @@ typeof Float64Array.prototype.map === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21899,6 +22757,9 @@ typeof Float64Array.prototype.reduce === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -21979,6 +22840,9 @@ typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22059,6 +22923,9 @@ typeof Float64Array.prototype.reverse === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22139,6 +23006,9 @@ typeof Float64Array.prototype.some === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22219,6 +23089,9 @@ typeof Float64Array.prototype.sort === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22299,6 +23172,9 @@ typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22379,6 +23255,9 @@ typeof Float64Array.prototype.find === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22459,6 +23338,9 @@ typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22539,6 +23421,9 @@ typeof Float64Array.prototype.fill === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22619,6 +23504,9 @@ typeof Float64Array.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22699,6 +23587,9 @@ typeof Float64Array.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22779,6 +23670,9 @@ typeof Float64Array.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22859,6 +23753,9 @@ typeof Float64Array.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -22939,6 +23836,9 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -23008,6 +23908,9 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally" data-browser="typescript" data-tally="1">19/19</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
@@ -23085,6 +23988,9 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23162,6 +24068,9 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23240,6 +24149,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23313,6 +24225,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23395,6 +24310,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23474,6 +24392,9 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -23547,6 +24468,9 @@ return map.set(0, 0) === map;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23625,6 +24549,9 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23702,6 +24629,9 @@ return map.size === 1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23774,6 +24704,9 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23846,6 +24779,9 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23918,6 +24854,9 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -23990,6 +24929,9 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24062,6 +25004,9 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24134,6 +25079,9 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24206,6 +25154,9 @@ return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24285,6 +25236,9 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24367,6 +25321,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -24440,6 +25397,9 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -24509,6 +25469,9 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally" data-browser="typescript" data-tally="1">19/19</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
@@ -24587,6 +25550,9 @@ return set.has(123);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24663,6 +25629,9 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24741,6 +25710,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24814,6 +25786,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24896,6 +25871,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -24978,6 +25956,9 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -25051,6 +26032,9 @@ return set.add(0) === set;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25129,6 +26113,9 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25208,6 +26195,9 @@ return set.size === 2;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25280,6 +26270,9 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25352,6 +26345,9 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25424,6 +26420,9 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25496,6 +26495,9 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25568,6 +26570,9 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25640,6 +26645,9 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25712,6 +26720,9 @@ return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25791,6 +26802,9 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -25873,6 +26887,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -25946,6 +26963,9 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -26015,6 +27035,9 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally" data-browser="typescript" data-tally="1">12/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">6/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
@@ -26092,6 +27115,9 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26169,6 +27195,9 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26247,6 +27276,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26320,6 +27352,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26402,6 +27437,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26477,6 +27515,9 @@ return m.get(f) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26556,6 +27597,9 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -26630,6 +27674,9 @@ return weakmap.set(key, 0) === weakmap;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26702,6 +27749,9 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26781,6 +27831,9 @@ return m.has(key);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26856,6 +27909,9 @@ return m.has(1) === false
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -26935,6 +27991,9 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27004,6 +28063,9 @@ catch(e) {
 <td class="tally" data-browser="typescript" data-tally="1">11/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
@@ -27082,6 +28144,9 @@ return weakset.has(obj1);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27157,6 +28222,9 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27235,6 +28303,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27308,6 +28379,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27390,6 +28464,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27469,6 +28546,9 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -27543,6 +28623,9 @@ return weakset.add(obj) === weakset;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27615,6 +28698,9 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27694,6 +28780,9 @@ return s.has(key);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27768,6 +28857,9 @@ return s.has(1) === false
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27847,6 +28939,9 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -27916,6 +29011,9 @@ catch(e) {
 <td class="tally" data-browser="typescript" data-tally="0">0/34</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/34</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/34</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/34</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/34</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/34</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/34</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/34</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">34/34</td>
@@ -27994,6 +29092,9 @@ try {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28067,6 +29168,9 @@ return !Proxy.hasOwnProperty(&apos;prototype&apos;);
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28145,6 +29249,9 @@ return proxy.foo === 5;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28223,6 +29330,9 @@ return proxy.foo === 5;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28322,6 +29432,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28402,6 +29515,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28482,6 +29598,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28581,6 +29700,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28660,6 +29782,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28739,6 +29864,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28835,6 +29963,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -28914,6 +30045,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29001,6 +30135,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29086,6 +30223,9 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29208,6 +30348,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29292,6 +30435,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29392,6 +30538,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29471,6 +30620,9 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29556,6 +30708,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29640,6 +30795,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29727,6 +30885,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29808,6 +30969,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29901,6 +31065,9 @@ return true;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -29983,6 +31150,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30068,6 +31238,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30149,6 +31322,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30251,6 +31427,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30333,6 +31512,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30418,6 +31600,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30498,6 +31683,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30593,6 +31781,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30673,6 +31864,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30745,6 +31939,9 @@ return Array.isArray(new Proxy([], {}));
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30817,6 +32014,9 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -30886,6 +32086,9 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="tally" data-browser="typescript" data-tally="0.9" style="background-color:hsl(108,46%,50%)">18/20</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/20</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/20</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/20</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/20</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.65" style="background-color:hsl(78,57%,50%)">13/20</td>
@@ -30958,6 +32161,9 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31032,6 +32238,9 @@ return obj.quux === 654;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31104,6 +32313,9 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31178,6 +32390,9 @@ return !(&quot;bar&quot; in obj);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31253,6 +32468,9 @@ return desc.value === 789 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31328,6 +32546,9 @@ return obj.foo === 123 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -31400,6 +32621,9 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31474,6 +32698,9 @@ return obj instanceof Array;
 <td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31547,6 +32774,9 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31621,6 +32851,9 @@ return !Object.isExtensible(obj);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31697,6 +32930,9 @@ return Reflect.ownKeys(obj).sort() + &apos;&apos; === &quot;A,B&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31777,6 +33013,9 @@ return keys.indexOf(s2) &gt;-1 &amp;&amp; keys.indexOf(s3) &gt;-1 &amp;&amp; key
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31849,6 +33088,9 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31923,6 +33165,9 @@ return Reflect.construct(function(a, b, c) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -31999,6 +33244,9 @@ return Reflect.construct(function(a, b, c) {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -32073,6 +33321,9 @@ return obj.y === 1 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -32148,6 +33399,9 @@ return obj.length === 3 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -32223,6 +33477,9 @@ return RegExp.prototype.exec.call(obj, &quot;foobarbaz&quot;)[0] === &quot;baz&q
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -32297,6 +33554,9 @@ return obj() === 2 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -32388,6 +33648,9 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -32457,6 +33720,9 @@ function check() {
 <td class="tally" data-browser="typescript" data-tally="1">8/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -32550,6 +33816,9 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -32628,6 +33897,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -32705,6 +33977,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -32791,6 +34066,9 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -32877,6 +34155,9 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -32963,6 +34244,9 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33049,6 +34333,9 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33122,6 +34409,9 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -33191,6 +34481,9 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="tally" data-browser="typescript" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">8/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">2/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
@@ -33267,6 +34560,9 @@ return object[symbol] === value;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33339,6 +34635,9 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33423,6 +34722,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33504,6 +34806,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33581,6 +34886,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33666,6 +34974,9 @@ return true;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33738,6 +35049,9 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33815,6 +35129,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33894,6 +35211,9 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -33969,6 +35289,9 @@ return JSON.stringify(object) === &apos;{}&apos; &amp;&amp; JSON.stringify(array
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -34054,6 +35377,9 @@ return testSymbolObject(objSym) &amp;&amp; testSymbolObject(symNoToJSON);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -34128,6 +35454,9 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -34197,6 +35526,9 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="0.5769230769230769" style="background-color:hsl(69,60%,50%)">15/26</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/26</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/26</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.11538461538461539" style="background-color:hsl(13,80%,50%)">3/26</td>
@@ -34276,6 +35608,9 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -34351,6 +35686,9 @@ return a[0] === b;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -34423,6 +35761,9 @@ return &quot;iterator&quot; in Symbol;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -34498,6 +35839,9 @@ return (function() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -34570,6 +35914,9 @@ return &quot;species&quot; in Symbol;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -34647,6 +35994,9 @@ return Array.prototype.concat.call(obj, []).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -34724,6 +36074,9 @@ return Array.prototype.filter.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -34801,6 +36154,9 @@ return Array.prototype.map.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -34878,6 +36234,9 @@ return Array.prototype.slice.call(obj, 0).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -34955,6 +36314,9 @@ return Array.prototype.splice.call(obj, 0).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35035,6 +36397,9 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35111,6 +36476,9 @@ return promise.then(function(){}) instanceof FakePromise2;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35187,6 +36555,9 @@ return &apos;&apos;.replace(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35263,6 +36634,9 @@ return &apos;&apos;.search(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35339,6 +36713,9 @@ return &apos;&apos;.split(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35415,6 +36792,9 @@ return &apos;&apos;.match(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35491,6 +36871,9 @@ return RegExp(re) !== re &amp;&amp; RegExp(foo) === foo;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35569,6 +36952,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35647,6 +37033,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35725,6 +37114,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35806,6 +37198,9 @@ return passed === 3;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35880,6 +37275,9 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -35969,6 +37367,9 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -36065,6 +37466,9 @@ passed = passed
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -36139,6 +37543,9 @@ return Math[s] === &quot;Math&quot;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -36215,6 +37622,9 @@ with (a) {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -36275,7 +37685,7 @@ with (a) {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="69">Built-in extensions</td>
+<tr class="category"><td colspan="72">Built-in extensions</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/4</td>
@@ -36286,6 +37696,9 @@ with (a) {
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="konq414" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
@@ -36359,6 +37772,9 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -36433,6 +37849,9 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -36513,6 +37932,9 @@ return result[0] === sym
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -36585,6 +38007,9 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -36654,6 +38079,9 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="tally" data-browser="typescript" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/17</td>
 <td class="tally" data-browser="konq414" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)" data-flagged-tally="1">8/17</td>
@@ -36728,6 +38156,9 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -36801,6 +38232,9 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -36873,6 +38307,9 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -36947,6 +38384,9 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -37021,6 +38461,9 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -37097,6 +38540,9 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -37172,6 +38618,9 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -37245,6 +38694,9 @@ return o.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -37318,6 +38770,9 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -37398,6 +38853,9 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -37473,6 +38931,9 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -37546,6 +39007,9 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -37623,6 +39087,9 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -37699,6 +39166,9 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -37772,6 +39242,9 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -37845,6 +39318,9 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -37920,6 +39396,9 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -37989,6 +39468,9 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es6shim" data-tally="1">2/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
@@ -38061,6 +39543,9 @@ return typeof String.raw === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38133,6 +39618,9 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38202,6 +39690,9 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
@@ -38274,6 +39765,9 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38348,6 +39842,9 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38421,6 +39918,9 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38494,6 +39994,9 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38570,6 +40073,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38643,6 +40149,9 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38719,6 +40228,9 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38792,6 +40304,9 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38864,6 +40379,9 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -38946,6 +40464,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -39015,6 +40536,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
@@ -39087,6 +40611,9 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -39159,6 +40686,9 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -39231,6 +40761,9 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -39303,6 +40836,9 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -39375,6 +40911,9 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -39448,6 +40987,9 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -39517,6 +41059,9 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally" data-browser="typescript" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)" data-flagged-tally="0.8181818181818182">7/11</td>
@@ -39589,6 +41134,9 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -39662,6 +41210,9 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -39735,6 +41286,9 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -39808,6 +41362,9 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -39882,6 +41439,9 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, functio
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -39957,6 +41517,9 @@ return Array.from(iterable, function(e, i) {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -40032,6 +41595,9 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40107,6 +41673,9 @@ return Array.from(Object.create(iterable), function(e, i) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40186,6 +41755,9 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -40259,6 +41831,9 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40332,6 +41907,9 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -40401,6 +41979,9 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
@@ -40473,6 +42054,9 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40545,6 +42129,9 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40617,6 +42204,9 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40689,6 +42279,9 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40761,6 +42354,9 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40833,6 +42429,9 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40905,6 +42504,9 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -40977,6 +42579,9 @@ return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41059,6 +42664,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -41139,6 +42747,9 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41208,6 +42819,9 @@ return true;
 <td class="tally" data-browser="typescript" data-tally="1">7/7</td>
 <td class="tally" data-browser="es6shim" data-tally="1">7/7</td>
 <td class="tally" data-browser="konq414" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
@@ -41280,6 +42894,9 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41352,6 +42969,9 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41424,6 +43044,9 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41496,6 +43119,9 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41568,6 +43194,9 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41640,6 +43269,9 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41712,6 +43344,9 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41781,6 +43416,9 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="tally" data-browser="typescript" data-tally="1">17/17</td>
 <td class="tally" data-browser="es6shim" data-tally="1">17/17</td>
 <td class="tally" data-browser="konq414" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">17/17</td>
@@ -41853,6 +43491,9 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41925,6 +43566,9 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -41997,6 +43641,9 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42069,6 +43716,9 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42141,6 +43791,9 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42213,6 +43866,9 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42285,6 +43941,9 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42357,6 +44016,9 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42429,6 +44091,9 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42501,6 +44166,9 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42573,6 +44241,9 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42645,6 +44316,9 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42717,6 +44391,9 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42789,6 +44466,9 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42861,6 +44541,9 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -42933,6 +44616,9 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -43008,6 +44694,9 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -43083,6 +44772,9 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -43143,7 +44835,7 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="69">Subclassing</td>
+<tr class="category"><td colspan="72">Subclassing</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array_is_subclassable"><span><a class="anchor" href="#test-Array_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-array-constructor">Array is subclassable</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/11</td>
@@ -43154,6 +44846,9 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.2727272727272727">0/11</td>
@@ -43231,6 +44926,9 @@ return len1 === 0 &amp;&amp; len2 === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -43307,6 +45005,9 @@ return c.length === 1 &amp;&amp; !(2 in c);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -43381,6 +45082,9 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -43454,6 +45158,9 @@ return Array.isArray(new C());
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -43528,6 +45235,9 @@ return c.concat(1) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -43602,6 +45312,9 @@ return c.filter(Boolean) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -43676,6 +45389,9 @@ return c.map(Boolean) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -43751,6 +45467,9 @@ return c.slice(1,2) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -43826,6 +45545,9 @@ return c.splice(1,2) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -43899,6 +45621,9 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -43972,6 +45697,9 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -44041,6 +45769,9 @@ return C.of(0) instanceof C;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.25">0/4</td>
@@ -44115,6 +45846,9 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -44189,6 +45923,9 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -44263,6 +46000,9 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -44337,6 +46077,9 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -44406,6 +46149,9 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.16666666666666666">0/6</td>
@@ -44480,6 +46226,9 @@ return c() === &apos;foo&apos;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -44554,6 +46303,9 @@ return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getProt
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -44629,6 +46381,9 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -44703,6 +46458,9 @@ return c.call({bar:1}, 2) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -44777,6 +46535,9 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -44851,6 +46612,9 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -44920,6 +46684,9 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
@@ -45014,6 +46781,9 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45088,6 +46858,9 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45175,6 +46948,9 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45262,6 +47038,9 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45331,6 +47110,9 @@ function check() {
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
@@ -45407,6 +47189,9 @@ return c instanceof Boolean
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45483,6 +47268,9 @@ return c instanceof Number
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45561,6 +47349,9 @@ return c instanceof String
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45637,6 +47428,9 @@ return c instanceof Error
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45715,6 +47509,9 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45794,6 +47591,9 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -45854,7 +47654,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="69">Misc</td>
+<tr class="category"><td colspan="72">Misc</td>
 </tr>
 <tr class="supertest" significance="0.125"><td id="test-prototype_of_bound_functions"><span><a class="anchor" href="#test-prototype_of_bound_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-boundfunctioncreate">prototype of bound functions</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/5</td>
@@ -45865,6 +47665,9 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/5</td>
@@ -45950,6 +47753,9 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -46035,6 +47841,9 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -46120,6 +47929,9 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -46205,6 +48017,9 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -46288,6 +48103,9 @@ return correctProtoBound(function(){})
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -46357,6 +48175,9 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="typescript" data-tally="0">0/36</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/36</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/36</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/36</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/36</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/36</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.3888888888888889" style="background-color:hsl(46,68%,50%)" data-flagged-tally="0.4166666666666667">14/36</td>
@@ -46433,6 +48254,9 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -46509,6 +48333,9 @@ return get + &apos;&apos; === &quot;length,0,1&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -46586,6 +48413,9 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -46665,6 +48495,9 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -46741,6 +48574,9 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -46817,6 +48653,9 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
@@ -46904,6 +48743,9 @@ return get + &apos;&apos; === &quot;done,value,done,value&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -46988,6 +48830,9 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -47064,6 +48909,9 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -47140,6 +48988,9 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -47216,6 +49067,9 @@ return get + &apos;&apos; === &quot;length,name&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -47292,6 +49146,9 @@ return get + &apos;&apos; === &quot;name,message&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -47369,6 +49226,9 @@ return get + &apos;&apos; === &quot;raw,length,0,1&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -47447,6 +49307,9 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -47523,6 +49386,9 @@ return get + &apos;&apos; === &quot;global,ignoreCase,multiline,unicode,sticky&q
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -47599,6 +49465,9 @@ return get + &apos;&apos; === &quot;exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -47675,6 +49544,9 @@ return get + &apos;&apos; === &quot;source,flags&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -47753,6 +49625,9 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -47831,6 +49706,9 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -47907,6 +49785,9 @@ return get + &apos;&apos; === &quot;lastIndex,exec,lastIndex&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -47985,6 +49866,9 @@ return get + &apos;&apos; === &quot;constructor,flags,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -48061,6 +49945,9 @@ return get[0] === Symbol.iterator &amp;&amp; get.slice(1) + &apos;&apos; === &qu
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -48144,6 +50031,9 @@ return get[0] === &quot;constructor&quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -48233,6 +50123,9 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -48309,6 +50202,9 @@ return get + &apos;&apos; === &quot;length,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -48385,6 +50281,9 @@ return get + &apos;&apos; === &quot;length,0,4,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -48461,6 +50360,9 @@ return get + &apos;&apos; === &quot;length,0,1,2,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -48538,6 +50440,9 @@ return get + &apos;&apos; === &quot;length,constructor,1,2,3,length,constructor,
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -48614,6 +50519,9 @@ return get + &apos;&apos; === &quot;join&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -48690,6 +50598,9 @@ return get + &apos;&apos; === &quot;toJSON&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -48766,6 +50677,9 @@ return get + &apos;&apos; === &quot;then&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -48844,6 +50758,9 @@ return get[0] === Symbol.match &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -48922,6 +50839,9 @@ return get[0] === Symbol.replace &amp;&amp; get[1] === Symbol.toPrimitive &amp;&
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -49000,6 +50920,9 @@ return get[0] === Symbol.search &amp;&amp; get[1] === Symbol.toPrimitive &amp;&a
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -49078,6 +51001,9 @@ return get[0] === Symbol.split &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -49155,6 +51081,9 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -49224,6 +51153,9 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">11/11</td>
@@ -49300,6 +51232,9 @@ return set + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -49376,6 +51311,9 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -49452,6 +51390,9 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -49528,6 +51469,9 @@ return set + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -49604,6 +51548,9 @@ return set + &apos;&apos; === &quot;3,4,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -49680,6 +51627,9 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -49756,6 +51706,9 @@ return set + &apos;&apos; === &quot;0,1,2,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -49832,6 +51785,9 @@ return set + &apos;&apos; === &quot;3,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -49908,6 +51864,9 @@ return set + &apos;&apos; === &quot;0,2,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -49984,6 +51943,9 @@ return set + &apos;&apos; === &quot;3,2,1,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50060,6 +52022,9 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50129,6 +52094,9 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
@@ -50205,6 +52173,9 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50281,6 +52252,9 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50350,6 +52324,9 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
@@ -50426,6 +52403,9 @@ return del + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50502,6 +52482,9 @@ return del + &apos;&apos; === &quot;2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50578,6 +52561,9 @@ return del + &apos;&apos; === &quot;0,4,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50654,6 +52640,9 @@ return del + &apos;&apos; === &quot;0,2,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50730,6 +52719,9 @@ return del + &apos;&apos; === &quot;3,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50806,6 +52798,9 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -50875,6 +52870,9 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
@@ -50952,6 +52950,9 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51029,6 +53030,9 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51106,6 +53110,9 @@ return gopd + &apos;&apos; === &quot;garply&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51183,6 +53190,9 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51252,6 +53262,9 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/3</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -51328,6 +53341,9 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51404,6 +53420,9 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51480,6 +53499,9 @@ return ownKeysCalled === 2;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -51549,6 +53571,9 @@ return ownKeysCalled === 2;
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="1">10/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">10/10</td>
@@ -51621,6 +53646,9 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51693,6 +53721,9 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51767,6 +53798,9 @@ return s.length === 2 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51839,6 +53873,9 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51911,6 +53948,9 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -51983,6 +54023,9 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -52055,6 +54098,9 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -52127,6 +54173,9 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -52199,6 +54248,9 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -52272,6 +54324,9 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -52341,6 +54396,9 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
@@ -52445,6 +54503,9 @@ return Object.keys(obj).join(&apos;&apos;) === forInOrder;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -52537,6 +54598,9 @@ return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1A
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -52634,6 +54698,9 @@ return result === &quot;012349 DB-1ACEFGHIJKLMNOPQRST&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -52727,6 +54794,9 @@ return JSON.stringify(obj) ===
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -52807,6 +54877,9 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
@@ -52899,6 +54972,9 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 <td class="no" data-browser="typescript">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -52986,6 +55062,9 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -53055,6 +55134,9 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td class="tally" data-browser="konq414" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally" data-browser="ie11" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
@@ -53132,6 +55214,9 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -53205,6 +55290,9 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -53277,6 +55365,9 @@ do {} while (false) return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -53355,6 +55446,9 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -53432,6 +55526,9 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -53504,6 +55601,9 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -53576,6 +55676,9 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -53648,6 +55751,9 @@ return RegExp.prototype.toString.call({source: &apos;foo&apos;, flags: &apos;bar
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -53733,6 +55839,9 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -53813,6 +55922,9 @@ return false;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -53873,7 +55985,7 @@ return false;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="69">Annex b</td>
+<tr class="category"><td colspan="72">Annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-non-strict_function_semantics"><span><a class="anchor" href="#test-non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[24]</sup></a></span></td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -53884,6 +55996,9 @@ return false;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally" data-browser="konq414" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
@@ -53970,6 +56085,9 @@ return passed;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -54046,6 +56164,9 @@ return foo() === 2;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -54125,6 +56246,9 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -54194,6 +56318,9 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
@@ -54267,6 +56394,9 @@ return { __proto__ : [] } instanceof Array
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -54344,6 +56474,9 @@ catch(e) {
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -54420,6 +56553,9 @@ return !({ [a] : [] } instanceof Array);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -54496,6 +56632,9 @@ return !({ __proto__ } instanceof Array);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -54571,6 +56710,9 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -54640,6 +56782,9 @@ return !({ __proto__(){} } instanceof Function);
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
@@ -54713,6 +56858,9 @@ return (new A()).__proto__ === A.prototype;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -54787,6 +56935,9 @@ return o instanceof Array;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -54861,6 +57012,9 @@ return Object.getPrototypeOf(o) !== p;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -54933,6 +57087,9 @@ return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55012,6 +57169,9 @@ return (desc
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55084,6 +57244,9 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55153,6 +57316,9 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="ie11" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
@@ -55232,6 +57398,9 @@ return true;
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55311,6 +57480,9 @@ return true;
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55389,6 +57561,9 @@ return true;
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55458,6 +57633,9 @@ return true;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
@@ -55534,6 +57712,9 @@ return rx.test(&apos;b&apos;);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55607,6 +57788,9 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55676,6 +57860,9 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">8/8</td>
 <td class="tally" data-browser="ie11" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">8/8</td>
@@ -55748,6 +57935,9 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55821,6 +58011,9 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55893,6 +58086,9 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -55966,6 +58162,9 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -56039,6 +58238,9 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -56112,6 +58314,9 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -56185,6 +58390,9 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -56258,6 +58466,9 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -56333,6 +58544,9 @@ return a === 3;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -121,13 +121,13 @@
           <th></th>
 
           <!-- TABLE HEADERS -->
-        <th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
-<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
+        <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
-<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
-<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
-<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
-<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
+<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
+<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
+<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a></th>
+<th class="platform edge16 desktop unstable" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16 Preview</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox47 desktop obsolete" data-browser="firefox47"><a href="#firefox47" class="browser-name"><abbr title="Firefox">FF 47</abbr></a></th>
 <th class="platform firefox48 desktop obsolete" data-browser="firefox48"><a href="#firefox48" class="browser-name"><abbr title="Firefox">FF 48</abbr></a></th>
@@ -159,15 +159,15 @@
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 32">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
-<th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node6_5 engine" data-browser="node6_5"><a href="#node6_5" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node7_6 engine" data-browser="node7_6"><a href="#node7_6" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node6_5 engine" data-browser="node6_5"><a href="#node6_5" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node7_6 engine" data-browser="node7_6"><a href="#node7_6" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform duktape2_0 engine" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -181,13 +181,13 @@
       <tbody>
         <!-- TABLE BODY -->
       <tr class="supertest" significance="1"><td id="test-Intl_object"><span><a class="anchor" href="#test-Intl_object">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-8">Intl object</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">2/2</td>
@@ -240,13 +240,13 @@
 return typeof Intl === &apos;object&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nreturn typeof Intl === 'object';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl === 'object';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -299,13 +299,13 @@ return typeof Intl === &apos;object&apos;;
 return Intl.constructor === Object;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nreturn Intl.constructor === Object;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.constructor === Object;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -355,13 +355,13 @@ return Intl.constructor === Object;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator"><span><a class="anchor" href="#test-Intl.Collator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10">Intl.Collator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">4/4</td>
@@ -414,13 +414,13 @@ return Intl.constructor === Object;
 return typeof Intl.Collator === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("4");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -473,13 +473,13 @@ return typeof Intl.Collator === &apos;function&apos;;
 return new Intl.Collator() instanceof Intl.Collator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nreturn new Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -532,13 +532,13 @@ return new Intl.Collator() instanceof Intl.Collator;
 return Intl.Collator() instanceof Intl.Collator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");try{return Function("asyncTestPassed","\nreturn Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("6");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -619,13 +619,13 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -675,13 +675,13 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.compare"><span><a class="anchor" href="#test-Intl.Collator.prototype.compare">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.2">Intl.Collator.prototype.compare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">1/1</td>
@@ -734,13 +734,13 @@ try {
 return typeof Intl.Collator().compare === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -790,13 +790,13 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.resolvedOptions"><span><a class="anchor" href="#test-Intl.Collator.prototype.resolvedOptions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.3">Intl.Collator.prototype.resolvedOptions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">1/1</td>
@@ -849,13 +849,13 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -905,13 +905,13 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-NumberFormat"><span><a class="anchor" href="#test-NumberFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-11">NumberFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">5/5</td>
@@ -964,13 +964,13 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 return typeof Intl.NumberFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1023,13 +1023,13 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 return typeof Intl.NumberFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1082,13 +1082,13 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 return new Intl.NumberFormat() instanceof Intl.NumberFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1141,13 +1141,13 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 return Intl.NumberFormat() instanceof Intl.NumberFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1228,13 +1228,13 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1284,13 +1284,13 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-DateTimeFormat"><span><a class="anchor" href="#test-DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge15" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox45" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
@@ -1343,13 +1343,13 @@ try {
 return typeof Intl.DateTimeFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1402,13 +1402,13 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("20");try{return Function("asyncTestPassed","\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("20");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1461,13 +1461,13 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1548,13 +1548,13 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1608,13 +1608,13 @@ var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 return tz !== undefined &amp;&amp; tz.length &gt; 0;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1675,13 +1675,13 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1731,13 +1731,13 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-String.prototype.localeCompare"><span><a class="anchor" href="#test-String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">1/1</td>
@@ -1790,13 +1790,13 @@ try {
 return typeof String.prototype.localeCompare === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1846,13 +1846,13 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Number.prototype.toLocaleString"><span><a class="anchor" href="#test-Number.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.tolocalestring">Number.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">1/1</td>
@@ -1905,13 +1905,13 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 return typeof Number.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1961,13 +1961,13 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Array.prototype.toLocaleString"><span><a class="anchor" href="#test-Array.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.tolocalestring">Array.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">1/1</td>
@@ -2020,13 +2020,13 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 return typeof Array.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2076,13 +2076,13 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object.prototype.toLocaleString"><span><a class="anchor" href="#test-Object.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.tolocalestring">Object.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">1/1</td>
@@ -2135,13 +2135,13 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 return typeof Object.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2191,13 +2191,13 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleString"><span><a class="anchor" href="#test-Date.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocalestring">Date.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">1/1</td>
@@ -2250,13 +2250,13 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2306,13 +2306,13 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleDateString"><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaledatestring">Date.prototype.toLocaleDateString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">1/1</td>
@@ -2365,13 +2365,13 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2421,13 +2421,13 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleTimeString"><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaletimestring">Date.prototype.toLocaleTimeString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">1/1</td>
@@ -2480,13 +2480,13 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2539,7 +2539,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="edge-experimental-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -121,7 +121,8 @@
           <th></th>
 
           <!-- TABLE HEADERS -->
-        <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
+        <th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
+<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -181,6 +182,7 @@
       <tbody>
         <!-- TABLE BODY -->
       <tr class="supertest" significance="1"><td id="test-Intl_object"><span><a class="anchor" href="#test-Intl_object">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-8">Intl object</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
@@ -240,6 +242,7 @@
 return typeof Intl === &apos;object&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nreturn typeof Intl === 'object';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl === 'object';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -299,6 +302,7 @@ return typeof Intl === &apos;object&apos;;
 return Intl.constructor === Object;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nreturn Intl.constructor === Object;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.constructor === Object;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -355,6 +359,7 @@ return Intl.constructor === Object;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator"><span><a class="anchor" href="#test-Intl.Collator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10">Intl.Collator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
@@ -414,6 +419,7 @@ return Intl.constructor === Object;
 return typeof Intl.Collator === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("4");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -473,6 +479,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 return new Intl.Collator() instanceof Intl.Collator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nreturn new Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -532,6 +539,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 return Intl.Collator() instanceof Intl.Collator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");try{return Function("asyncTestPassed","\nreturn Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("6");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -619,6 +627,7 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -675,6 +684,7 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.compare"><span><a class="anchor" href="#test-Intl.Collator.prototype.compare">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.2">Intl.Collator.prototype.compare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
@@ -734,6 +744,7 @@ try {
 return typeof Intl.Collator().compare === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -790,6 +801,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.resolvedOptions"><span><a class="anchor" href="#test-Intl.Collator.prototype.resolvedOptions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.3">Intl.Collator.prototype.resolvedOptions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
@@ -849,6 +861,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -905,6 +918,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-NumberFormat"><span><a class="anchor" href="#test-NumberFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-11">NumberFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
@@ -964,6 +978,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 return typeof Intl.NumberFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1023,6 +1038,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 return typeof Intl.NumberFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1082,6 +1098,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 return new Intl.NumberFormat() instanceof Intl.NumberFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1141,6 +1158,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 return Intl.NumberFormat() instanceof Intl.NumberFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1228,6 +1246,7 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1284,6 +1303,7 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-DateTimeFormat"><span><a class="anchor" href="#test-DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
@@ -1343,6 +1363,7 @@ try {
 return typeof Intl.DateTimeFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1402,6 +1423,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("20");try{return Function("asyncTestPassed","\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("20");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1461,6 +1483,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1548,6 +1571,7 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1608,6 +1632,7 @@ var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 return tz !== undefined &amp;&amp; tz.length &gt; 0;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1675,6 +1700,7 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1731,6 +1757,7 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-String.prototype.localeCompare"><span><a class="anchor" href="#test-String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
@@ -1790,6 +1817,7 @@ try {
 return typeof String.prototype.localeCompare === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1846,6 +1874,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Number.prototype.toLocaleString"><span><a class="anchor" href="#test-Number.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.tolocalestring">Number.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
@@ -1905,6 +1934,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 return typeof Number.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -1961,6 +1991,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Array.prototype.toLocaleString"><span><a class="anchor" href="#test-Array.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.tolocalestring">Array.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
@@ -2020,6 +2051,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 return typeof Array.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2076,6 +2108,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object.prototype.toLocaleString"><span><a class="anchor" href="#test-Object.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.tolocalestring">Object.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
@@ -2135,6 +2168,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 return typeof Object.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2191,6 +2225,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleString"><span><a class="anchor" href="#test-Date.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocalestring">Date.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
@@ -2250,6 +2285,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2306,6 +2342,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleDateString"><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaledatestring">Date.prototype.toLocaleDateString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
@@ -2365,6 +2402,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2421,6 +2459,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleTimeString"><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaletimestring">Date.prototype.toLocaleTimeString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
@@ -2480,6 +2519,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -115,6 +115,9 @@
 <th class="platform babel compiler" data-browser="babel"><a href="#babel" class="browser-name"><abbr title="Babel 6.5 + core-js 2.4">Babel +<br><nobr>core-js</nobr></abbr></a><a href="#babel-optional-note"><sup>[2]</sup></a></th>
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20161024">Closure</abbr></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
+<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
+<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
+<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
@@ -173,13 +176,16 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="59">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="62">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-SIMD_(Single_Instruction,_Multiple_Data)"><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/">SIMD (Single Instruction, Multiple Data)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/57</td>
 <td class="tally" data-browser="babel" data-tally="0">0/57</td>
 <td class="tally" data-browser="closure" data-tally="0">0/57</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/57</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.017543859649122806">0/57</td>
@@ -250,6 +256,9 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -312,6 +321,9 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -374,6 +386,9 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -436,6 +451,9 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -498,6 +516,9 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -560,6 +581,9 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -622,6 +646,9 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -684,6 +711,9 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -746,6 +776,9 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -808,6 +841,9 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -870,6 +906,9 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -934,6 +973,9 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -998,6 +1040,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1062,6 +1107,9 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1126,6 +1174,9 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1190,6 +1241,9 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1254,6 +1308,9 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1318,6 +1375,9 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1382,6 +1442,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1446,6 +1509,9 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1510,6 +1576,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1574,6 +1643,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1638,6 +1710,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1702,6 +1777,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1766,6 +1844,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1830,6 +1911,9 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1894,6 +1978,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1958,6 +2045,9 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2022,6 +2112,9 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2086,6 +2179,9 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2150,6 +2246,9 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2214,6 +2313,9 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2278,6 +2380,9 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2342,6 +2447,9 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2406,6 +2514,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2470,6 +2581,9 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2534,6 +2648,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2598,6 +2715,9 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2662,6 +2782,9 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2726,6 +2849,9 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2790,6 +2916,9 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2854,6 +2983,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2918,6 +3050,9 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2982,6 +3117,9 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3046,6 +3184,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3110,6 +3251,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3174,6 +3318,9 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3238,6 +3385,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3302,6 +3452,9 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3366,6 +3519,9 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3430,6 +3586,9 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3494,6 +3653,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3558,6 +3720,9 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3622,6 +3787,9 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3686,6 +3854,9 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3750,6 +3921,9 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3812,6 +3986,9 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3871,6 +4048,9 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
@@ -3934,6 +4114,9 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -3998,6 +4181,9 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4057,6 +4243,9 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="babel" data-tally="0">0/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
@@ -4121,6 +4310,9 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4190,6 +4382,9 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4249,6 +4444,9 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
@@ -4318,6 +4516,9 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4397,6 +4598,9 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4466,6 +4670,9 @@ return result.groups.year === &apos;2016&apos;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4529,6 +4736,9 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4592,6 +4802,9 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4651,6 +4864,9 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="babel" data-tally="0">0/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
@@ -4715,6 +4931,9 @@ return fn + &apos;&apos; === str;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4778,6 +4997,9 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4841,6 +5063,9 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -4904,6 +5129,9 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -4967,6 +5195,9 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5030,6 +5261,9 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5093,6 +5327,9 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5147,7 +5384,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="59">Draft (stage 2)</td>
+<tr class="category"><td colspan="62">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -5163,6 +5400,9 @@ return result === &apos;tromple&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5222,6 +5462,9 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="babel" data-tally="0">0/1</td>
 <td class="tally" data-browser="closure" data-tally="0">0/1</td>
 <td class="tally" data-browser="typescript" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/1</td>
@@ -5292,6 +5535,9 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="babel">No<a href="#regenerator-decorators-legacy-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5351,6 +5597,9 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally" data-browser="babel" data-tally="1">4/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5413,6 +5662,9 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5475,6 +5727,9 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -5537,6 +5792,9 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5599,6 +5857,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5658,6 +5919,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="babel" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
@@ -5724,6 +5988,9 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5795,6 +6062,9 @@ return new C(42).x() === 42;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5863,6 +6133,9 @@ return new C().x() === 42;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5917,7 +6190,7 @@ return new C().x() === 42;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="59">Proposal (stage 1)</td>
+<tr class="category"><td colspan="62">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://gist.github.com/dherman/1c97dfb25179fa34a41b5fff040f9879">do expressions</a></span><script data-source="
 return do {
@@ -5930,6 +6203,9 @@ return do {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -5995,6 +6271,9 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6054,6 +6333,9 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="babel" data-tally="1">8/8</td>
 <td class="tally" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/8</td>
@@ -6116,6 +6398,9 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6178,6 +6463,9 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6240,6 +6528,9 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6312,6 +6603,9 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6375,6 +6669,9 @@ return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6438,6 +6735,9 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6500,6 +6800,9 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6562,6 +6865,9 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6634,6 +6940,9 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6700,6 +7009,9 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6763,6 +7075,9 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -6817,13 +7132,16 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="59">Strawman (stage 0)</td>
+<tr class="category"><td colspan="62">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -6888,6 +7206,9 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6951,6 +7272,9 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7013,6 +7337,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7072,6 +7399,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -7135,6 +7465,9 @@ return f();
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7197,6 +7530,9 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7264,6 +7600,9 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7337,6 +7676,9 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7406,6 +7748,9 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7465,6 +7810,9 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7529,6 +7877,9 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7593,6 +7944,9 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7652,6 +8006,9 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -7714,6 +8071,9 @@ return typeof Zone == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7776,6 +8136,9 @@ return &apos;current&apos; in Zone;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7838,6 +8201,9 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7900,6 +8266,9 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7962,6 +8331,9 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8024,6 +8396,9 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8086,6 +8461,9 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8151,6 +8529,9 @@ passed = true;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8210,6 +8591,9 @@ passed = true;
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -8278,6 +8662,9 @@ return (function f(n){
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8353,6 +8740,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8407,13 +8797,16 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="ios10_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="ios11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="59">Pre-strawman</td>
+<tr class="category"><td colspan="62">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -8476,6 +8869,9 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8538,6 +8934,9 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8600,6 +8999,9 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8662,6 +9064,9 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8724,6 +9129,9 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8786,6 +9194,9 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8848,6 +9259,9 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8910,6 +9324,9 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8972,6 +9389,9 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
+<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -115,15 +115,13 @@
 <th class="platform babel compiler" data-browser="babel"><a href="#babel" class="browser-name"><abbr title="Babel 6.5 + core-js 2.4">Babel +<br><nobr>core-js</nobr></abbr></a><a href="#babel-optional-note"><sup>[2]</sup></a></th>
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20161024">Closure</abbr></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
-<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
-<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
-<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
-<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
-<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
-<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
+<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
+<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
+<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a></th>
+<th class="platform edge16 desktop unstable" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16 Preview</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox47 desktop obsolete" data-browser="firefox47"><a href="#firefox47" class="browser-name"><abbr title="Firefox">FF 47</abbr></a></th>
 <th class="platform firefox48 desktop obsolete" data-browser="firefox48"><a href="#firefox48" class="browser-name"><abbr title="Firefox">FF 48</abbr></a></th>
@@ -154,15 +152,15 @@
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 32">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
-<th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node6_5 engine" data-browser="node6_5"><a href="#node6_5" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node7_6 engine" data-browser="node7_6"><a href="#node7_6" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node6_5 engine" data-browser="node6_5"><a href="#node6_5" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node7_6 engine" data-browser="node7_6"><a href="#node7_6" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform duktape2_0 engine" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -175,22 +173,20 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="61">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="59">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-SIMD_(Single_Instruction,_Multiple_Data)"><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/">SIMD (Single Instruction, Multiple Data)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/57</td>
 <td class="tally" data-browser="babel" data-tally="0">0/57</td>
 <td class="tally" data-browser="closure" data-tally="0">0/57</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/57</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.017543859649122806">0/57</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.543859649122807">0/57</td>
 <td class="tally" data-browser="edge14" data-tally="0" data-flagged-tally="1">0/57</td>
 <td class="tally" data-browser="edge15" data-tally="0" data-flagged-tally="0.9649122807017544">0/57</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0" data-flagged-tally="0.9649122807017544">0/57</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/57</td>
@@ -254,15 +250,13 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge12">Flag</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -318,15 +312,13 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -382,15 +374,13 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -446,15 +436,13 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -510,15 +498,13 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -574,15 +560,13 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -638,15 +622,13 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -702,15 +684,13 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -766,15 +746,13 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -830,15 +808,13 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -894,15 +870,13 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -960,15 +934,13 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1026,15 +998,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1092,15 +1062,13 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1158,15 +1126,13 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1224,15 +1190,13 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1290,15 +1254,13 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1356,15 +1318,13 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1422,15 +1382,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1488,15 +1446,13 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1554,15 +1510,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1620,15 +1574,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1686,15 +1638,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1752,15 +1702,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1818,15 +1766,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1884,15 +1830,13 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1950,15 +1894,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2016,15 +1958,13 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2082,15 +2022,13 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2148,15 +2086,13 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2214,15 +2150,13 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2280,15 +2214,13 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2346,15 +2278,13 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2412,15 +2342,13 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2478,15 +2406,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2544,15 +2470,13 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2610,15 +2534,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2676,15 +2598,13 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2742,15 +2662,13 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2808,15 +2726,13 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2874,15 +2790,13 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -2940,15 +2854,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3006,15 +2918,13 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3072,15 +2982,13 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3138,15 +3046,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3204,15 +3110,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3270,15 +3174,13 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3336,15 +3238,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3402,15 +3302,13 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3468,15 +3366,13 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3534,15 +3430,13 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3600,15 +3494,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3666,15 +3558,13 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3732,15 +3622,13 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no flagged obsolete" data-browser="edge13">Flag</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3798,15 +3686,13 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3864,15 +3750,13 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3928,15 +3812,13 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
-<td class="no flagged" data-browser="edge15">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
+<td class="no flagged unstable" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3989,15 +3871,13 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge15" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/2</td>
@@ -4054,15 +3934,13 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4120,15 +3998,13 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4181,15 +4057,13 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="babel" data-tally="0">0/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge15" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/2</td>
@@ -4247,15 +4121,13 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4318,15 +4190,13 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4379,15 +4249,13 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge15" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/2</td>
@@ -4450,15 +4318,13 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4531,15 +4397,13 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4602,15 +4466,13 @@ return result.groups.year === &apos;2016&apos;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4667,15 +4529,13 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4732,15 +4592,13 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4793,15 +4651,13 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="babel" data-tally="0">0/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td class="tally" data-browser="edge14" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="edge15" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="firefox45" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
@@ -4859,15 +4715,13 @@ return fn + &apos;&apos; === str;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4924,15 +4778,13 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -4989,15 +4841,13 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5054,15 +4904,13 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5119,15 +4967,13 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5184,15 +5030,13 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5249,15 +5093,13 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5305,7 +5147,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="61">Draft (stage 2)</td>
+<tr class="category"><td colspan="59">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -5321,15 +5163,13 @@ return result === &apos;tromple&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5382,15 +5222,13 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="babel" data-tally="0">0/1</td>
 <td class="tally" data-browser="closure" data-tally="0">0/1</td>
 <td class="tally" data-browser="typescript" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/1</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/1</td>
 <td class="tally" data-browser="edge15" data-tally="0">0/1</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0">0/1</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/1</td>
@@ -5454,15 +5292,13 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="babel">No<a href="#regenerator-decorators-legacy-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5515,15 +5351,13 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally" data-browser="babel" data-tally="1">4/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge15" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="firefox45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5579,15 +5413,13 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5643,15 +5475,13 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -5707,15 +5537,13 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5771,15 +5599,13 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5832,15 +5658,13 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="babel" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge15" data-tally="0">0/3</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/3</td>
@@ -5900,15 +5724,13 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -5973,15 +5795,13 @@ return new C(42).x() === 42;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6043,15 +5863,13 @@ return new C().x() === 42;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6099,7 +5917,7 @@ return new C().x() === 42;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="61">Proposal (stage 1)</td>
+<tr class="category"><td colspan="59">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://gist.github.com/dherman/1c97dfb25179fa34a41b5fff040f9879">do expressions</a></span><script data-source="
 return do {
@@ -6112,15 +5930,13 @@ return do {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6179,15 +5995,13 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6240,15 +6054,13 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="babel" data-tally="1">8/8</td>
 <td class="tally" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/8</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/8</td>
 <td class="tally" data-browser="edge15" data-tally="0">0/8</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0">0/8</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="0">0/8</td>
@@ -6304,15 +6116,13 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6368,15 +6178,13 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6432,15 +6240,13 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6506,15 +6312,13 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6571,15 +6375,13 @@ return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6636,15 +6438,13 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6700,15 +6500,13 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6764,15 +6562,13 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6838,15 +6634,13 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6906,15 +6700,13 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -6971,15 +6763,13 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -7027,22 +6817,20 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="61">Strawman (stage 0)</td>
+<tr class="category"><td colspan="59">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7100,15 +6888,13 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7165,15 +6951,13 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7229,15 +7013,13 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7290,15 +7072,13 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -7355,15 +7135,13 @@ return f();
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7419,15 +7197,13 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7488,15 +7264,13 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7563,15 +7337,13 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7634,15 +7406,13 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7695,15 +7465,13 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7761,15 +7529,13 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7827,15 +7593,13 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7888,15 +7652,13 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -7952,15 +7714,13 @@ return typeof Zone == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8016,15 +7776,13 @@ return &apos;current&apos; in Zone;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8080,15 +7838,13 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8144,15 +7900,13 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8208,15 +7962,13 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8272,15 +8024,13 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8336,15 +8086,13 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8403,15 +8151,13 @@ passed = true;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8464,15 +8210,13 @@ passed = true;
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -8534,15 +8278,13 @@ return (function f(n){
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8611,15 +8353,13 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8667,22 +8407,20 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="ios10_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="ios11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="61">Pre-strawman</td>
+<tr class="category"><td colspan="59">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -8738,15 +8476,13 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8802,15 +8538,13 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8866,15 +8600,13 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8930,15 +8662,13 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8994,15 +8724,13 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9058,15 +8786,13 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9122,15 +8848,13 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9186,15 +8910,13 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9250,15 +8972,13 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox47" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox48" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9310,7 +9030,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="babel-optional-note">  <sup>[2]</sup> Flagged features require an optional transformer setting.</p><p id="edge-experimental-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p><p id="harmony-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="firefox-nightly-note">  <sup>[5]</sup> The feature is enabled by default only in Firefox Nightly.</p><p id="chrome-simd-note">  <sup>[6]</sup> The feature have to be enabled via --js-flags=&quot;--harmony-simd&quot; flag</p><p id="ffox-global-property-note">  <sup>[7]</sup> The feature was disabled due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1325907">some</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1326032">compatibility</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1328218">issues</a>.</p><p id="wk-global-property-note">  <sup>[8]</sup> The feature was disabled due to <a href="https://bugs.webkit.org/show_bug.cgi?id=165171">compatibility issues</a>.</p><p id="regenerator-decorators-legacy-note">  <sup>[9]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/regenerator-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="typescript-core-js-note">  <sup>[10]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>, or when a native ES6 host is used.</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="babel-optional-note">  <sup>[2]</sup> Flagged features require an optional transformer setting.</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="edge-experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p><p id="firefox-nightly-note">  <sup>[5]</sup> The feature is enabled by default only in Firefox Nightly.</p><p id="chrome-simd-note">  <sup>[6]</sup> The feature have to be enabled via --js-flags=&quot;--harmony-simd&quot; flag</p><p id="ffox-global-property-note">  <sup>[7]</sup> The feature was disabled due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1325907">some</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1326032">compatibility</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1328218">issues</a>.</p><p id="wk-global-property-note">  <sup>[8]</sup> The feature was disabled due to <a href="https://bugs.webkit.org/show_bug.cgi?id=165171">compatibility issues</a>.</p><p id="regenerator-decorators-legacy-note">  <sup>[9]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/regenerator-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="typescript-core-js-note">  <sup>[10]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>, or when a native ES6 host is used.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -105,15 +105,13 @@
             <!-- TABLE HEADERS -->
           <th class="platform konq44 desktop obsolete" data-browser="konq44"><a href="#konq44" class="browser-name"><abbr title="Konqueror 4.4">Konq 4.4</abbr></a></th>
 <th class="platform konq49 desktop obsolete" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></a></th>
-<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
-<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
-<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
-<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
-<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
-<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
+<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
+<th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
+<th class="platform edge15 desktop" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a></th>
+<th class="platform edge16 desktop unstable" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16 Preview</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox47 desktop obsolete" data-browser="firefox47"><a href="#firefox47" class="browser-name"><abbr title="Firefox">FF 47</abbr></a></th>
 <th class="platform firefox48 desktop obsolete" data-browser="firefox48"><a href="#firefox48" class="browser-name"><abbr title="Firefox">FF 48</abbr></a></th>
@@ -161,15 +159,13 @@
         <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq44" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge15" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="edge16" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox47" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox48" data-tally="1">4/4</td>
@@ -216,15 +212,13 @@ return typeof uneval == &apos;function&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -279,15 +273,13 @@ return &apos;toSource&apos; in Object.prototype
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -334,15 +326,13 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -478,15 +468,13 @@ return true;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -534,15 +522,13 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -583,7 +569,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -593,15 +579,13 @@ return 'caller' in function(){};
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -654,15 +638,13 @@ return (function () {}).arity === 0 &&
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -717,15 +699,13 @@ return f(1, 'boo');
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -774,15 +754,13 @@ return typeof Function.prototype.isGenerator == 'function';
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -823,7 +801,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -832,15 +810,13 @@ return new C instanceof C;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -891,15 +867,13 @@ return typeof ({}).__count__ === 'number' &&
 }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -948,15 +922,13 @@ return typeof ({}).__parent__ !== 'undefined';
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1015,15 +987,13 @@ return executed;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1072,15 +1042,13 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1129,15 +1097,13 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1178,7 +1144,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -1188,15 +1154,13 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1243,15 +1207,13 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1298,15 +1260,13 @@ return (function(x)x)(1) === 1;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1353,15 +1313,13 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1412,15 +1370,13 @@ return str === &quot;foobarbaz&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1468,15 +1424,13 @@ return arr[1] === arr;
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1517,7 +1471,7 @@ return arr[1] === arr;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -1557,15 +1511,13 @@ catch(e) {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1652,15 +1604,13 @@ catch(e) {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1746,15 +1696,13 @@ global.test((function () {
         }</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1803,15 +1751,13 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1865,15 +1811,13 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -1914,7 +1858,7 @@ return passed;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -1938,15 +1882,13 @@ try {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -1999,15 +1941,13 @@ return RegExp.lastMatch === 'x';
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2062,15 +2002,13 @@ return true;
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2117,15 +2055,13 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2173,15 +2109,13 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2222,21 +2156,19 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2281,15 +2213,13 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2330,21 +2260,19 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2399,15 +2327,13 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2448,21 +2374,19 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2507,15 +2431,13 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 function () { return typeof Object.prototype.unwatch == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2560,15 +2482,13 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 function () { return typeof Object.prototype.eval == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2615,15 +2535,13 @@ return typeof Object.observe == &apos;function&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2664,7 +2582,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -2682,15 +2600,13 @@ try {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2739,15 +2655,13 @@ return 'lineNumber' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2796,15 +2710,13 @@ return 'columnNumber' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2853,15 +2765,13 @@ return 'fileName' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no" data-browser="edge15">No</td>
+<td class="no unstable" data-browser="edge16">No</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -2910,15 +2820,13 @@ return 'description' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes" data-browser="edge15">Yes</td>
+<td class="yes unstable" data-browser="edge16">Yes</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox47">No</td>
 <td class="no obsolete" data-browser="firefox48">No</td>
@@ -2959,14 +2867,14 @@ return 'description' in new Error();
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="53" class="separator"></th>
+<tr><th colspan="51" class="separator"></th>
 </tr>
 </tbody>
       </table>
     </div>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="edge-experimental-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p></div>
     <pre class="info-tooltip" style="display:none"></pre>
     <script src="../jquery.floatThead.min.js"></script>
   </body>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -105,6 +105,9 @@
             <!-- TABLE HEADERS -->
           <th class="platform konq44 desktop obsolete" data-browser="konq44"><a href="#konq44" class="browser-name"><abbr title="Konqueror 4.4">Konq 4.4</abbr></a></th>
 <th class="platform konq49 desktop obsolete" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></a></th>
+<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
+<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
+<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
@@ -159,6 +162,9 @@
         <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq44" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
@@ -212,6 +218,9 @@ return typeof uneval == &apos;function&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -273,6 +282,9 @@ return &apos;toSource&apos; in Object.prototype
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -326,6 +338,9 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -468,6 +483,9 @@ return true;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -522,6 +540,9 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -569,7 +590,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -579,6 +600,9 @@ return 'caller' in function(){};
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="yes obsolete" data-browser="ie7">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -638,6 +662,9 @@ return (function () {}).arity === 0 &&
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -699,6 +726,9 @@ return f(1, 'boo');
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="yes obsolete" data-browser="ie7">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -754,6 +784,9 @@ return typeof Function.prototype.isGenerator == 'function';
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -801,7 +834,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -810,6 +843,9 @@ return new C instanceof C;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -867,6 +903,9 @@ return typeof ({}).__count__ === 'number' &&
 }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -922,6 +961,9 @@ return typeof ({}).__parent__ !== 'undefined';
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -987,6 +1029,9 @@ return executed;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1042,6 +1087,9 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1097,6 +1145,9 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1144,7 +1195,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -1154,6 +1205,9 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1207,6 +1261,9 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1260,6 +1317,9 @@ return (function(x)x)(1) === 1;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1313,6 +1373,9 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1370,6 +1433,9 @@ return str === &quot;foobarbaz&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1424,6 +1490,9 @@ return arr[1] === arr;
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1471,7 +1540,7 @@ return arr[1] === arr;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -1511,6 +1580,9 @@ catch(e) {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1604,6 +1676,9 @@ catch(e) {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1696,6 +1771,9 @@ global.test((function () {
         }</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1751,6 +1829,9 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1811,6 +1892,9 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1858,7 +1942,7 @@ return passed;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -1882,6 +1966,9 @@ try {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -1941,6 +2028,9 @@ return RegExp.lastMatch === 'x';
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="yes obsolete" data-browser="ie7">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2002,6 +2092,9 @@ return true;
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="yes obsolete" data-browser="ie7">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2055,6 +2148,9 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2109,6 +2205,9 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2156,12 +2255,15 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2213,6 +2315,9 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2260,12 +2365,15 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2327,6 +2435,9 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2374,12 +2485,15 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2431,6 +2545,9 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 function () { return typeof Object.prototype.unwatch == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2482,6 +2599,9 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 function () { return typeof Object.prototype.eval == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2535,6 +2655,9 @@ return typeof Object.observe == &apos;function&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2582,7 +2705,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -2600,6 +2723,9 @@ try {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2655,6 +2781,9 @@ return 'lineNumber' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2710,6 +2839,9 @@ return 'columnNumber' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2765,6 +2897,9 @@ return 'fileName' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
@@ -2820,6 +2955,9 @@ return 'description' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="yes obsolete" data-browser="ie7">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
@@ -2867,7 +3005,7 @@ return 'description' in new Error();
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="51" class="separator"></th>
+<tr><th colspan="54" class="separator"></th>
 </tr>
 </tbody>
       </table>


### PR DESCRIPTION
The Edge 16 Insiders Preview is already available, adding it to the tables.  I am also retiring some ancient versions of IE.
Finally, I am updating the flagged Edge features to link to the notes, as in the other browsers.
This PR fixes #1110.
