### PR TITLE
Dropping ancient IE versions

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -144,11 +144,12 @@
     "family": "Chakra",
     "short": "IE 7",
     "release": "2006-10-18",
-    "obsolete": true,
+    "retire": "2016-01-12",
+    "obsolete": "very",
     "test_suites": [
       "es5",
       "es6",
-      "esnext",
+      "esintl",
       "non-standard"
     ]
   },
@@ -157,11 +158,12 @@
     "family": "Chakra",
     "short": "IE 8",
     "release": "2009-03-19",
-    "obsolete": true,
+    "retire": "2016-01-12",
+    "obsolete": "very",
     "test_suites": [
       "es5",
       "es6",
-      "esnext",
+      "esintl",
       "non-standard"
     ]
   },
@@ -170,14 +172,16 @@
     "family": "Chakra",
     "short": "IE 9",
     "release": "2011-03-14",
-    "obsolete": true
+    "retire": "2016-01-12",
+    "obsolete": "very"
   },
   "ie10": {
     "full": "Internet Explorer",
     "family": "Chakra",
     "short": "IE 10",
     "release": "2012-10-26",
-    "obsolete": true
+    "retire": "2016-01-12",
+    "obsolete": "very"
   },
   "ie11": {
     "full": "Internet Explorer",

--- a/environments.json
+++ b/environments.json
@@ -148,7 +148,6 @@
     "obsolete": "very",
     "test_suites": [
       "es5",
-      "esintl",
       "non-standard"
     ]
   },
@@ -188,6 +187,7 @@
     "test_suites": [
       "es5",
       "es6",
+      "es2016plus",
       "esintl",
       "non-standard"
     ]

--- a/environments.json
+++ b/environments.json
@@ -148,7 +148,6 @@
     "obsolete": "very",
     "test_suites": [
       "es5",
-      "es6",
       "esintl",
       "non-standard"
     ]
@@ -159,10 +158,9 @@
     "short": "IE 8",
     "release": "2009-03-19",
     "retire": "2016-01-12",
-    "obsolete": "very",
+    "obsolete": true,
     "test_suites": [
       "es5",
-      "es6",
       "esintl",
       "non-standard"
     ]
@@ -173,7 +171,12 @@
     "short": "IE 9",
     "release": "2011-03-14",
     "retire": "2016-01-12",
-    "obsolete": "very"
+    "obsolete": true,
+    "test_suites": [
+      "es5",
+      "esintl",
+      "non-standard"
+    ]
   },
   "ie10": {
     "full": "Internet Explorer",
@@ -181,7 +184,13 @@
     "short": "IE 10",
     "release": "2012-10-26",
     "retire": "2016-01-12",
-    "obsolete": "very"
+    "obsolete": true,
+    "test_suites": [
+      "es5",
+      "es6",
+      "esintl",
+      "non-standard"
+    ]
   },
   "ie11": {
     "full": "Internet Explorer",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -110,6 +110,7 @@
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20161024">Closure</abbr></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
+<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -167,7 +168,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="59">2016 features</td>
+      <tr class="category"><td colspan="60">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -175,6 +176,7 @@
 <td class="tally" data-browser="closure" data-tally="1">3/3</td>
 <td class="tally" data-browser="typescript" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.6666666666666666">0/3</td>
@@ -237,6 +239,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -299,6 +302,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -366,6 +370,7 @@ return true;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -425,6 +430,7 @@ return true;
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
@@ -491,6 +497,7 @@ return [1, 2, 3].includes(1)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -575,6 +582,7 @@ return 24;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -642,6 +650,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -695,7 +704,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="59">2016 misc</td>
+<tr class="category"><td colspan="60">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -713,6 +722,7 @@ return true;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -788,6 +798,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -855,6 +866,7 @@ return true;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -918,6 +930,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -982,6 +995,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1051,6 +1065,7 @@ return passed;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1122,6 +1137,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1175,7 +1191,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="59">2017 features</td>
+<tr class="category"><td colspan="60">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1183,6 +1199,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/4</td>
@@ -1248,6 +1265,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1317,6 +1335,7 @@ return Array.isArray(e)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1387,6 +1406,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1452,6 +1472,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1511,6 +1532,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -1578,6 +1600,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1645,6 +1668,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1704,6 +1728,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -1766,6 +1791,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1828,6 +1854,7 @@ return Math.min(1,2,3,) === 1;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1887,6 +1914,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="closure" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally" data-browser="typescript" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.7333333333333333">0/15</td>
@@ -1960,6 +1988,7 @@ p.then(function(result) {
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2033,6 +2062,7 @@ p.catch(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2096,6 +2126,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2159,6 +2190,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2228,6 +2260,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2299,6 +2332,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2362,6 +2396,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2430,6 +2465,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2493,6 +2529,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2566,6 +2603,7 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2639,6 +2677,7 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2710,6 +2749,7 @@ p.then(function(result) {
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2775,6 +2815,7 @@ return passed;
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2837,6 +2878,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2908,6 +2950,7 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2967,6 +3010,7 @@ p.then(function(result) {
 <td class="tally" data-browser="closure" data-tally="0">0/17</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/17</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/17</td>
@@ -3029,6 +3073,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3091,6 +3136,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3153,6 +3199,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3215,6 +3262,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3277,6 +3325,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3339,6 +3388,7 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3401,6 +3451,7 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3463,6 +3514,7 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3525,6 +3577,7 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3587,6 +3640,7 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3649,6 +3703,7 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3711,6 +3766,7 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3773,6 +3829,7 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3835,6 +3892,7 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3897,6 +3955,7 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3959,6 +4018,7 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4021,6 +4081,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4074,7 +4135,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="59">2017 misc</td>
+<tr class="category"><td colspan="60">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -4090,6 +4151,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4155,6 +4217,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4220,6 +4283,7 @@ return (function(){
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4273,7 +4337,7 @@ return (function(){
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="59">2017 annex b</td>
+<tr class="category"><td colspan="60">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -4281,6 +4345,7 @@ return (function(){
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
@@ -4348,6 +4413,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4416,6 +4482,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4484,6 +4551,7 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4551,6 +4619,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4619,6 +4688,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4687,6 +4757,7 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4756,6 +4827,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4825,6 +4897,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4895,6 +4968,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4962,6 +5036,7 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5028,6 +5103,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5097,6 +5173,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5166,6 +5243,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5236,6 +5314,7 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5303,6 +5382,7 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5369,6 +5449,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5428,6 +5509,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5494,6 +5576,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5560,6 +5643,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5631,6 +5715,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5702,6 +5787,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5765,7 +5851,8 @@ return i === 0;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no" data-browser="ie11">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
@@ -5818,7 +5905,7 @@ return i === 0;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="59">2018 features</td>
+<tr class="category"><td colspan="60">2018 features</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -5836,6 +5923,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -5765,7 +5765,7 @@ return i === 0;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes" data-browser="ie11">Yes</td>
+<td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -110,8 +110,6 @@
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20161024">Closure</abbr></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
-<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -169,7 +167,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="61">2016 features</td>
+      <tr class="category"><td colspan="59">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -177,8 +175,6 @@
 <td class="tally" data-browser="closure" data-tally="1">3/3</td>
 <td class="tally" data-browser="typescript" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.6666666666666666">0/3</td>
@@ -241,8 +237,6 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -305,8 +299,6 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -374,8 +366,6 @@ return true;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -435,8 +425,6 @@ return true;
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
@@ -503,8 +491,6 @@ return [1, 2, 3].includes(1)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -589,8 +575,6 @@ return 24;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -658,8 +642,6 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -713,7 +695,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="61">2016 misc</td>
+<tr class="category"><td colspan="59">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -731,8 +713,6 @@ return true;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -808,8 +788,6 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -877,8 +855,6 @@ return true;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -942,8 +918,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1008,8 +982,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1079,8 +1051,6 @@ return passed;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1152,8 +1122,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1207,7 +1175,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="61">2017 features</td>
+<tr class="category"><td colspan="59">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1215,8 +1183,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/4</td>
@@ -1282,8 +1248,6 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1353,8 +1317,6 @@ return Array.isArray(e)
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1425,8 +1387,6 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1492,8 +1452,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1553,8 +1511,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -1622,8 +1578,6 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1691,8 +1645,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1752,8 +1704,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -1816,8 +1766,6 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1880,8 +1828,6 @@ return Math.min(1,2,3,) === 1;
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1941,8 +1887,6 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="closure" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally" data-browser="typescript" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.7333333333333333">0/15</td>
@@ -2016,8 +1960,6 @@ p.then(function(result) {
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2091,8 +2033,6 @@ p.catch(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2156,8 +2096,6 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2221,8 +2159,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2292,8 +2228,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2365,8 +2299,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2430,8 +2362,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2500,8 +2430,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2565,8 +2493,6 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2640,8 +2566,6 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2715,8 +2639,6 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2788,8 +2710,6 @@ p.then(function(result) {
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2855,8 +2775,6 @@ return passed;
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2919,8 +2837,6 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2992,8 +2908,6 @@ p.then(function(result) {
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3053,8 +2967,6 @@ p.then(function(result) {
 <td class="tally" data-browser="closure" data-tally="0">0/17</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/17</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/17</td>
@@ -3117,8 +3029,6 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3181,8 +3091,6 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3245,8 +3153,6 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3309,8 +3215,6 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3373,8 +3277,6 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3437,8 +3339,6 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3501,8 +3401,6 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3565,8 +3463,6 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3629,8 +3525,6 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3693,8 +3587,6 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3757,8 +3649,6 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3821,8 +3711,6 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3885,8 +3773,6 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3949,8 +3835,6 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4013,8 +3897,6 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4077,8 +3959,6 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4141,8 +4021,6 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4196,7 +4074,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="61">2017 misc</td>
+<tr class="category"><td colspan="59">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -4212,8 +4090,6 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4279,8 +4155,6 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4346,8 +4220,6 @@ return (function(){
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4401,7 +4273,7 @@ return (function(){
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="61">2017 annex b</td>
+<tr class="category"><td colspan="59">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -4409,8 +4281,6 @@ return (function(){
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
@@ -4478,8 +4348,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4548,8 +4416,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4618,8 +4484,6 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4687,8 +4551,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4757,8 +4619,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4827,8 +4687,6 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4898,8 +4756,6 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4969,8 +4825,6 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5041,8 +4895,6 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5110,8 +4962,6 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5178,8 +5028,6 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5249,8 +5097,6 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5320,8 +5166,6 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5392,8 +5236,6 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5461,8 +5303,6 @@ return true;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5529,8 +5369,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5590,8 +5428,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5658,8 +5494,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5726,8 +5560,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5799,8 +5631,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5872,8 +5702,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5937,8 +5765,6 @@ return i === 0;
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5992,7 +5818,7 @@ return i === 0;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="61">2018 features</td>
+<tr class="category"><td colspan="59">2018 features</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -6010,8 +5836,6 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -116,10 +116,6 @@
 <th class="platform konq49 desktop obsolete" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></a></th>
 <th class="platform konq413 desktop obsolete" data-browser="konq413"><a href="#konq413" class="browser-name"><abbr title="Konqueror 4.13">Konq 4.13</abbr></a></th>
 <th class="platform konq414 desktop" data-browser="konq414"><a href="#konq414" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr></a><a href="#khtml-note"><sup>[2]</sup></a></th>
-<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
-<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
-<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -182,10 +178,6 @@
 <td class="tally obsolete" data-browser="konq49" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="konq414" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">5/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -247,10 +239,6 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -314,10 +302,6 @@ return value === 1;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -379,10 +363,6 @@ return { a: true, }.a === true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -444,10 +424,6 @@ return [1,].length === 1;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -509,10 +485,6 @@ return ({ if: 1 }).if === 1;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -564,7 +536,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="63" class="separator"></th>
+<tr><th colspan="59" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -573,10 +545,6 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="konq49" data-tally="0.23076923076923078" style="background-color:hsl(27,75%,50%)">3/13</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">13/13</td>
 <td class="tally" data-browser="konq414" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0.15384615384615385" style="background-color:hsl(18,79%,50%)">2/13</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">13/13</td>
 <td class="tally" data-browser="ie11" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">13/13</td>
@@ -640,10 +608,6 @@ return typeof Object.create == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -707,10 +671,6 @@ return typeof Object.defineProperty == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="yes obsolete" data-browser="ie8">Yes<a href="#define-property-ie-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -774,10 +734,6 @@ return typeof Object.defineProperties == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -841,10 +797,6 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -908,10 +860,6 @@ return typeof Object.keys == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -975,10 +923,6 @@ return typeof Object.seal == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1042,10 +986,6 @@ return typeof Object.freeze == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1109,10 +1049,6 @@ return typeof Object.preventExtensions == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1176,10 +1112,6 @@ return typeof Object.isSealed == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1243,10 +1175,6 @@ return typeof Object.isFrozen == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1310,10 +1238,6 @@ return typeof Object.isExtensible == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1377,10 +1301,6 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="yes obsolete" data-browser="ie8">Yes<a href="#get-own-property-descriptor-ie-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1444,10 +1364,6 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1506,10 +1422,6 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally obsolete" data-browser="konq49" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="konq414" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">12/12</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">12/12</td>
 <td class="tally" data-browser="ie11" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">12/12</td>
@@ -1573,10 +1485,6 @@ return typeof Array.isArray == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1640,10 +1548,6 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1707,10 +1611,6 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1768,16 +1668,12 @@ return typeof Array.prototype.every == &apos;function&apos;;
 function () {
 return typeof Array.prototype.every == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1835,16 +1731,12 @@ return typeof Array.prototype.some == &apos;function&apos;;
 function () {
 return typeof Array.prototype.some == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1902,16 +1794,12 @@ return typeof Array.prototype.forEach == &apos;function&apos;;
 function () {
 return typeof Array.prototype.forEach == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1969,16 +1857,12 @@ return typeof Array.prototype.map == &apos;function&apos;;
 function () {
 return typeof Array.prototype.map == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2036,16 +1920,12 @@ return typeof Array.prototype.filter == &apos;function&apos;;
 function () {
 return typeof Array.prototype.filter == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2103,16 +1983,12 @@ return typeof Array.prototype.reduce == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduce == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2170,16 +2046,12 @@ return typeof Array.prototype.reduceRight == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduceRight == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2283,10 +2155,6 @@ return true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2360,10 +2228,6 @@ try {
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2422,10 +2286,6 @@ try {
 <td class="tally obsolete" data-browser="konq49" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">2/2</td>
 <td class="tally" data-browser="konq414" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -2489,10 +2349,6 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2556,10 +2412,6 @@ return typeof String.prototype.trim == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2618,10 +2470,6 @@ return typeof String.prototype.trim == 'function';
 <td class="tally obsolete" data-browser="konq49" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -2685,10 +2533,6 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2752,10 +2596,6 @@ return typeof Date.now == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2827,10 +2667,6 @@ try {
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2850,7 +2686,7 @@ try {
 <td class="yes unstable" data-browser="firefox56">Yes</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
-<td class="yes obsolete" data-browser="opera12">Yes<a href="#Date.prototype.toJSON-OP11_60-OP11_64-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="opera12">Yes<a href="#Date.prototype.toJSON-OP11_60-OP11_64-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome51">Yes</td>
 <td class="yes obsolete" data-browser="chrome52">Yes</td>
@@ -2894,10 +2730,6 @@ return typeof Function.prototype.bind == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2961,10 +2793,6 @@ return typeof JSON == 'object';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3016,7 +2844,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="63" class="separator"></th>
+<tr><th colspan="59" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -3025,10 +2853,6 @@ return typeof JSON == 'object';
 <td class="tally obsolete" data-browser="konq49" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -3093,10 +2917,6 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3161,10 +2981,6 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3229,10 +3045,6 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3291,10 +3103,6 @@ return result;
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="ie11" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
@@ -3358,10 +3166,6 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3425,10 +3229,6 @@ return parseInt('010') === 10;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3490,10 +3290,6 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3555,10 +3351,6 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3621,10 +3413,6 @@ return _\u200c\u200d;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3688,10 +3476,6 @@ return true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3761,10 +3545,6 @@ return result;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3832,10 +3612,6 @@ catch(e) {
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="unknown obsolete" data-browser="ie7">?</td>
-<td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3894,10 +3670,6 @@ catch(e) {
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0">0/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">19/19</td>
 <td class="tally" data-browser="ie11" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">19/19</td>
@@ -3964,10 +3736,6 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4030,16 +3798,12 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="edge12">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes unstable" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="edge12">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -4098,10 +3862,6 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4180,10 +3940,6 @@ return test(String, &apos;&apos;)
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4248,10 +4004,6 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4314,10 +4066,6 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4384,10 +4132,6 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4454,10 +4198,6 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4526,10 +4266,6 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4595,10 +4331,6 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4662,10 +4394,6 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4730,10 +4458,6 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4802,10 +4526,6 @@ return (function(x){
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4868,10 +4588,6 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4934,10 +4650,6 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5000,10 +4712,6 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5066,10 +4774,6 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5132,10 +4836,6 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5198,10 +4898,6 @@ return typeof foo === &apos;function&apos;;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5257,7 +4953,7 @@ return typeof foo === &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="khtml-note">  <sup>[2]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="define-property-ie-note">  <sup>[3]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="get-own-property-descriptor-ie-note">  <sup>[4]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="sparse_arrays-note">  <sup>[5]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[6]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="strict-mode-ie10-note">  <sup>[7]</sup> IE10 PP2 fails this test.</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="khtml-note">  <sup>[2]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="sparse_arrays-note">  <sup>[3]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[4]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="strict-mode-ie10-note">  <sup>[5]</sup> IE10 PP2 fails this test.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/es5/index.html
+++ b/es5/index.html
@@ -116,6 +116,9 @@
 <th class="platform konq49 desktop obsolete" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></a></th>
 <th class="platform konq413 desktop obsolete" data-browser="konq413"><a href="#konq413" class="browser-name"><abbr title="Konqueror 4.13">Konq 4.13</abbr></a></th>
 <th class="platform konq414 desktop" data-browser="konq414"><a href="#konq414" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr></a><a href="#khtml-note"><sup>[2]</sup></a></th>
+<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
+<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
+<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -178,6 +181,9 @@
 <td class="tally obsolete" data-browser="konq49" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="konq414" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">5/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -239,6 +245,9 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -302,6 +311,9 @@ return value === 1;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -363,6 +375,9 @@ return { a: true, }.a === true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -424,6 +439,9 @@ return [1,].length === 1;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -485,6 +503,9 @@ return ({ if: 1 }).if === 1;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -536,7 +557,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="59" class="separator"></th>
+<tr><th colspan="62" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -545,6 +566,9 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="konq49" data-tally="0.23076923076923078" style="background-color:hsl(27,75%,50%)">3/13</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">13/13</td>
 <td class="tally" data-browser="konq414" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0.15384615384615385" style="background-color:hsl(18,79%,50%)">2/13</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">13/13</td>
 <td class="tally" data-browser="ie11" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">13/13</td>
@@ -608,6 +632,9 @@ return typeof Object.create == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -671,6 +698,9 @@ return typeof Object.defineProperty == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes<a href="#define-property-ie-note"><sup>[3]</sup></a></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -734,6 +764,9 @@ return typeof Object.defineProperties == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -797,6 +830,9 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -860,6 +896,9 @@ return typeof Object.keys == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -923,6 +962,9 @@ return typeof Object.seal == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -986,6 +1028,9 @@ return typeof Object.freeze == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1049,6 +1094,9 @@ return typeof Object.preventExtensions == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1112,6 +1160,9 @@ return typeof Object.isSealed == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1175,6 +1226,9 @@ return typeof Object.isFrozen == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1238,6 +1292,9 @@ return typeof Object.isExtensible == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1301,6 +1358,9 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes<a href="#get-own-property-descriptor-ie-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1364,6 +1424,9 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1422,6 +1485,9 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally obsolete" data-browser="konq49" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="konq414" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">12/12</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">12/12</td>
 <td class="tally" data-browser="ie11" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">12/12</td>
@@ -1485,6 +1551,9 @@ return typeof Array.isArray == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1548,6 +1617,9 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1611,6 +1683,9 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1668,12 +1743,15 @@ return typeof Array.prototype.every == &apos;function&apos;;
 function () {
 return typeof Array.prototype.every == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1731,12 +1809,15 @@ return typeof Array.prototype.some == &apos;function&apos;;
 function () {
 return typeof Array.prototype.some == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1794,12 +1875,15 @@ return typeof Array.prototype.forEach == &apos;function&apos;;
 function () {
 return typeof Array.prototype.forEach == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1857,12 +1941,15 @@ return typeof Array.prototype.map == &apos;function&apos;;
 function () {
 return typeof Array.prototype.map == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1920,12 +2007,15 @@ return typeof Array.prototype.filter == &apos;function&apos;;
 function () {
 return typeof Array.prototype.filter == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1983,12 +2073,15 @@ return typeof Array.prototype.reduce == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduce == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2046,12 +2139,15 @@ return typeof Array.prototype.reduceRight == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduceRight == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="konq43">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2155,6 +2251,9 @@ return true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2228,6 +2327,9 @@ try {
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2286,6 +2388,9 @@ try {
 <td class="tally obsolete" data-browser="konq49" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">2/2</td>
 <td class="tally" data-browser="konq414" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -2349,6 +2454,9 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2412,6 +2520,9 @@ return typeof String.prototype.trim == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2470,6 +2581,9 @@ return typeof String.prototype.trim == 'function';
 <td class="tally obsolete" data-browser="konq49" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -2533,6 +2647,9 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2596,6 +2713,9 @@ return typeof Date.now == 'function';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2667,6 +2787,9 @@ try {
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2686,7 +2809,7 @@ try {
 <td class="yes unstable" data-browser="firefox56">Yes</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
-<td class="yes obsolete" data-browser="opera12">Yes<a href="#Date.prototype.toJSON-OP11_60-OP11_64-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="opera12">Yes<a href="#Date.prototype.toJSON-OP11_60-OP11_64-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome51">Yes</td>
 <td class="yes obsolete" data-browser="chrome52">Yes</td>
@@ -2730,6 +2853,9 @@ return typeof Function.prototype.bind == 'function';
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2793,6 +2919,9 @@ return typeof JSON == 'object';
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2844,7 +2973,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="59" class="separator"></th>
+<tr><th colspan="62" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -2853,6 +2982,9 @@ return typeof JSON == 'object';
 <td class="tally obsolete" data-browser="konq49" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -2917,6 +3049,9 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2981,6 +3116,9 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3045,6 +3183,9 @@ return result;
 <td class="yes obsolete" data-browser="konq49">Yes</td>
 <td class="yes obsolete" data-browser="konq413">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3103,6 +3244,9 @@ return result;
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="ie11" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
@@ -3166,6 +3310,9 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3229,6 +3376,9 @@ return parseInt('010') === 10;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3290,6 +3440,9 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3351,6 +3504,9 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3413,6 +3569,9 @@ return _\u200c\u200d;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3476,6 +3635,9 @@ return true;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3545,6 +3707,9 @@ return result;
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3612,6 +3777,9 @@ catch(e) {
 <td class="unknown obsolete" data-browser="konq49">?</td>
 <td class="unknown obsolete" data-browser="konq413">?</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="unknown obsolete" data-browser="ie8">?</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3670,6 +3838,9 @@ catch(e) {
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="konq413" data-tally="0">0/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">19/19</td>
 <td class="tally" data-browser="ie11" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">19/19</td>
@@ -3736,6 +3907,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3798,12 +3972,15 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="edge12">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
-<td class="yes unstable" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="edge12">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes unstable" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox47">Yes</td>
 <td class="yes obsolete" data-browser="firefox48">Yes</td>
@@ -3862,6 +4039,9 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3940,6 +4120,9 @@ return test(String, &apos;&apos;)
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4004,6 +4187,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4066,6 +4252,9 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4132,6 +4321,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4198,6 +4390,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4266,6 +4461,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4331,6 +4529,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4394,6 +4595,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4458,6 +4662,9 @@ return true;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4526,6 +4733,9 @@ return (function(x){
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4588,6 +4798,9 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4650,6 +4863,9 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4712,6 +4928,9 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4774,6 +4993,9 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4836,6 +5058,9 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4898,6 +5123,9 @@ return typeof foo === &apos;function&apos;;
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="konq413">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4953,7 +5181,7 @@ return typeof foo === &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="khtml-note">  <sup>[2]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="sparse_arrays-note">  <sup>[3]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[4]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="strict-mode-ie10-note">  <sup>[5]</sup> IE10 PP2 fails this test.</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="khtml-note">  <sup>[2]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="define-property-ie-note">  <sup>[3]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="get-own-property-descriptor-ie-note">  <sup>[4]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="sparse_arrays-note">  <sup>[5]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[6]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="strict-mode-ie10-note">  <sup>[7]</sup> IE10 PP2 fails this test.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/es6/index.html
+++ b/es6/index.html
@@ -149,10 +149,6 @@
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es6shim compiler" data-browser="es6shim"><a href="#es6shim" class="browser-name"><abbr title="es6-shim">es6-shim</abbr></a></th>
 <th class="platform konq414 desktop" data-browser="konq414"><a href="#konq414" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr></a><a href="#khtml-note"><sup>[3]</sup></a></th>
-<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
-<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
-<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -216,7 +212,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="72">Optimisation</td>
+      <tr class="category"><td colspan="68">Optimisation</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#test-proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/2</td>
@@ -227,10 +223,6 @@
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -308,10 +300,6 @@ return (function f(n){
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -396,10 +384,6 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -459,7 +443,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">Syntax</td>
+<tr class="category"><td colspan="68">Syntax</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-default_function_parameters"><span><a class="anchor" href="#test-default_function_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">default function parameters</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -470,10 +454,6 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally" data-browser="typescript" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/7</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.8571428571428571">0/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="1">0/7</td>
@@ -545,10 +525,6 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -620,10 +596,6 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -695,10 +667,6 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -777,10 +745,6 @@ return (function (a = &quot;baz&quot;, b = &quot;qux&quot;, c = &quot;quux&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -862,10 +826,6 @@ return (function(x = 1) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -942,10 +902,6 @@ return (function(a=function(){
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -1019,10 +975,6 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -1091,10 +1043,6 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -1168,10 +1116,6 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1243,10 +1187,6 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1326,10 +1266,6 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1407,10 +1343,6 @@ return (function (...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1484,10 +1416,6 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1556,10 +1484,6 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.26666666666666666" style="background-color:hsl(32,74%,50%)">4/15</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/15</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="0.9333333333333333">12/15</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">15/15</td>
@@ -1631,10 +1555,6 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1706,10 +1626,6 @@ return [...[1, 2, 3]][2] === 3;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1782,10 +1698,6 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1858,10 +1770,6 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1933,10 +1841,6 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2008,10 +1912,6 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2083,10 +1983,6 @@ return Array(...&quot;&#x20BB7;&#x20BB6;&quot;)[0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2158,10 +2054,6 @@ return [...&quot;&#x20BB7;&#x20BB6;&quot;][0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2234,10 +2126,6 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2310,10 +2198,6 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2386,10 +2270,6 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2462,10 +2342,6 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2538,10 +2414,6 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2614,10 +2486,6 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2693,10 +2561,6 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2765,10 +2629,6 @@ try {
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -2841,10 +2701,6 @@ return ({ [x]: 1 }).y === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2917,10 +2773,6 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2992,10 +2844,6 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3067,10 +2915,6 @@ return ({ &quot;foo bar&quot;() { return 4; } })[&quot;foo bar&quot;]() === 4;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3143,10 +2987,6 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3225,10 +3065,6 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3297,10 +3133,6 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/9</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/9</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.7777777777777778">6/9</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
@@ -3374,10 +3206,6 @@ for (var item of arr)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3453,10 +3281,6 @@ return count === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3531,10 +3355,6 @@ return str === &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3609,10 +3429,6 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3689,10 +3505,6 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3769,10 +3581,6 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3849,10 +3657,6 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3929,10 +3733,6 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4011,10 +3811,6 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4083,10 +3879,6 @@ return closed;
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -4158,10 +3950,6 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4233,10 +4021,6 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4308,10 +4092,6 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4383,10 +4163,6 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4455,10 +4231,6 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -4532,10 +4304,6 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4611,10 +4379,6 @@ return `${a}` === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4697,10 +4461,6 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4774,10 +4534,6 @@ return (function(parts) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4854,10 +4610,6 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4926,10 +4678,6 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.4" style="background-color:hsl(48,68%,50%)" data-flagged-tally="0.8">2/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -5003,10 +4751,6 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5081,10 +4825,6 @@ return result === &apos;yy&apos; &amp;&amp; re.lastIndex === 5;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5156,10 +4896,6 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5231,10 +4967,6 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5306,10 +5038,6 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5378,10 +5106,6 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="tally" data-browser="typescript" data-tally="0.6818181818181818" style="background-color:hsl(81,56%,50%)">15/22</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/22</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/22</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/22</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/22</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/22</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/22</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.9090909090909091">0/22</td>
@@ -5454,10 +5178,6 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5530,10 +5250,6 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5606,10 +5322,6 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5682,10 +5394,6 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5758,10 +5466,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5834,10 +5538,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5910,10 +5610,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5990,10 +5686,6 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6066,10 +5758,6 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6142,10 +5830,6 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6220,10 +5904,6 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6296,10 +5976,6 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6385,10 +6061,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6462,10 +6134,6 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6538,10 +6206,6 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6616,10 +6280,6 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6693,10 +6353,6 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6770,10 +6426,6 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6853,10 +6505,6 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6931,10 +6579,6 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7009,10 +6653,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7093,10 +6733,6 @@ return a === 1 &amp;&amp; b === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7165,10 +6801,6 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally" data-browser="typescript" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.9583333333333334">0/24</td>
@@ -7242,10 +6874,6 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7319,10 +6947,6 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7396,10 +7020,6 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7473,10 +7093,6 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7550,10 +7166,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7627,10 +7239,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7704,10 +7312,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7785,10 +7389,6 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7861,10 +7461,6 @@ return ([a, b] = iterable) === iterable;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7938,10 +7534,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8015,10 +7607,6 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8092,10 +7680,6 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8171,10 +7755,6 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8248,10 +7828,6 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8324,10 +7900,6 @@ return ({a,b} = obj) === obj;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8406,10 +7978,6 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8483,10 +8051,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8573,10 +8137,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8650,10 +8210,6 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8729,10 +8285,6 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8808,10 +8360,6 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8885,10 +8433,6 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8962,10 +8506,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9041,10 +8581,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9113,10 +8649,6 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally" data-browser="typescript" data-tally="0.6521739130434783" style="background-color:hsl(78,57%,50%)">15/23</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/23</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/23</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/23</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/23</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/23</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/23</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.9565217391304348">0/23</td>
@@ -9190,10 +8722,6 @@ return function([a, , [b], c]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9267,10 +8795,6 @@ return function([a, , b]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9344,10 +8868,6 @@ return function([a, b, c]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9421,10 +8941,6 @@ return function([c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9498,10 +9014,6 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9575,10 +9087,6 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9652,10 +9160,6 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9732,10 +9236,6 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9809,10 +9309,6 @@ return function([a,]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9886,10 +9382,6 @@ return function({c, x:d, e}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9964,10 +9456,6 @@ return function({toFixed}, {slice}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10041,10 +9529,6 @@ return function({a,}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10124,10 +9608,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10202,10 +9682,6 @@ return function({ [qux]: grault }) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10280,10 +9756,6 @@ return function([e, {x:f, g}], {h, x:[i]}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10358,10 +9830,6 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10436,10 +9904,6 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10511,10 +9975,6 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10589,10 +10049,6 @@ return function([a, ...b], [c, ...d]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10666,10 +10122,6 @@ return function ([],{}){
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10745,10 +10197,6 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5},
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10825,10 +10273,6 @@ return (function({a=function(){
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10902,10 +10346,6 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10974,10 +10414,6 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -11049,10 +10485,6 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11125,10 +10557,6 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11197,10 +10625,6 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -11279,10 +10703,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11363,10 +10783,6 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11426,7 +10842,7 @@ try {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">Bindings</td>
+<tr class="category"><td colspan="68">Bindings</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-const"><span><a class="anchor" href="#test-const">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">const</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
@@ -11437,10 +10853,6 @@ try {
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/16</td>
 <td class="tally" data-browser="konq414" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
@@ -11513,10 +10925,6 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11590,10 +10998,6 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11670,10 +11074,6 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11750,10 +11150,6 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11827,10 +11223,6 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11906,10 +11298,6 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11985,10 +11373,6 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12064,10 +11448,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12141,10 +11521,6 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12219,10 +11595,6 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12300,10 +11672,6 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12381,10 +11749,6 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12459,10 +11823,6 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12539,10 +11899,6 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12619,10 +11975,6 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12699,10 +12051,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12771,10 +12119,6 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
@@ -12847,10 +12191,6 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12924,10 +12264,6 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13004,10 +12340,6 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13081,10 +12413,6 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13160,10 +12488,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13246,10 +12570,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -13323,10 +12643,6 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13401,10 +12717,6 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13482,10 +12794,6 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13560,10 +12868,6 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13640,10 +12944,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13727,10 +13027,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -13811,10 +13107,6 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13874,7 +13166,7 @@ return true;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">Functions</td>
+<tr class="category"><td colspan="68">Functions</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-arrow_functions"><span><a class="anchor" href="#test-arrow_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions">arrow functions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
@@ -13885,10 +13177,6 @@ return true;
 <td class="tally" data-browser="typescript" data-tally="0.6923076923076923" style="background-color:hsl(83,55%,50%)">9/13</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/13</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/13</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)" data-flagged-tally="0.7692307692307693">8/13</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">13/13</td>
@@ -13960,10 +13248,6 @@ return (() =&gt; 5)() === 5;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14036,10 +13320,6 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14112,10 +13392,6 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14189,10 +13465,6 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14266,10 +13538,6 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14343,10 +13611,6 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14419,10 +13683,6 @@ return f(6) === 5;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14496,10 +13756,6 @@ return (() =&gt; {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14573,10 +13829,6 @@ return (() =&gt; {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14649,10 +13901,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14737,10 +13985,6 @@ return new C instanceof C &amp;&amp; received === &apos;foo&apos;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14823,10 +14067,6 @@ return arrow() === &quot;quux&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14901,10 +14141,6 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14973,10 +14209,6 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="tally" data-browser="typescript" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/24</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.875">0/24</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">24/24</td>
@@ -15049,10 +14281,6 @@ return typeof C === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15130,10 +14358,6 @@ return C === c1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15205,10 +14429,6 @@ return typeof class C {} === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15280,10 +14500,6 @@ return typeof class {} === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15359,10 +14575,6 @@ return C.prototype.constructor === C
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15438,10 +14650,6 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15517,10 +14725,6 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15597,10 +14801,6 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15680,10 +14880,6 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15759,10 +14955,6 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15839,10 +15031,6 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15920,10 +15108,6 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16001,10 +15185,6 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16082,10 +15262,6 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16163,10 +15339,6 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16243,10 +15415,6 @@ return C === undefined &amp;&amp; M();
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16324,10 +15492,6 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16403,10 +15567,6 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16481,10 +15641,6 @@ return (0,C.method)();
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16562,10 +15718,6 @@ catch(e) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16640,10 +15792,6 @@ return new C() instanceof B
 <td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16718,10 +15866,6 @@ return new C() instanceof B
 <td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16797,10 +15941,6 @@ return Function.prototype.isPrototypeOf(C)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16884,10 +16024,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16956,10 +16092,6 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.75">0/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
@@ -17039,10 +16171,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17120,10 +16248,6 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17202,10 +16326,6 @@ return new C().quux(&quot;bar&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17283,10 +16403,6 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17366,10 +16482,6 @@ return obj.qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17449,10 +16561,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17534,10 +16642,6 @@ return obj.qux() === &quot;barley&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17621,10 +16725,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17693,10 +16793,6 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0">0/27</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/27</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/27</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/27</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/27</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/27</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/27</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.9259259259259259">0/27</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">27/27</td>
@@ -17778,10 +16874,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17863,10 +16955,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17948,10 +17036,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18031,10 +17115,6 @@ catch (e) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18114,10 +17194,6 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18198,10 +17274,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18286,10 +17358,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18373,10 +17441,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18459,10 +17523,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18544,10 +17604,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18626,10 +17682,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18710,10 +17762,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18794,10 +17842,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18878,10 +17922,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18962,10 +18002,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19048,10 +18084,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19134,10 +18166,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19220,10 +18248,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19307,10 +18331,6 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19398,10 +18418,6 @@ return closed === &apos;ab&apos;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19488,10 +18504,6 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19575,10 +18587,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19662,10 +18670,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19750,10 +18754,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19837,10 +18837,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19925,10 +18921,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20009,10 +19001,6 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20072,7 +19060,7 @@ try {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">Built-ins</td>
+<tr class="category"><td colspan="68">Built-ins</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-typed_arrays"><span><a class="anchor" href="#test-typed_arrays">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects">typed arrays</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/46</td>
@@ -20083,10 +19071,6 @@ try {
 <td class="tally" data-browser="typescript" data-tally="0.9782608695652174" style="background-color:hsl(117,42%,50%)">45/46</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/46</td>
 <td class="tally" data-browser="konq414" data-tally="0.17391304347826086" style="background-color:hsl(20,78%,50%)">8/46</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/46</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/46</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/46</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally" data-browser="ie11" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9130434782608695" style="background-color:hsl(109,45%,50%)">42/46</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9565217391304348" style="background-color:hsl(114,43%,50%)">44/46</td>
@@ -20160,10 +19144,6 @@ return view[0] === -0x80;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20237,10 +19217,6 @@ return view[0] === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20314,10 +19290,6 @@ return view[0] === 0xFF;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20391,10 +19363,6 @@ return view[0] === -0x8000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20468,10 +19436,6 @@ return view[0] === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20545,10 +19509,6 @@ return view[0] === -0x80000000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20622,10 +19582,6 @@ return view[0] === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20699,10 +19655,6 @@ return view[0] === 0.10000000149011612;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20776,10 +19728,6 @@ return view[0] === 0.1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20854,10 +19802,6 @@ return view.getInt8(0) === -0x80;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20932,10 +19876,6 @@ return view.getUint8(0) === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21010,10 +19950,6 @@ return view.getInt16(0) === -0x8000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21088,10 +20024,6 @@ return view.getUint16(0) === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21166,10 +20098,6 @@ return view.getInt32(0) === -0x80000000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21244,10 +20172,6 @@ return view.getUint32(0) === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21322,10 +20246,6 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21400,10 +20320,6 @@ return view.getFloat64(0) === 0.1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21475,10 +20391,6 @@ return typeof ArrayBuffer[Symbol.species] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21573,10 +20485,6 @@ return constructors.every(function (constructor) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -21663,10 +20571,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -21761,10 +20665,6 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21844,10 +20744,6 @@ typeof Float64Array.from === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21927,10 +20823,6 @@ typeof Float64Array.of === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22010,10 +20902,6 @@ typeof Float64Array.prototype.subarray === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22093,10 +20981,6 @@ typeof Float64Array.prototype.join === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22176,10 +21060,6 @@ typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22259,10 +21139,6 @@ typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22342,10 +21218,6 @@ typeof Float64Array.prototype.slice === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22425,10 +21297,6 @@ typeof Float64Array.prototype.every === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22508,10 +21376,6 @@ typeof Float64Array.prototype.filter === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22591,10 +21455,6 @@ typeof Float64Array.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22674,10 +21534,6 @@ typeof Float64Array.prototype.map === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22757,10 +21613,6 @@ typeof Float64Array.prototype.reduce === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22840,10 +21692,6 @@ typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22923,10 +21771,6 @@ typeof Float64Array.prototype.reverse === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23006,10 +21850,6 @@ typeof Float64Array.prototype.some === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23089,10 +21929,6 @@ typeof Float64Array.prototype.sort === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23172,10 +22008,6 @@ typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23255,10 +22087,6 @@ typeof Float64Array.prototype.find === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23338,10 +22166,6 @@ typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23421,10 +22245,6 @@ typeof Float64Array.prototype.fill === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23504,10 +22324,6 @@ typeof Float64Array.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23587,10 +22403,6 @@ typeof Float64Array.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23670,10 +22482,6 @@ typeof Float64Array.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23753,10 +22561,6 @@ typeof Float64Array.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23836,10 +22640,6 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23908,10 +22708,6 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally" data-browser="typescript" data-tally="1">19/19</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
@@ -23988,10 +22784,6 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24068,10 +22860,6 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24149,10 +22937,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24225,10 +23009,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24310,10 +23090,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24392,10 +23168,6 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -24468,10 +23240,6 @@ return map.set(0, 0) === map;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24549,10 +23317,6 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24629,10 +23393,6 @@ return map.size === 1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24704,10 +23464,6 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24779,10 +23535,6 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24854,10 +23606,6 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24929,10 +23677,6 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25004,10 +23748,6 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25079,10 +23819,6 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25154,10 +23890,6 @@ return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25236,10 +23968,6 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25321,10 +24049,6 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25397,10 +24121,6 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25469,10 +24189,6 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally" data-browser="typescript" data-tally="1">19/19</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
@@ -25550,10 +24266,6 @@ return set.has(123);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25629,10 +24341,6 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25710,10 +24418,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25786,10 +24490,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25871,10 +24571,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25956,10 +24652,6 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -26032,10 +24724,6 @@ return set.add(0) === set;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26113,10 +24801,6 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26195,10 +24879,6 @@ return set.size === 2;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26270,10 +24950,6 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26345,10 +25021,6 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26420,10 +25092,6 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26495,10 +25163,6 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26570,10 +25234,6 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26645,10 +25305,6 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26720,10 +25376,6 @@ return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26802,10 +25454,6 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26887,10 +25535,6 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26963,10 +25607,6 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27035,10 +25675,6 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally" data-browser="typescript" data-tally="1">12/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">6/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
@@ -27115,10 +25751,6 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27195,10 +25827,6 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27276,10 +25904,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27352,10 +25976,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27437,10 +26057,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27515,10 +26131,6 @@ return m.get(f) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27597,10 +26209,6 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -27674,10 +26282,6 @@ return weakmap.set(key, 0) === weakmap;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27749,10 +26353,6 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27831,10 +26431,6 @@ return m.has(key);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27909,10 +26505,6 @@ return m.has(1) === false
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27991,10 +26583,6 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28063,10 +26651,6 @@ catch(e) {
 <td class="tally" data-browser="typescript" data-tally="1">11/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
@@ -28144,10 +26728,6 @@ return weakset.has(obj1);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28222,10 +26802,6 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28303,10 +26879,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28379,10 +26951,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28464,10 +27032,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28546,10 +27110,6 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -28623,10 +27183,6 @@ return weakset.add(obj) === weakset;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28698,10 +27254,6 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28780,10 +27332,6 @@ return s.has(key);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28857,10 +27405,6 @@ return s.has(1) === false
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28939,10 +27483,6 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29011,10 +27551,6 @@ catch(e) {
 <td class="tally" data-browser="typescript" data-tally="0">0/34</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/34</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/34</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/34</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/34</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/34</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/34</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/34</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">34/34</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">34/34</td>
@@ -29092,10 +27628,6 @@ try {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29168,10 +27700,6 @@ return !Proxy.hasOwnProperty(&apos;prototype&apos;);
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29249,10 +27777,6 @@ return proxy.foo === 5;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29330,10 +27854,6 @@ return proxy.foo === 5;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29432,10 +27952,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29515,10 +28031,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29598,10 +28110,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29700,10 +28208,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29782,10 +28286,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29864,10 +28364,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29963,10 +28459,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30045,10 +28537,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30135,10 +28623,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30223,10 +28707,6 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30348,10 +28828,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30435,10 +28911,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30538,10 +29010,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30620,10 +29088,6 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30708,10 +29172,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30795,10 +29255,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30885,10 +29341,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30969,10 +29421,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31065,10 +29513,6 @@ return true;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31150,10 +29594,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31238,10 +29678,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31322,10 +29758,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31427,10 +29859,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31512,10 +29940,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31600,10 +30024,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31683,10 +30103,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31781,10 +30197,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31864,10 +30276,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31939,10 +30347,6 @@ return Array.isArray(new Proxy([], {}));
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32014,10 +30418,6 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32086,10 +30486,6 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="tally" data-browser="typescript" data-tally="0.9" style="background-color:hsl(108,46%,50%)">18/20</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/20</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/20</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/20</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/20</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/20</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.65" style="background-color:hsl(78,57%,50%)">13/20</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">20/20</td>
@@ -32161,10 +30557,6 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32238,10 +30630,6 @@ return obj.quux === 654;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32313,10 +30701,6 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32390,10 +30774,6 @@ return !(&quot;bar&quot; in obj);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32468,10 +30848,6 @@ return desc.value === 789 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32546,10 +30922,6 @@ return obj.foo === 123 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32621,10 +30993,6 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32698,10 +31066,6 @@ return obj instanceof Array;
 <td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32774,10 +31138,6 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32851,10 +31211,6 @@ return !Object.isExtensible(obj);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32930,10 +31286,6 @@ return Reflect.ownKeys(obj).sort() + &apos;&apos; === &quot;A,B&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33013,10 +31365,6 @@ return keys.indexOf(s2) &gt;-1 &amp;&amp; keys.indexOf(s3) &gt;-1 &amp;&amp; key
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33088,10 +31436,6 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33165,10 +31509,6 @@ return Reflect.construct(function(a, b, c) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33244,10 +31584,6 @@ return Reflect.construct(function(a, b, c) {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33321,10 +31657,6 @@ return obj.y === 1 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33399,10 +31731,6 @@ return obj.length === 3 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33477,10 +31805,6 @@ return RegExp.prototype.exec.call(obj, &quot;foobarbaz&quot;)[0] === &quot;baz&q
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33554,10 +31878,6 @@ return obj() === 2 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33648,10 +31968,6 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33720,10 +32036,6 @@ function check() {
 <td class="tally" data-browser="typescript" data-tally="1">8/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
@@ -33816,10 +32128,6 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33897,10 +32205,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33977,10 +32281,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34066,10 +32366,6 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34155,10 +32451,6 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34244,10 +32536,6 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34333,10 +32621,6 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34409,10 +32693,6 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34481,10 +32761,6 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="tally" data-browser="typescript" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">8/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">2/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">12/12</td>
@@ -34560,10 +32836,6 @@ return object[symbol] === value;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34635,10 +32907,6 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34722,10 +32990,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34806,10 +33070,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34886,10 +33146,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34974,10 +33230,6 @@ return true;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35049,10 +33301,6 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35129,10 +33377,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35211,10 +33455,6 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35289,10 +33529,6 @@ return JSON.stringify(object) === &apos;{}&apos; &amp;&amp; JSON.stringify(array
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35377,10 +33613,6 @@ return testSymbolObject(objSym) &amp;&amp; testSymbolObject(symNoToJSON);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35454,10 +33686,6 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35526,10 +33754,6 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="0.5769230769230769" style="background-color:hsl(69,60%,50%)">15/26</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/26</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/26</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.11538461538461539" style="background-color:hsl(13,80%,50%)">3/26</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.34615384615384615" style="background-color:hsl(41,70%,50%)">9/26</td>
@@ -35608,10 +33832,6 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35686,10 +33906,6 @@ return a[0] === b;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35761,10 +33977,6 @@ return &quot;iterator&quot; in Symbol;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35839,10 +34051,6 @@ return (function() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35914,10 +34122,6 @@ return &quot;species&quot; in Symbol;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35994,10 +34198,6 @@ return Array.prototype.concat.call(obj, []).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36074,10 +34274,6 @@ return Array.prototype.filter.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36154,10 +34350,6 @@ return Array.prototype.map.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36234,10 +34426,6 @@ return Array.prototype.slice.call(obj, 0).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36314,10 +34502,6 @@ return Array.prototype.splice.call(obj, 0).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36397,10 +34581,6 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -36476,10 +34656,6 @@ return promise.then(function(){}) instanceof FakePromise2;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -36555,10 +34731,6 @@ return &apos;&apos;.replace(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -36634,10 +34806,6 @@ return &apos;&apos;.search(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -36713,10 +34881,6 @@ return &apos;&apos;.split(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -36792,10 +34956,6 @@ return &apos;&apos;.match(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -36871,10 +35031,6 @@ return RegExp(re) !== re &amp;&amp; RegExp(foo) === foo;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -36952,10 +35108,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -37033,10 +35185,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -37114,10 +35262,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -37198,10 +35342,6 @@ return passed === 3;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -37275,10 +35415,6 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -37367,10 +35503,6 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -37466,10 +35598,6 @@ passed = passed
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -37543,10 +35671,6 @@ return Math[s] === &quot;Math&quot;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -37622,10 +35746,6 @@ with (a) {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37685,7 +35805,7 @@ with (a) {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">Built-in extensions</td>
+<tr class="category"><td colspan="68">Built-in extensions</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/4</td>
@@ -37696,10 +35816,6 @@ with (a) {
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="konq414" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -37772,10 +35888,6 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37849,10 +35961,6 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37932,10 +36040,6 @@ return result[0] === sym
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38007,10 +36111,6 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38079,10 +36179,6 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="tally" data-browser="typescript" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/17</td>
 <td class="tally" data-browser="konq414" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)" data-flagged-tally="1">8/17</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)" data-flagged-tally="0.8823529411764706">14/17</td>
@@ -38156,10 +36252,6 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -38232,10 +36324,6 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -38307,10 +36395,6 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38384,10 +36468,6 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38461,10 +36541,6 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -38540,10 +36616,6 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38618,10 +36690,6 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38694,10 +36762,6 @@ return o.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38770,10 +36834,6 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38853,10 +36913,6 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38931,10 +36987,6 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39007,10 +37059,6 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39087,10 +37135,6 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39166,10 +37210,6 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39242,10 +37282,6 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39318,10 +37354,6 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39396,10 +37428,6 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39468,10 +37496,6 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es6shim" data-tally="1">2/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -39543,10 +37567,6 @@ return typeof String.raw === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39618,10 +37638,6 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39690,10 +37706,6 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">10/10</td>
@@ -39765,10 +37777,6 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39842,10 +37850,6 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39918,10 +37922,6 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39994,10 +37994,6 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40073,10 +38069,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40149,10 +38141,6 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40228,10 +38216,6 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40304,10 +38288,6 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40379,10 +38359,6 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40464,10 +38440,6 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40536,10 +38508,6 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -40611,10 +38579,6 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -40686,10 +38650,6 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -40761,10 +38721,6 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -40836,10 +38792,6 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -40911,10 +38863,6 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -40987,10 +38935,6 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41059,10 +39003,6 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally" data-browser="typescript" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)" data-flagged-tally="0.8181818181818182">7/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
@@ -41134,10 +39074,6 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41210,10 +39146,6 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41286,10 +39218,6 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41362,10 +39290,6 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41439,10 +39363,6 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, functio
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41517,10 +39437,6 @@ return Array.from(iterable, function(e, i) {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41595,10 +39511,6 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41673,10 +39585,6 @@ return Array.from(Object.create(iterable), function(e, i) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41755,10 +39663,6 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -41831,10 +39735,6 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41907,10 +39807,6 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41979,10 +39875,6 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">10/10</td>
@@ -42054,10 +39946,6 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42129,10 +40017,6 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42204,10 +40088,6 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42279,10 +40159,6 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42354,10 +40230,6 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42429,10 +40301,6 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42504,10 +40372,6 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42579,10 +40443,6 @@ return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42664,10 +40524,6 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42747,10 +40603,6 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42819,10 +40671,6 @@ return true;
 <td class="tally" data-browser="typescript" data-tally="1">7/7</td>
 <td class="tally" data-browser="es6shim" data-tally="1">7/7</td>
 <td class="tally" data-browser="konq414" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">7/7</td>
@@ -42894,10 +40742,6 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42969,10 +40813,6 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43044,10 +40884,6 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43119,10 +40955,6 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43194,10 +41026,6 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43269,10 +41097,6 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43344,10 +41168,6 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43416,10 +41236,6 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="tally" data-browser="typescript" data-tally="1">17/17</td>
 <td class="tally" data-browser="es6shim" data-tally="1">17/17</td>
 <td class="tally" data-browser="konq414" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">17/17</td>
@@ -43491,10 +41307,6 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43566,10 +41378,6 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43641,10 +41449,6 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43716,10 +41520,6 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43791,10 +41591,6 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43866,10 +41662,6 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43941,10 +41733,6 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44016,10 +41804,6 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44091,10 +41875,6 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44166,10 +41946,6 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44241,10 +42017,6 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44316,10 +42088,6 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44391,10 +42159,6 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44466,10 +42230,6 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44541,10 +42301,6 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44616,10 +42372,6 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44694,10 +42446,6 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44772,10 +42520,6 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -44835,7 +42579,7 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">Subclassing</td>
+<tr class="category"><td colspan="68">Subclassing</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array_is_subclassable"><span><a class="anchor" href="#test-Array_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-array-constructor">Array is subclassable</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/11</td>
@@ -44846,10 +42590,6 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.2727272727272727">0/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">11/11</td>
@@ -44926,10 +42666,6 @@ return len1 === 0 &amp;&amp; len2 === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45005,10 +42741,6 @@ return c.length === 1 &amp;&amp; !(2 in c);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45082,10 +42814,6 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45158,10 +42886,6 @@ return Array.isArray(new C());
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45235,10 +42959,6 @@ return c.concat(1) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45312,10 +43032,6 @@ return c.filter(Boolean) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45389,10 +43105,6 @@ return c.map(Boolean) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45467,10 +43179,6 @@ return c.slice(1,2) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45545,10 +43253,6 @@ return c.splice(1,2) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45621,10 +43325,6 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45697,10 +43397,6 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45769,10 +43465,6 @@ return C.of(0) instanceof C;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.25">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -45846,10 +43538,6 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45923,10 +43611,6 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46000,10 +43684,6 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46077,10 +43757,6 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46149,10 +43825,6 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.16666666666666666">0/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -46226,10 +43898,6 @@ return c() === &apos;foo&apos;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46303,10 +43971,6 @@ return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getProt
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46381,10 +44045,6 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46458,10 +44118,6 @@ return c.call({bar:1}, 2) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46535,10 +44191,6 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46612,10 +44264,6 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46684,10 +44332,6 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -46781,10 +44425,6 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46858,10 +44498,6 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46948,10 +44584,6 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47038,10 +44670,6 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47110,10 +44738,6 @@ function check() {
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -47189,10 +44813,6 @@ return c instanceof Boolean
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47268,10 +44888,6 @@ return c instanceof Number
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47349,10 +44965,6 @@ return c instanceof String
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47428,10 +45040,6 @@ return c instanceof Error
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47509,10 +45117,6 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47591,10 +45195,6 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47654,7 +45254,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">Misc</td>
+<tr class="category"><td colspan="68">Misc</td>
 </tr>
 <tr class="supertest" significance="0.125"><td id="test-prototype_of_bound_functions"><span><a class="anchor" href="#test-prototype_of_bound_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-boundfunctioncreate">prototype of bound functions</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/5</td>
@@ -47665,10 +45265,6 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -47753,10 +45349,6 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47841,10 +45433,6 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47929,10 +45517,6 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48017,10 +45601,6 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48103,10 +45683,6 @@ return correctProtoBound(function(){})
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48175,10 +45751,6 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="typescript" data-tally="0">0/36</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/36</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/36</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/36</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/36</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/36</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/36</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.3888888888888889" style="background-color:hsl(46,68%,50%)" data-flagged-tally="0.4166666666666667">14/36</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5277777777777778" style="background-color:hsl(63,62%,50%)">19/36</td>
@@ -48254,10 +45826,6 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -48333,10 +45901,6 @@ return get + &apos;&apos; === &quot;length,0,1&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48413,10 +45977,6 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -48495,10 +46055,6 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -48574,10 +46130,6 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48653,10 +46205,6 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48743,10 +46291,6 @@ return get + &apos;&apos; === &quot;done,value,done,value&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48830,10 +46374,6 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48909,10 +46449,6 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48988,10 +46524,6 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49067,10 +46599,6 @@ return get + &apos;&apos; === &quot;length,name&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49146,10 +46674,6 @@ return get + &apos;&apos; === &quot;name,message&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49226,10 +46750,6 @@ return get + &apos;&apos; === &quot;raw,length,0,1&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49307,10 +46827,6 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -49386,10 +46902,6 @@ return get + &apos;&apos; === &quot;global,ignoreCase,multiline,unicode,sticky&q
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -49465,10 +46977,6 @@ return get + &apos;&apos; === &quot;exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -49544,10 +47052,6 @@ return get + &apos;&apos; === &quot;source,flags&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -49625,10 +47129,6 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -49706,10 +47206,6 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -49785,10 +47281,6 @@ return get + &apos;&apos; === &quot;lastIndex,exec,lastIndex&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -49866,10 +47358,6 @@ return get + &apos;&apos; === &quot;constructor,flags,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -49945,10 +47433,6 @@ return get[0] === Symbol.iterator &amp;&amp; get.slice(1) + &apos;&apos; === &qu
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50031,10 +47515,6 @@ return get[0] === &quot;constructor&quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -50123,10 +47603,6 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50202,10 +47678,6 @@ return get + &apos;&apos; === &quot;length,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50281,10 +47753,6 @@ return get + &apos;&apos; === &quot;length,0,4,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50360,10 +47828,6 @@ return get + &apos;&apos; === &quot;length,0,1,2,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50440,10 +47904,6 @@ return get + &apos;&apos; === &quot;length,constructor,1,2,3,length,constructor,
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50519,10 +47979,6 @@ return get + &apos;&apos; === &quot;join&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50598,10 +48054,6 @@ return get + &apos;&apos; === &quot;toJSON&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50677,10 +48129,6 @@ return get + &apos;&apos; === &quot;then&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50758,10 +48206,6 @@ return get[0] === Symbol.match &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -50839,10 +48283,6 @@ return get[0] === Symbol.replace &amp;&amp; get[1] === Symbol.toPrimitive &amp;&
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -50920,10 +48360,6 @@ return get[0] === Symbol.search &amp;&amp; get[1] === Symbol.toPrimitive &amp;&a
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -51001,10 +48437,6 @@ return get[0] === Symbol.split &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -51081,10 +48513,6 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -51153,10 +48581,6 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/11</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">11/11</td>
@@ -51232,10 +48656,6 @@ return set + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51311,10 +48731,6 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51390,10 +48806,6 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51469,10 +48881,6 @@ return set + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51548,10 +48956,6 @@ return set + &apos;&apos; === &quot;3,4,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51627,10 +49031,6 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51706,10 +49106,6 @@ return set + &apos;&apos; === &quot;0,1,2,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51785,10 +49181,6 @@ return set + &apos;&apos; === &quot;3,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51864,10 +49256,6 @@ return set + &apos;&apos; === &quot;0,2,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51943,10 +49331,6 @@ return set + &apos;&apos; === &quot;3,2,1,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52022,10 +49406,6 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52094,10 +49474,6 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -52173,10 +49549,6 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52252,10 +49624,6 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52324,10 +49692,6 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -52403,10 +49767,6 @@ return del + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52482,10 +49842,6 @@ return del + &apos;&apos; === &quot;2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52561,10 +49917,6 @@ return del + &apos;&apos; === &quot;0,4,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52640,10 +49992,6 @@ return del + &apos;&apos; === &quot;0,2,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52719,10 +50067,6 @@ return del + &apos;&apos; === &quot;3,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52798,10 +50142,6 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52870,10 +50210,6 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -52950,10 +50286,6 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53030,10 +50362,6 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53110,10 +50438,6 @@ return gopd + &apos;&apos; === &quot;garply&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53190,10 +50514,6 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53262,10 +50582,6 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/3</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -53341,10 +50657,6 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53420,10 +50732,6 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53499,10 +50807,6 @@ return ownKeysCalled === 2;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53571,10 +50875,6 @@ return ownKeysCalled === 2;
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="1">10/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">10/10</td>
@@ -53646,10 +50946,6 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53721,10 +51017,6 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53798,10 +51090,6 @@ return s.length === 2 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53873,10 +51161,6 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53948,10 +51232,6 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54023,10 +51303,6 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54098,10 +51374,6 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54173,10 +51445,6 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54248,10 +51516,6 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54324,10 +51588,6 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54396,10 +51656,6 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">7/7</td>
@@ -54503,10 +51759,6 @@ return Object.keys(obj).join(&apos;&apos;) === forInOrder;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54598,10 +51850,6 @@ return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1A
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -54698,10 +51946,6 @@ return result === &quot;012349 DB-1ACEFGHIJKLMNOPQRST&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -54794,10 +52038,6 @@ return JSON.stringify(obj) ===
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -54877,10 +52117,6 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
@@ -54972,10 +52208,6 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 <td class="no" data-browser="typescript">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55062,10 +52294,6 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55134,10 +52362,6 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td class="tally" data-browser="konq414" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally" data-browser="ie11" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
@@ -55214,10 +52438,6 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55290,10 +52510,6 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55365,10 +52581,6 @@ do {} while (false) return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55446,10 +52658,6 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -55526,10 +52734,6 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55601,10 +52805,6 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55676,10 +52876,6 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55751,10 +52947,6 @@ return RegExp.prototype.toString.call({source: &apos;foo&apos;, flags: &apos;bar
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -55839,10 +53031,6 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -55922,10 +53110,6 @@ return false;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55985,7 +53169,7 @@ return false;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">Annex b</td>
+<tr class="category"><td colspan="68">Annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-non-strict_function_semantics"><span><a class="anchor" href="#test-non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[24]</sup></a></span></td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -55996,10 +53180,6 @@ return false;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally" data-browser="konq414" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -56085,10 +53265,6 @@ return passed;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -56164,10 +53340,6 @@ return foo() === 2;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -56246,10 +53418,6 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -56318,10 +53486,6 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -56394,10 +53558,6 @@ return { __proto__ : [] } instanceof Array
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -56474,10 +53634,6 @@ catch(e) {
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -56553,10 +53709,6 @@ return !({ [a] : [] } instanceof Array);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -56632,10 +53784,6 @@ return !({ __proto__ } instanceof Array);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -56710,10 +53858,6 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -56782,10 +53926,6 @@ return !({ __proto__(){} } instanceof Function);
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -56858,10 +53998,6 @@ return (new A()).__proto__ === A.prototype;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -56935,10 +54071,6 @@ return o instanceof Array;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57012,10 +54144,6 @@ return Object.getPrototypeOf(o) !== p;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57087,10 +54215,6 @@ return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57169,10 +54293,6 @@ return (desc
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57244,10 +54364,6 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57316,10 +54432,6 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="ie11" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -57398,10 +54510,6 @@ return true;
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57480,10 +54588,6 @@ return true;
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57561,10 +54665,6 @@ return true;
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57633,10 +54733,6 @@ return true;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -57712,10 +54808,6 @@ return rx.test(&apos;b&apos;);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57788,10 +54880,6 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown" data-browser="konq414">?</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -57860,10 +54948,6 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">8/8</td>
 <td class="tally" data-browser="ie11" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
@@ -57935,10 +55019,6 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -58011,10 +55091,6 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -58086,10 +55162,6 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -58162,10 +55234,6 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -58238,10 +55306,6 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -58314,10 +55378,6 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -58390,10 +55450,6 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -58466,10 +55522,6 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -58544,10 +55596,6 @@ return a === 3;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -149,6 +149,7 @@
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es6shim compiler" data-browser="es6shim"><a href="#es6shim" class="browser-name"><abbr title="es6-shim">es6-shim</abbr></a></th>
 <th class="platform konq414 desktop" data-browser="konq414"><a href="#konq414" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr></a><a href="#khtml-note"><sup>[3]</sup></a></th>
+<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -212,7 +213,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="68">Optimisation</td>
+      <tr class="category"><td colspan="69">Optimisation</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#test-proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/2</td>
@@ -223,6 +224,7 @@
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -300,6 +302,7 @@ return (function f(n){
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -384,6 +387,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -443,7 +447,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="68">Syntax</td>
+<tr class="category"><td colspan="69">Syntax</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-default_function_parameters"><span><a class="anchor" href="#test-default_function_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">default function parameters</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -454,6 +458,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally" data-browser="typescript" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/7</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.8571428571428571">0/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="1">0/7</td>
@@ -525,6 +530,7 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -596,6 +602,7 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -667,6 +674,7 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -745,6 +753,7 @@ return (function (a = &quot;baz&quot;, b = &quot;qux&quot;, c = &quot;quux&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -826,6 +835,7 @@ return (function(x = 1) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -902,6 +912,7 @@ return (function(a=function(){
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -975,6 +986,7 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -1043,6 +1055,7 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -1116,6 +1129,7 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1187,6 +1201,7 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1266,6 +1281,7 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1343,6 +1359,7 @@ return (function (...args) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1416,6 +1433,7 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1484,6 +1502,7 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.26666666666666666" style="background-color:hsl(32,74%,50%)">4/15</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/15</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="0.9333333333333333">12/15</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">15/15</td>
@@ -1555,6 +1574,7 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1626,6 +1646,7 @@ return [...[1, 2, 3]][2] === 3;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1698,6 +1719,7 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1770,6 +1792,7 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1841,6 +1864,7 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1912,6 +1936,7 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1983,6 +2008,7 @@ return Array(...&quot;&#x20BB7;&#x20BB6;&quot;)[0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2054,6 +2080,7 @@ return [...&quot;&#x20BB7;&#x20BB6;&quot;][0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2126,6 +2153,7 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2198,6 +2226,7 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2270,6 +2299,7 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2342,6 +2372,7 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2414,6 +2445,7 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2486,6 +2518,7 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2561,6 +2594,7 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2629,6 +2663,7 @@ try {
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -2701,6 +2736,7 @@ return ({ [x]: 1 }).y === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2773,6 +2809,7 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2844,6 +2881,7 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2915,6 +2953,7 @@ return ({ &quot;foo bar&quot;() { return 4; } })[&quot;foo bar&quot;]() === 4;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2987,6 +3026,7 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3065,6 +3105,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3133,6 +3174,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/9</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/9</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.7777777777777778">6/9</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
@@ -3206,6 +3248,7 @@ for (var item of arr)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3281,6 +3324,7 @@ return count === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3355,6 +3399,7 @@ return str === &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3429,6 +3474,7 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3505,6 +3551,7 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3581,6 +3628,7 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3657,6 +3705,7 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3733,6 +3782,7 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3811,6 +3861,7 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3879,6 +3930,7 @@ return closed;
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -3950,6 +4002,7 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4021,6 +4074,7 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4092,6 +4146,7 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4163,6 +4218,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4231,6 +4287,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -4304,6 +4361,7 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4379,6 +4437,7 @@ return `${a}` === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4461,6 +4520,7 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4534,6 +4594,7 @@ return (function(parts) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4610,6 +4671,7 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4678,6 +4740,7 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.4" style="background-color:hsl(48,68%,50%)" data-flagged-tally="0.8">2/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -4751,6 +4814,7 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4825,6 +4889,7 @@ return result === &apos;yy&apos; &amp;&amp; re.lastIndex === 5;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4896,6 +4961,7 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -4967,6 +5033,7 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5038,6 +5105,7 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5106,6 +5174,7 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="tally" data-browser="typescript" data-tally="0.6818181818181818" style="background-color:hsl(81,56%,50%)">15/22</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/22</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/22</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/22</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.9090909090909091">0/22</td>
@@ -5178,6 +5247,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5250,6 +5320,7 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5322,6 +5393,7 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5394,6 +5466,7 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5466,6 +5539,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5538,6 +5612,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5610,6 +5685,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5686,6 +5762,7 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5758,6 +5835,7 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5830,6 +5908,7 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5904,6 +5983,7 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -5976,6 +6056,7 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6061,6 +6142,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6134,6 +6216,7 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6206,6 +6289,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6280,6 +6364,7 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6353,6 +6438,7 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6426,6 +6512,7 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6505,6 +6592,7 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6579,6 +6667,7 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6653,6 +6742,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6733,6 +6823,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6801,6 +6892,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally" data-browser="typescript" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.9583333333333334">0/24</td>
@@ -6874,6 +6966,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -6947,6 +7040,7 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7020,6 +7114,7 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7093,6 +7188,7 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7166,6 +7262,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7239,6 +7336,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7312,6 +7410,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7389,6 +7488,7 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7461,6 +7561,7 @@ return ([a, b] = iterable) === iterable;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7534,6 +7635,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7607,6 +7709,7 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7680,6 +7783,7 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7755,6 +7859,7 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7828,6 +7933,7 @@ return a === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7900,6 +8006,7 @@ return ({a,b} = obj) === obj;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -7978,6 +8085,7 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8051,6 +8159,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8137,6 +8246,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8210,6 +8320,7 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8285,6 +8396,7 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8360,6 +8472,7 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8433,6 +8546,7 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8506,6 +8620,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8581,6 +8696,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8649,6 +8765,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally" data-browser="typescript" data-tally="0.6521739130434783" style="background-color:hsl(78,57%,50%)">15/23</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/23</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/23</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/23</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.9565217391304348">0/23</td>
@@ -8722,6 +8839,7 @@ return function([a, , [b], c]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8795,6 +8913,7 @@ return function([a, , b]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8868,6 +8987,7 @@ return function([a, b, c]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -8941,6 +9061,7 @@ return function([c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9014,6 +9135,7 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9087,6 +9209,7 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9160,6 +9283,7 @@ return function([a, b, c]) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9236,6 +9360,7 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9309,6 +9434,7 @@ return function([a,]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9382,6 +9508,7 @@ return function({c, x:d, e}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9456,6 +9583,7 @@ return function({toFixed}, {slice}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9529,6 +9657,7 @@ return function({a,}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9608,6 +9737,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9682,6 +9812,7 @@ return function({ [qux]: grault }) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9756,6 +9887,7 @@ return function([e, {x:f, g}], {h, x:[i]}) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9830,6 +9962,7 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9904,6 +10037,7 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -9975,6 +10109,7 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10049,6 +10184,7 @@ return function([a, ...b], [c, ...d]) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10122,6 +10258,7 @@ return function ([],{}){
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10197,6 +10334,7 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5},
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10273,6 +10411,7 @@ return (function({a=function(){
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10346,6 +10485,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -10414,6 +10554,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="tally" data-browser="typescript" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -10485,6 +10626,7 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -10557,6 +10699,7 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -10625,6 +10768,7 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -10703,6 +10847,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -10783,6 +10928,7 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10842,7 +10988,7 @@ try {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="68">Bindings</td>
+<tr class="category"><td colspan="69">Bindings</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-const"><span><a class="anchor" href="#test-const">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">const</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
@@ -10853,6 +10999,7 @@ try {
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/16</td>
 <td class="tally" data-browser="konq414" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
@@ -10925,6 +11072,7 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -10998,6 +11146,7 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11074,6 +11223,7 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11150,6 +11300,7 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11223,6 +11374,7 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11298,6 +11450,7 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11373,6 +11526,7 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11448,6 +11602,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11521,6 +11676,7 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11595,6 +11751,7 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11672,6 +11829,7 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11749,6 +11907,7 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11823,6 +11982,7 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -11899,6 +12059,7 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11975,6 +12136,7 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12051,6 +12213,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12119,6 +12282,7 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
@@ -12191,6 +12355,7 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12264,6 +12429,7 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12340,6 +12506,7 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12413,6 +12580,7 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12488,6 +12656,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12570,6 +12739,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12643,6 +12813,7 @@ return (foo === 123);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12717,6 +12888,7 @@ return bar === 123;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12794,6 +12966,7 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12868,6 +13041,7 @@ return baz === 1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -12944,6 +13118,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13027,6 +13202,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -13107,6 +13283,7 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13166,7 +13343,7 @@ return true;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="68">Functions</td>
+<tr class="category"><td colspan="69">Functions</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-arrow_functions"><span><a class="anchor" href="#test-arrow_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions">arrow functions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
@@ -13177,6 +13354,7 @@ return true;
 <td class="tally" data-browser="typescript" data-tally="0.6923076923076923" style="background-color:hsl(83,55%,50%)">9/13</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/13</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/13</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/13</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)" data-flagged-tally="0.7692307692307693">8/13</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">13/13</td>
@@ -13248,6 +13426,7 @@ return (() =&gt; 5)() === 5;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13320,6 +13499,7 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13392,6 +13572,7 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13465,6 +13646,7 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13538,6 +13720,7 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13611,6 +13794,7 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13683,6 +13867,7 @@ return f(6) === 5;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13756,6 +13941,7 @@ return (() =&gt; {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13829,6 +14015,7 @@ return (() =&gt; {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13901,6 +14088,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -13985,6 +14173,7 @@ return new C instanceof C &amp;&amp; received === &apos;foo&apos;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14067,6 +14256,7 @@ return arrow() === &quot;quux&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14141,6 +14331,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14209,6 +14400,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="tally" data-browser="typescript" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.875">0/24</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">24/24</td>
@@ -14281,6 +14473,7 @@ return typeof C === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14358,6 +14551,7 @@ return C === c1;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14429,6 +14623,7 @@ return typeof class C {} === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14500,6 +14695,7 @@ return typeof class {} === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14575,6 +14771,7 @@ return C.prototype.constructor === C
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14650,6 +14847,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14725,6 +14923,7 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14801,6 +15000,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14880,6 +15080,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -14955,6 +15156,7 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15031,6 +15233,7 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15108,6 +15311,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15185,6 +15389,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15262,6 +15467,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15339,6 +15545,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15415,6 +15622,7 @@ return C === undefined &amp;&amp; M();
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15492,6 +15700,7 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15567,6 +15776,7 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15641,6 +15851,7 @@ return (0,C.method)();
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15718,6 +15929,7 @@ catch(e) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15792,6 +16004,7 @@ return new C() instanceof B
 <td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15866,6 +16079,7 @@ return new C() instanceof B
 <td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -15941,6 +16155,7 @@ return Function.prototype.isPrototypeOf(C)
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16024,6 +16239,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16092,6 +16308,7 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.75">0/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
@@ -16171,6 +16388,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16248,6 +16466,7 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16326,6 +16545,7 @@ return new C().quux(&quot;bar&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16403,6 +16623,7 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16482,6 +16703,7 @@ return obj.qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16561,6 +16783,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16642,6 +16865,7 @@ return obj.qux() === &quot;barley&quot;;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16725,6 +16949,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16793,6 +17018,7 @@ return passed;
 <td class="tally" data-browser="typescript" data-tally="0">0/27</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/27</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/27</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/27</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.9259259259259259">0/27</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">27/27</td>
@@ -16874,6 +17100,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -16955,6 +17182,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17036,6 +17264,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17115,6 +17344,7 @@ catch (e) {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17194,6 +17424,7 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17274,6 +17505,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17358,6 +17590,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17441,6 +17674,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17523,6 +17757,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17604,6 +17839,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17682,6 +17918,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17762,6 +17999,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17842,6 +18080,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -17922,6 +18161,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18002,6 +18242,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18084,6 +18325,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18166,6 +18408,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18248,6 +18491,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18331,6 +18575,7 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18418,6 +18663,7 @@ return closed === &apos;ab&apos;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18504,6 +18750,7 @@ return closed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18587,6 +18834,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18670,6 +18918,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18754,6 +19003,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18837,6 +19087,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -18921,6 +19172,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19001,6 +19253,7 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19060,7 +19313,7 @@ try {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="68">Built-ins</td>
+<tr class="category"><td colspan="69">Built-ins</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-typed_arrays"><span><a class="anchor" href="#test-typed_arrays">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects">typed arrays</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/46</td>
@@ -19071,6 +19324,7 @@ try {
 <td class="tally" data-browser="typescript" data-tally="0.9782608695652174" style="background-color:hsl(117,42%,50%)">45/46</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/46</td>
 <td class="tally" data-browser="konq414" data-tally="0.17391304347826086" style="background-color:hsl(20,78%,50%)">8/46</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally" data-browser="ie11" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9130434782608695" style="background-color:hsl(109,45%,50%)">42/46</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9565217391304348" style="background-color:hsl(114,43%,50%)">44/46</td>
@@ -19144,6 +19398,7 @@ return view[0] === -0x80;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19217,6 +19472,7 @@ return view[0] === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19290,6 +19546,7 @@ return view[0] === 0xFF;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19363,6 +19620,7 @@ return view[0] === -0x8000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19436,6 +19694,7 @@ return view[0] === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19509,6 +19768,7 @@ return view[0] === -0x80000000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19582,6 +19842,7 @@ return view[0] === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19655,6 +19916,7 @@ return view[0] === 0.10000000149011612;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19728,6 +19990,7 @@ return view[0] === 0.1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19802,6 +20065,7 @@ return view.getInt8(0) === -0x80;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19876,6 +20140,7 @@ return view.getUint8(0) === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -19950,6 +20215,7 @@ return view.getInt16(0) === -0x8000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20024,6 +20290,7 @@ return view.getUint16(0) === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20098,6 +20365,7 @@ return view.getInt32(0) === -0x80000000;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20172,6 +20440,7 @@ return view.getUint32(0) === 0;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20246,6 +20515,7 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20320,6 +20590,7 @@ return view.getFloat64(0) === 0.1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20391,6 +20662,7 @@ return typeof ArrayBuffer[Symbol.species] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20485,6 +20757,7 @@ return constructors.every(function (constructor) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -20571,6 +20844,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -20665,6 +20939,7 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20744,6 +21019,7 @@ typeof Float64Array.from === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20823,6 +21099,7 @@ typeof Float64Array.of === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20902,6 +21179,7 @@ typeof Float64Array.prototype.subarray === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -20981,6 +21259,7 @@ typeof Float64Array.prototype.join === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21060,6 +21339,7 @@ typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21139,6 +21419,7 @@ typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21218,6 +21499,7 @@ typeof Float64Array.prototype.slice === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21297,6 +21579,7 @@ typeof Float64Array.prototype.every === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21376,6 +21659,7 @@ typeof Float64Array.prototype.filter === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21455,6 +21739,7 @@ typeof Float64Array.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21534,6 +21819,7 @@ typeof Float64Array.prototype.map === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21613,6 +21899,7 @@ typeof Float64Array.prototype.reduce === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21692,6 +21979,7 @@ typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21771,6 +22059,7 @@ typeof Float64Array.prototype.reverse === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21850,6 +22139,7 @@ typeof Float64Array.prototype.some === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -21929,6 +22219,7 @@ typeof Float64Array.prototype.sort === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22008,6 +22299,7 @@ typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22087,6 +22379,7 @@ typeof Float64Array.prototype.find === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22166,6 +22459,7 @@ typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22245,6 +22539,7 @@ typeof Float64Array.prototype.fill === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22324,6 +22619,7 @@ typeof Float64Array.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22403,6 +22699,7 @@ typeof Float64Array.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22482,6 +22779,7 @@ typeof Float64Array.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22561,6 +22859,7 @@ typeof Float64Array.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22640,6 +22939,7 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22708,6 +23008,7 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally" data-browser="typescript" data-tally="1">19/19</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
@@ -22784,6 +23085,7 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22860,6 +23162,7 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -22937,6 +23240,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23009,6 +23313,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23090,6 +23395,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23168,6 +23474,7 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -23240,6 +23547,7 @@ return map.set(0, 0) === map;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23317,6 +23625,7 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23393,6 +23702,7 @@ return map.size === 1;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23464,6 +23774,7 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23535,6 +23846,7 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23606,6 +23918,7 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23677,6 +23990,7 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23748,6 +24062,7 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23819,6 +24134,7 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23890,6 +24206,7 @@ return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -23968,6 +24285,7 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24049,6 +24367,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24121,6 +24440,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24189,6 +24509,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally" data-browser="typescript" data-tally="1">19/19</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
@@ -24266,6 +24587,7 @@ return set.has(123);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24341,6 +24663,7 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24418,6 +24741,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24490,6 +24814,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24571,6 +24896,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24652,6 +24978,7 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -24724,6 +25051,7 @@ return set.add(0) === set;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24801,6 +25129,7 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24879,6 +25208,7 @@ return set.size === 2;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -24950,6 +25280,7 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25021,6 +25352,7 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25092,6 +25424,7 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25163,6 +25496,7 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25234,6 +25568,7 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25305,6 +25640,7 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25376,6 +25712,7 @@ return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25454,6 +25791,7 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25535,6 +25873,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25607,6 +25946,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25675,6 +26015,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally" data-browser="typescript" data-tally="1">12/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">6/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
@@ -25751,6 +26092,7 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25827,6 +26169,7 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25904,6 +26247,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -25976,6 +26320,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26057,6 +26402,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26131,6 +26477,7 @@ return m.get(f) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26209,6 +26556,7 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -26282,6 +26630,7 @@ return weakmap.set(key, 0) === weakmap;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26353,6 +26702,7 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26431,6 +26781,7 @@ return m.has(key);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26505,6 +26856,7 @@ return m.has(1) === false
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26583,6 +26935,7 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26651,6 +27004,7 @@ catch(e) {
 <td class="tally" data-browser="typescript" data-tally="1">11/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
@@ -26728,6 +27082,7 @@ return weakset.has(obj1);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26802,6 +27157,7 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26879,6 +27235,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -26951,6 +27308,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27032,6 +27390,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27110,6 +27469,7 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -27183,6 +27543,7 @@ return weakset.add(obj) === weakset;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27254,6 +27615,7 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27332,6 +27694,7 @@ return s.has(key);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27405,6 +27768,7 @@ return s.has(1) === false
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27483,6 +27847,7 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27551,6 +27916,7 @@ catch(e) {
 <td class="tally" data-browser="typescript" data-tally="0">0/34</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/34</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/34</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/34</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/34</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">34/34</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">34/34</td>
@@ -27628,6 +27994,7 @@ try {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27700,6 +28067,7 @@ return !Proxy.hasOwnProperty(&apos;prototype&apos;);
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27777,6 +28145,7 @@ return proxy.foo === 5;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27854,6 +28223,7 @@ return proxy.foo === 5;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -27952,6 +28322,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28031,6 +28402,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28110,6 +28482,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28208,6 +28581,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28286,6 +28660,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28364,6 +28739,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28459,6 +28835,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28537,6 +28914,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28623,6 +29001,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28707,6 +29086,7 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28828,6 +29208,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -28911,6 +29292,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29010,6 +29392,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29088,6 +29471,7 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29172,6 +29556,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29255,6 +29640,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29341,6 +29727,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29421,6 +29808,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29513,6 +29901,7 @@ return true;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29594,6 +29983,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29678,6 +30068,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29758,6 +30149,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29859,6 +30251,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -29940,6 +30333,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30024,6 +30418,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30103,6 +30498,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30197,6 +30593,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30276,6 +30673,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30347,6 +30745,7 @@ return Array.isArray(new Proxy([], {}));
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30418,6 +30817,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30486,6 +30886,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="tally" data-browser="typescript" data-tally="0.9" style="background-color:hsl(108,46%,50%)">18/20</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/20</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/20</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.65" style="background-color:hsl(78,57%,50%)">13/20</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">20/20</td>
@@ -30557,6 +30958,7 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30630,6 +31032,7 @@ return obj.quux === 654;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30701,6 +31104,7 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30774,6 +31178,7 @@ return !(&quot;bar&quot; in obj);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30848,6 +31253,7 @@ return desc.value === 789 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30922,6 +31328,7 @@ return obj.foo === 123 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -30993,6 +31400,7 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31066,6 +31474,7 @@ return obj instanceof Array;
 <td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31138,6 +31547,7 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31211,6 +31621,7 @@ return !Object.isExtensible(obj);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31286,6 +31697,7 @@ return Reflect.ownKeys(obj).sort() + &apos;&apos; === &quot;A,B&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31365,6 +31777,7 @@ return keys.indexOf(s2) &gt;-1 &amp;&amp; keys.indexOf(s3) &gt;-1 &amp;&amp; key
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31436,6 +31849,7 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31509,6 +31923,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31584,6 +31999,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31657,6 +32073,7 @@ return obj.y === 1 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31731,6 +32148,7 @@ return obj.length === 3 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31805,6 +32223,7 @@ return RegExp.prototype.exec.call(obj, &quot;foobarbaz&quot;)[0] === &quot;baz&q
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31878,6 +32297,7 @@ return obj() === 2 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -31968,6 +32388,7 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32036,6 +32457,7 @@ function check() {
 <td class="tally" data-browser="typescript" data-tally="1">8/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
@@ -32128,6 +32550,7 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32205,6 +32628,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32281,6 +32705,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32366,6 +32791,7 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32451,6 +32877,7 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32536,6 +32963,7 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32621,6 +33049,7 @@ function check() {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32693,6 +33122,7 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32761,6 +33191,7 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="tally" data-browser="typescript" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">8/12</td>
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">2/12</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">12/12</td>
@@ -32836,6 +33267,7 @@ return object[symbol] === value;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32907,6 +33339,7 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -32990,6 +33423,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33070,6 +33504,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33146,6 +33581,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33230,6 +33666,7 @@ return true;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33301,6 +33738,7 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33377,6 +33815,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33455,6 +33894,7 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33529,6 +33969,7 @@ return JSON.stringify(object) === &apos;{}&apos; &amp;&amp; JSON.stringify(array
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33613,6 +34054,7 @@ return testSymbolObject(objSym) &amp;&amp; testSymbolObject(symNoToJSON);
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33686,6 +34128,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -33754,6 +34197,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="0.5769230769230769" style="background-color:hsl(69,60%,50%)">15/26</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/26</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/26</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.11538461538461539" style="background-color:hsl(13,80%,50%)">3/26</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.34615384615384615" style="background-color:hsl(41,70%,50%)">9/26</td>
@@ -33832,6 +34276,7 @@ return passed;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -33906,6 +34351,7 @@ return a[0] === b;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -33977,6 +34423,7 @@ return &quot;iterator&quot; in Symbol;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34051,6 +34498,7 @@ return (function() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34122,6 +34570,7 @@ return &quot;species&quot; in Symbol;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34198,6 +34647,7 @@ return Array.prototype.concat.call(obj, []).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34274,6 +34724,7 @@ return Array.prototype.filter.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34350,6 +34801,7 @@ return Array.prototype.map.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34426,6 +34878,7 @@ return Array.prototype.slice.call(obj, 0).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34502,6 +34955,7 @@ return Array.prototype.splice.call(obj, 0).foo === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -34581,6 +35035,7 @@ return passed;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -34656,6 +35111,7 @@ return promise.then(function(){}) instanceof FakePromise2;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -34731,6 +35187,7 @@ return &apos;&apos;.replace(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -34806,6 +35263,7 @@ return &apos;&apos;.search(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -34881,6 +35339,7 @@ return &apos;&apos;.split(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -34956,6 +35415,7 @@ return &apos;&apos;.match(O) === 42;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35031,6 +35491,7 @@ return RegExp(re) !== re &amp;&amp; RegExp(foo) === foo;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35108,6 +35569,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35185,6 +35647,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35262,6 +35725,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35342,6 +35806,7 @@ return passed === 3;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35415,6 +35880,7 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35503,6 +35969,7 @@ return passed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35598,6 +36065,7 @@ passed = passed
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35671,6 +36139,7 @@ return Math[s] === &quot;Math&quot;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -35746,6 +36215,7 @@ with (a) {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35805,7 +36275,7 @@ with (a) {
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="68">Built-in extensions</td>
+<tr class="category"><td colspan="69">Built-in extensions</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/4</td>
@@ -35816,6 +36286,7 @@ with (a) {
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="konq414" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -35888,6 +36359,7 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -35961,6 +36433,7 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36040,6 +36513,7 @@ return result[0] === sym
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36111,6 +36585,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36179,6 +36654,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="tally" data-browser="typescript" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/17</td>
 <td class="tally" data-browser="konq414" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)" data-flagged-tally="1">8/17</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)" data-flagged-tally="0.8823529411764706">14/17</td>
@@ -36252,6 +36728,7 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -36324,6 +36801,7 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -36395,6 +36873,7 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36468,6 +36947,7 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36541,6 +37021,7 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag</td>
@@ -36616,6 +37097,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36690,6 +37172,7 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36762,6 +37245,7 @@ return o.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36834,6 +37318,7 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36913,6 +37398,7 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -36987,6 +37473,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37059,6 +37546,7 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37135,6 +37623,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37210,6 +37699,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37282,6 +37772,7 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37354,6 +37845,7 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37428,6 +37920,7 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37496,6 +37989,7 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es6shim" data-tally="1">2/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -37567,6 +38061,7 @@ return typeof String.raw === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37638,6 +38133,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37706,6 +38202,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">10/10</td>
@@ -37777,6 +38274,7 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37850,6 +38348,7 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37922,6 +38421,7 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -37994,6 +38494,7 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38069,6 +38570,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38141,6 +38643,7 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38216,6 +38719,7 @@ try {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38288,6 +38792,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38359,6 +38864,7 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38440,6 +38946,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -38508,6 +39015,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -38579,6 +39087,7 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -38650,6 +39159,7 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -38721,6 +39231,7 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -38792,6 +39303,7 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -38863,6 +39375,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -38935,6 +39448,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39003,6 +39517,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally" data-browser="typescript" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)" data-flagged-tally="0.8181818181818182">7/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
@@ -39074,6 +39589,7 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39146,6 +39662,7 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39218,6 +39735,7 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39290,6 +39808,7 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39363,6 +39882,7 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, functio
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39437,6 +39957,7 @@ return Array.from(iterable, function(e, i) {
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39511,6 +40032,7 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39585,6 +40107,7 @@ return Array.from(Object.create(iterable), function(e, i) {
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39663,6 +40186,7 @@ return closed;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -39735,6 +40259,7 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39807,6 +40332,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -39875,6 +40401,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">10/10</td>
@@ -39946,6 +40473,7 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40017,6 +40545,7 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40088,6 +40617,7 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40159,6 +40689,7 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40230,6 +40761,7 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40301,6 +40833,7 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40372,6 +40905,7 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40443,6 +40977,7 @@ return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40524,6 +41059,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40603,6 +41139,7 @@ return true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40671,6 +41208,7 @@ return true;
 <td class="tally" data-browser="typescript" data-tally="1">7/7</td>
 <td class="tally" data-browser="es6shim" data-tally="1">7/7</td>
 <td class="tally" data-browser="konq414" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">7/7</td>
@@ -40742,6 +41280,7 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40813,6 +41352,7 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40884,6 +41424,7 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -40955,6 +41496,7 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41026,6 +41568,7 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41097,6 +41640,7 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41168,6 +41712,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41236,6 +41781,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="tally" data-browser="typescript" data-tally="1">17/17</td>
 <td class="tally" data-browser="es6shim" data-tally="1">17/17</td>
 <td class="tally" data-browser="konq414" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">17/17</td>
@@ -41307,6 +41853,7 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41378,6 +41925,7 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41449,6 +41997,7 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41520,6 +42069,7 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41591,6 +42141,7 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41662,6 +42213,7 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41733,6 +42285,7 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41804,6 +42357,7 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41875,6 +42429,7 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -41946,6 +42501,7 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42017,6 +42573,7 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42088,6 +42645,7 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42159,6 +42717,7 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42230,6 +42789,7 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42301,6 +42861,7 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42372,6 +42933,7 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42446,6 +43008,7 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42520,6 +43083,7 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -42579,7 +43143,7 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="68">Subclassing</td>
+<tr class="category"><td colspan="69">Subclassing</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array_is_subclassable"><span><a class="anchor" href="#test-Array_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-array-constructor">Array is subclassable</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/11</td>
@@ -42590,6 +43154,7 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.2727272727272727">0/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">11/11</td>
@@ -42666,6 +43231,7 @@ return len1 === 0 &amp;&amp; len2 === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42741,6 +43307,7 @@ return c.length === 1 &amp;&amp; !(2 in c);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42814,6 +43381,7 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42886,6 +43454,7 @@ return Array.isArray(new C());
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -42959,6 +43528,7 @@ return c.concat(1) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43032,6 +43602,7 @@ return c.filter(Boolean) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43105,6 +43676,7 @@ return c.map(Boolean) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43179,6 +43751,7 @@ return c.slice(1,2) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43253,6 +43826,7 @@ return c.splice(1,2) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43325,6 +43899,7 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43397,6 +43972,7 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43465,6 +44041,7 @@ return C.of(0) instanceof C;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.25">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -43538,6 +44115,7 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43611,6 +44189,7 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43684,6 +44263,7 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43757,6 +44337,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43825,6 +44406,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.16666666666666666">0/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -43898,6 +44480,7 @@ return c() === &apos;foo&apos;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -43971,6 +44554,7 @@ return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getProt
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44045,6 +44629,7 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44118,6 +44703,7 @@ return c.call({bar:1}, 2) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44191,6 +44777,7 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44264,6 +44851,7 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44332,6 +44920,7 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -44425,6 +45014,7 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44498,6 +45088,7 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44584,6 +45175,7 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44670,6 +45262,7 @@ function check() {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44738,6 +45331,7 @@ function check() {
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -44813,6 +45407,7 @@ return c instanceof Boolean
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44888,6 +45483,7 @@ return c instanceof Number
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -44965,6 +45561,7 @@ return c instanceof String
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45040,6 +45637,7 @@ return c instanceof Error
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45117,6 +45715,7 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45195,6 +45794,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45254,7 +45854,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="68">Misc</td>
+<tr class="category"><td colspan="69">Misc</td>
 </tr>
 <tr class="supertest" significance="0.125"><td id="test-prototype_of_bound_functions"><span><a class="anchor" href="#test-prototype_of_bound_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-boundfunctioncreate">prototype of bound functions</a></span></td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/5</td>
@@ -45265,6 +45865,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -45349,6 +45950,7 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45433,6 +46035,7 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45517,6 +46120,7 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45601,6 +46205,7 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45683,6 +46288,7 @@ return correctProtoBound(function(){})
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45751,6 +46357,7 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="typescript" data-tally="0">0/36</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/36</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/36</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/36</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.3888888888888889" style="background-color:hsl(46,68%,50%)" data-flagged-tally="0.4166666666666667">14/36</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5277777777777778" style="background-color:hsl(63,62%,50%)">19/36</td>
@@ -45826,6 +46433,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -45901,6 +46509,7 @@ return get + &apos;&apos; === &quot;length,0,1&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -45977,6 +46586,7 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -46055,6 +46665,7 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -46130,6 +46741,7 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46205,6 +46817,7 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46291,6 +46904,7 @@ return get + &apos;&apos; === &quot;done,value,done,value&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46374,6 +46988,7 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46449,6 +47064,7 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46524,6 +47140,7 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46599,6 +47216,7 @@ return get + &apos;&apos; === &quot;length,name&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46674,6 +47292,7 @@ return get + &apos;&apos; === &quot;name,message&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46750,6 +47369,7 @@ return get + &apos;&apos; === &quot;raw,length,0,1&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -46827,6 +47447,7 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -46902,6 +47523,7 @@ return get + &apos;&apos; === &quot;global,ignoreCase,multiline,unicode,sticky&q
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -46977,6 +47599,7 @@ return get + &apos;&apos; === &quot;exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -47052,6 +47675,7 @@ return get + &apos;&apos; === &quot;source,flags&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -47129,6 +47753,7 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -47206,6 +47831,7 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -47281,6 +47907,7 @@ return get + &apos;&apos; === &quot;lastIndex,exec,lastIndex&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -47358,6 +47985,7 @@ return get + &apos;&apos; === &quot;constructor,flags,exec&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -47433,6 +48061,7 @@ return get[0] === Symbol.iterator &amp;&amp; get.slice(1) + &apos;&apos; === &qu
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47515,6 +48144,7 @@ return get[0] === &quot;constructor&quot;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -47603,6 +48233,7 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47678,6 +48309,7 @@ return get + &apos;&apos; === &quot;length,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47753,6 +48385,7 @@ return get + &apos;&apos; === &quot;length,0,4,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47828,6 +48461,7 @@ return get + &apos;&apos; === &quot;length,0,1,2,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47904,6 +48538,7 @@ return get + &apos;&apos; === &quot;length,constructor,1,2,3,length,constructor,
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -47979,6 +48614,7 @@ return get + &apos;&apos; === &quot;join&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48054,6 +48690,7 @@ return get + &apos;&apos; === &quot;toJSON&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48129,6 +48766,7 @@ return get + &apos;&apos; === &quot;then&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48206,6 +48844,7 @@ return get[0] === Symbol.match &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -48283,6 +48922,7 @@ return get[0] === Symbol.replace &amp;&amp; get[1] === Symbol.toPrimitive &amp;&
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -48360,6 +49000,7 @@ return get[0] === Symbol.search &amp;&amp; get[1] === Symbol.toPrimitive &amp;&a
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -48437,6 +49078,7 @@ return get[0] === Symbol.split &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -48513,6 +49155,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -48581,6 +49224,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">11/11</td>
@@ -48656,6 +49300,7 @@ return set + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48731,6 +49376,7 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48806,6 +49452,7 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48881,6 +49528,7 @@ return set + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -48956,6 +49604,7 @@ return set + &apos;&apos; === &quot;3,4,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49031,6 +49680,7 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49106,6 +49756,7 @@ return set + &apos;&apos; === &quot;0,1,2,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49181,6 +49832,7 @@ return set + &apos;&apos; === &quot;3,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49256,6 +49908,7 @@ return set + &apos;&apos; === &quot;0,2,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49331,6 +49984,7 @@ return set + &apos;&apos; === &quot;3,2,1,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49406,6 +50060,7 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49474,6 +50129,7 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -49549,6 +50205,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49624,6 +50281,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49692,6 +50350,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -49767,6 +50426,7 @@ return del + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49842,6 +50502,7 @@ return del + &apos;&apos; === &quot;2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49917,6 +50578,7 @@ return del + &apos;&apos; === &quot;0,4,2&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -49992,6 +50654,7 @@ return del + &apos;&apos; === &quot;0,2,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50067,6 +50730,7 @@ return del + &apos;&apos; === &quot;3,5&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50142,6 +50806,7 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50210,6 +50875,7 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -50286,6 +50952,7 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50362,6 +51029,7 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50438,6 +51106,7 @@ return gopd + &apos;&apos; === &quot;garply&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50514,6 +51183,7 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50582,6 +51252,7 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="tally" data-browser="typescript" data-tally="0">0/3</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -50657,6 +51328,7 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50732,6 +51404,7 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50807,6 +51480,7 @@ return ownKeysCalled === 2;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -50875,6 +51549,7 @@ return ownKeysCalled === 2;
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="1">10/10</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">10/10</td>
@@ -50946,6 +51621,7 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51017,6 +51693,7 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51090,6 +51767,7 @@ return s.length === 2 &amp;&amp;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51161,6 +51839,7 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51232,6 +51911,7 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51303,6 +51983,7 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51374,6 +52055,7 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51445,6 +52127,7 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51516,6 +52199,7 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51588,6 +52272,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51656,6 +52341,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="tally" data-browser="typescript" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="konq414" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">7/7</td>
@@ -51759,6 +52445,7 @@ return Object.keys(obj).join(&apos;&apos;) === forInOrder;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -51850,6 +52537,7 @@ return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1A
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -51946,6 +52634,7 @@ return result === &quot;012349 DB-1ACEFGHIJKLMNOPQRST&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -52038,6 +52727,7 @@ return JSON.stringify(obj) ===
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -52117,6 +52807,7 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[22]</sup></a></td>
@@ -52208,6 +52899,7 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 <td class="no" data-browser="typescript">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52294,6 +52986,7 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52362,6 +53055,7 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td class="tally" data-browser="konq414" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally" data-browser="ie11" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
@@ -52438,6 +53132,7 @@ try {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52510,6 +53205,7 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52581,6 +53277,7 @@ do {} while (false) return true;
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52658,6 +53355,7 @@ catch(e) {
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -52734,6 +53432,7 @@ try {
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52805,6 +53504,7 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52876,6 +53576,7 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -52947,6 +53648,7 @@ return RegExp.prototype.toString.call({source: &apos;foo&apos;, flags: &apos;bar
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -53031,6 +53733,7 @@ return true;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -53110,6 +53813,7 @@ return false;
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53169,7 +53873,7 @@ return false;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="68">Annex b</td>
+<tr class="category"><td colspan="69">Annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-non-strict_function_semantics"><span><a class="anchor" href="#test-non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[24]</sup></a></span></td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -53180,6 +53884,7 @@ return false;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally" data-browser="konq414" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -53265,6 +53970,7 @@ return passed;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53340,6 +54046,7 @@ return foo() === 2;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53418,6 +54125,7 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53486,6 +54194,7 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally" data-browser="konq414" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -53558,6 +54267,7 @@ return { __proto__ : [] } instanceof Array
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53634,6 +54344,7 @@ catch(e) {
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53709,6 +54420,7 @@ return !({ [a] : [] } instanceof Array);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53784,6 +54496,7 @@ return !({ __proto__ } instanceof Array);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53858,6 +54571,7 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -53926,6 +54640,7 @@ return !({ __proto__(){} } instanceof Function);
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally" data-browser="konq414" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">6/6</td>
@@ -53998,6 +54713,7 @@ return (new A()).__proto__ === A.prototype;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54071,6 +54787,7 @@ return o instanceof Array;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54144,6 +54861,7 @@ return Object.getPrototypeOf(o) !== p;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54215,6 +54933,7 @@ return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54293,6 +55012,7 @@ return (desc
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54364,6 +55084,7 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no" data-browser="konq414">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54432,6 +55153,7 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally" data-browser="konq414" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="ie11" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">3/3</td>
@@ -54510,6 +55232,7 @@ return true;
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54588,6 +55311,7 @@ return true;
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54665,6 +55389,7 @@ return true;
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54733,6 +55458,7 @@ return true;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally" data-browser="konq414" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -54808,6 +55534,7 @@ return rx.test(&apos;b&apos;);
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54880,6 +55607,7 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown" data-browser="konq414">?</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -54948,6 +55676,7 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally" data-browser="konq414" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">8/8</td>
 <td class="tally" data-browser="ie11" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">8/8</td>
@@ -55019,6 +55748,7 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55091,6 +55821,7 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55162,6 +55893,7 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55234,6 +55966,7 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55306,6 +56039,7 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55378,6 +56112,7 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55450,6 +56185,7 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55522,6 +56258,7 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -55596,6 +56333,7 @@ return a === 3;
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes" data-browser="konq414">Yes</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -121,7 +121,10 @@
           <th></th>
 
           <!-- TABLE HEADERS -->
-        <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
+        <th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
+<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
+<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
+<th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
 <th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
@@ -180,6 +183,9 @@
       <tbody>
         <!-- TABLE BODY -->
       <tr class="supertest" significance="1"><td id="test-Intl_object"><span><a class="anchor" href="#test-Intl_object">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-8">Intl object</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -238,6 +244,9 @@
 return typeof Intl === &apos;object&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nreturn typeof Intl === 'object';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl === 'object';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -296,6 +305,9 @@ return typeof Intl === &apos;object&apos;;
 return Intl.constructor === Object;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nreturn Intl.constructor === Object;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.constructor === Object;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -351,6 +363,9 @@ return Intl.constructor === Object;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator"><span><a class="anchor" href="#test-Intl.Collator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10">Intl.Collator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -409,6 +424,9 @@ return Intl.constructor === Object;
 return typeof Intl.Collator === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("4");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -467,6 +485,9 @@ return typeof Intl.Collator === &apos;function&apos;;
 return new Intl.Collator() instanceof Intl.Collator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nreturn new Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -525,6 +546,9 @@ return new Intl.Collator() instanceof Intl.Collator;
 return Intl.Collator() instanceof Intl.Collator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");try{return Function("asyncTestPassed","\nreturn Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("6");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -611,6 +635,9 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -666,6 +693,9 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.compare"><span><a class="anchor" href="#test-Intl.Collator.prototype.compare">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.2">Intl.Collator.prototype.compare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -724,6 +754,9 @@ try {
 return typeof Intl.Collator().compare === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -779,6 +812,9 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.resolvedOptions"><span><a class="anchor" href="#test-Intl.Collator.prototype.resolvedOptions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.3">Intl.Collator.prototype.resolvedOptions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -837,6 +873,9 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -892,6 +931,9 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-NumberFormat"><span><a class="anchor" href="#test-NumberFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-11">NumberFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -950,6 +992,9 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 return typeof Intl.NumberFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1008,6 +1053,9 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 return typeof Intl.NumberFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1066,6 +1114,9 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 return new Intl.NumberFormat() instanceof Intl.NumberFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1124,6 +1175,9 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 return Intl.NumberFormat() instanceof Intl.NumberFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1210,6 +1264,9 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1265,6 +1322,9 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-DateTimeFormat"><span><a class="anchor" href="#test-DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
@@ -1323,6 +1383,9 @@ try {
 return typeof Intl.DateTimeFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1381,6 +1444,9 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("20");try{return Function("asyncTestPassed","\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("20");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1439,6 +1505,9 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1525,6 +1594,9 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1584,6 +1656,9 @@ var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 return tz !== undefined &amp;&amp; tz.length &gt; 0;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1650,6 +1725,9 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1705,6 +1783,9 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-String.prototype.localeCompare"><span><a class="anchor" href="#test-String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -1763,6 +1844,9 @@ try {
 return typeof String.prototype.localeCompare === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1818,6 +1902,9 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Number.prototype.toLocaleString"><span><a class="anchor" href="#test-Number.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.tolocalestring">Number.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -1876,6 +1963,9 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 return typeof Number.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1931,6 +2021,9 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Array.prototype.toLocaleString"><span><a class="anchor" href="#test-Array.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.tolocalestring">Array.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -1989,6 +2082,9 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 return typeof Array.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2044,6 +2140,9 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object.prototype.toLocaleString"><span><a class="anchor" href="#test-Object.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.tolocalestring">Object.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -2102,6 +2201,9 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 return typeof Object.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2157,6 +2259,9 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleString"><span><a class="anchor" href="#test-Date.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocalestring">Date.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -2215,6 +2320,9 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2270,6 +2378,9 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleDateString"><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaledatestring">Date.prototype.toLocaleDateString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -2328,6 +2439,9 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2383,6 +2497,9 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleTimeString"><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaletimestring">Date.prototype.toLocaleTimeString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -2441,6 +2558,9 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -121,9 +121,7 @@
           <th></th>
 
           <!-- TABLE HEADERS -->
-        <th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
-<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
-<th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
+        <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
 <th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
@@ -182,8 +180,6 @@
       <tbody>
         <!-- TABLE BODY -->
       <tr class="supertest" significance="1"><td id="test-Intl_object"><span><a class="anchor" href="#test-Intl_object">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-8">Intl object</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">2/2</td>
@@ -242,8 +238,6 @@
 return typeof Intl === &apos;object&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nreturn typeof Intl === 'object';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl === 'object';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -302,8 +296,6 @@ return typeof Intl === &apos;object&apos;;
 return Intl.constructor === Object;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nreturn Intl.constructor === Object;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.constructor === Object;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -359,8 +351,6 @@ return Intl.constructor === Object;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator"><span><a class="anchor" href="#test-Intl.Collator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10">Intl.Collator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">4/4</td>
@@ -419,8 +409,6 @@ return Intl.constructor === Object;
 return typeof Intl.Collator === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("4");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -479,8 +467,6 @@ return typeof Intl.Collator === &apos;function&apos;;
 return new Intl.Collator() instanceof Intl.Collator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nreturn new Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -539,8 +525,6 @@ return new Intl.Collator() instanceof Intl.Collator;
 return Intl.Collator() instanceof Intl.Collator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");try{return Function("asyncTestPassed","\nreturn Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("6");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.Collator() instanceof Intl.Collator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -627,8 +611,6 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -684,8 +666,6 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.compare"><span><a class="anchor" href="#test-Intl.Collator.prototype.compare">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.2">Intl.Collator.prototype.compare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -744,8 +724,6 @@ try {
 return typeof Intl.Collator().compare === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -801,8 +779,6 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.resolvedOptions"><span><a class="anchor" href="#test-Intl.Collator.prototype.resolvedOptions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.3">Intl.Collator.prototype.resolvedOptions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -861,8 +837,6 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -918,8 +892,6 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-NumberFormat"><span><a class="anchor" href="#test-NumberFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-11">NumberFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">5/5</td>
@@ -978,8 +950,6 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 return typeof Intl.NumberFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1038,8 +1008,6 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 return typeof Intl.NumberFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1098,8 +1066,6 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 return new Intl.NumberFormat() instanceof Intl.NumberFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1158,8 +1124,6 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 return Intl.NumberFormat() instanceof Intl.NumberFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1246,8 +1210,6 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1303,8 +1265,6 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-DateTimeFormat"><span><a class="anchor" href="#test-DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
@@ -1363,8 +1323,6 @@ try {
 return typeof Intl.DateTimeFormat === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1423,8 +1381,6 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("20");try{return Function("asyncTestPassed","\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("20");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1483,8 +1439,6 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1571,8 +1525,6 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1632,8 +1584,6 @@ var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 return tz !== undefined &amp;&amp; tz.length &gt; 0;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1700,8 +1650,6 @@ try {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1757,8 +1705,6 @@ try {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-String.prototype.localeCompare"><span><a class="anchor" href="#test-String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -1817,8 +1763,6 @@ try {
 return typeof String.prototype.localeCompare === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1874,8 +1818,6 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Number.prototype.toLocaleString"><span><a class="anchor" href="#test-Number.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.tolocalestring">Number.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -1934,8 +1876,6 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 return typeof Number.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1991,8 +1931,6 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Array.prototype.toLocaleString"><span><a class="anchor" href="#test-Array.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.tolocalestring">Array.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -2051,8 +1989,6 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 return typeof Array.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2108,8 +2044,6 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object.prototype.toLocaleString"><span><a class="anchor" href="#test-Object.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.tolocalestring">Object.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -2168,8 +2102,6 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 return typeof Object.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2225,8 +2157,6 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleString"><span><a class="anchor" href="#test-Date.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocalestring">Date.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -2285,8 +2215,6 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2342,8 +2270,6 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleDateString"><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaledatestring">Date.prototype.toLocaleDateString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -2402,8 +2328,6 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2459,8 +2383,6 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleTimeString"><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaletimestring">Date.prototype.toLocaleTimeString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="1">1/1</td>
@@ -2519,8 +2441,6 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -115,10 +115,6 @@
 <th class="platform babel compiler" data-browser="babel"><a href="#babel" class="browser-name"><abbr title="Babel 6.5 + core-js 2.4">Babel +<br><nobr>core-js</nobr></abbr></a><a href="#babel-optional-note"><sup>[2]</sup></a></th>
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20161024">Closure</abbr></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.4">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
-<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
-<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
-<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -176,17 +172,13 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="62">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="58">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-SIMD_(Single_Instruction,_Multiple_Data)"><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/">SIMD (Single Instruction, Multiple Data)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/57</td>
 <td class="tally" data-browser="babel" data-tally="0">0/57</td>
 <td class="tally" data-browser="closure" data-tally="0">0/57</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/57</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.017543859649122806">0/57</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.543859649122807">0/57</td>
@@ -256,10 +248,6 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -321,10 +309,6 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -386,10 +370,6 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -451,10 +431,6 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -516,10 +492,6 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -581,10 +553,6 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -646,10 +614,6 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -711,10 +675,6 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -776,10 +736,6 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -841,10 +797,6 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -906,10 +858,6 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -973,10 +921,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1040,10 +984,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1107,10 +1047,6 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1174,10 +1110,6 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1241,10 +1173,6 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1308,10 +1236,6 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1375,10 +1299,6 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1442,10 +1362,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1509,10 +1425,6 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1576,10 +1488,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1643,10 +1551,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1710,10 +1614,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1777,10 +1677,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1844,10 +1740,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1911,10 +1803,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -1978,10 +1866,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2045,10 +1929,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2112,10 +1992,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2179,10 +2055,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2246,10 +2118,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2313,10 +2181,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2380,10 +2244,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2447,10 +2307,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2514,10 +2370,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2581,10 +2433,6 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2648,10 +2496,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2715,10 +2559,6 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2782,10 +2622,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2849,10 +2685,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2916,10 +2748,6 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -2983,10 +2811,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3050,10 +2874,6 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3117,10 +2937,6 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3184,10 +3000,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3251,10 +3063,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3318,10 +3126,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3385,10 +3189,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3452,10 +3252,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3519,10 +3315,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3586,10 +3378,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3653,10 +3441,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3720,10 +3504,6 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3787,10 +3567,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[4]</sup></a></td>
@@ -3854,10 +3630,6 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3921,10 +3693,6 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3986,10 +3754,6 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4048,10 +3812,6 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -4114,10 +3874,6 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4181,10 +3937,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4243,10 +3995,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="babel" data-tally="0">0/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -4310,10 +4058,6 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4382,10 +4126,6 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4444,10 +4184,6 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -4516,10 +4252,6 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4598,10 +4330,6 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4670,10 +4398,6 @@ return result.groups.year === &apos;2016&apos;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4736,10 +4460,6 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4802,10 +4522,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4864,10 +4580,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="babel" data-tally="0">0/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
@@ -4931,10 +4643,6 @@ return fn + &apos;&apos; === str;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4997,10 +4705,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5063,10 +4767,6 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5129,10 +4829,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5195,10 +4891,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5261,10 +4953,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5327,10 +5015,6 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5384,7 +5068,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="62">Draft (stage 2)</td>
+<tr class="category"><td colspan="58">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -5400,10 +5084,6 @@ return result === &apos;tromple&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5462,10 +5142,6 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="babel" data-tally="0">0/1</td>
 <td class="tally" data-browser="closure" data-tally="0">0/1</td>
 <td class="tally" data-browser="typescript" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/1</td>
@@ -5535,10 +5211,6 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="babel">No<a href="#regenerator-decorators-legacy-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5597,10 +5269,6 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally" data-browser="babel" data-tally="1">4/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5662,10 +5330,6 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5727,10 +5391,6 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -5792,10 +5452,6 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5857,10 +5513,6 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5919,10 +5571,6 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="babel" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
@@ -5988,10 +5636,6 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6062,10 +5706,6 @@ return new C(42).x() === 42;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6133,10 +5773,6 @@ return new C().x() === 42;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6190,7 +5826,7 @@ return new C().x() === 42;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="62">Proposal (stage 1)</td>
+<tr class="category"><td colspan="58">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://gist.github.com/dherman/1c97dfb25179fa34a41b5fff040f9879">do expressions</a></span><script data-source="
 return do {
@@ -6203,10 +5839,6 @@ return do {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6271,10 +5903,6 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6333,10 +5961,6 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="babel" data-tally="1">8/8</td>
 <td class="tally" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/8</td>
@@ -6398,10 +6022,6 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6463,10 +6083,6 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6528,10 +6144,6 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6603,10 +6215,6 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6669,10 +6277,6 @@ return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6735,10 +6339,6 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6800,10 +6400,6 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6865,10 +6461,6 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6940,10 +6532,6 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7009,10 +6597,6 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7075,10 +6659,6 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7132,17 +6712,13 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="62">Strawman (stage 0)</td>
+<tr class="category"><td colspan="58">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7206,10 +6782,6 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7272,10 +6844,6 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7337,10 +6905,6 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7399,10 +6963,6 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -7465,10 +7025,6 @@ return f();
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7530,10 +7086,6 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7600,10 +7152,6 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7676,10 +7224,6 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7748,10 +7292,6 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7810,10 +7350,6 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7877,10 +7413,6 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7944,10 +7476,6 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8006,10 +7534,6 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -8071,10 +7595,6 @@ return typeof Zone == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8136,10 +7656,6 @@ return &apos;current&apos; in Zone;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8201,10 +7717,6 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8266,10 +7778,6 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8331,10 +7839,6 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8396,10 +7900,6 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8461,10 +7961,6 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8529,10 +8025,6 @@ passed = true;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8591,10 +8083,6 @@ passed = true;
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -8662,10 +8150,6 @@ return (function f(n){
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8740,10 +8224,6 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8797,17 +8277,13 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="ios10_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="ios11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="62">Pre-strawman</td>
+<tr class="category"><td colspan="58">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -8869,10 +8345,6 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8934,10 +8406,6 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8999,10 +8467,6 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9064,10 +8528,6 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9129,10 +8589,6 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9194,10 +8650,6 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9259,10 +8711,6 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9324,10 +8772,6 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9389,10 +8833,6 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
-<td class="no obsolete not-applicable" data-browser="ie7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -105,10 +105,6 @@
             <!-- TABLE HEADERS -->
           <th class="platform konq44 desktop obsolete" data-browser="konq44"><a href="#konq44" class="browser-name"><abbr title="Konqueror 4.4">Konq 4.4</abbr></a></th>
 <th class="platform konq49 desktop obsolete" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></a></th>
-<th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
-<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
-<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -162,10 +158,6 @@
         <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq44" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/4</td>
@@ -218,10 +210,6 @@ return typeof uneval == &apos;function&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -282,10 +270,6 @@ return &apos;toSource&apos; in Object.prototype
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -338,10 +322,6 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -483,10 +463,6 @@ return true;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -540,10 +516,6 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -590,7 +562,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -600,10 +572,6 @@ return 'caller' in function(){};
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -662,10 +630,6 @@ return (function () {}).arity === 0 &&
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -726,10 +690,6 @@ return f(1, 'boo');
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -784,10 +744,6 @@ return typeof Function.prototype.isGenerator == 'function';
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -834,7 +790,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -843,10 +799,6 @@ return new C instanceof C;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -903,10 +855,6 @@ return typeof ({}).__count__ === 'number' &&
 }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -961,10 +909,6 @@ return typeof ({}).__parent__ !== 'undefined';
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1029,10 +973,6 @@ return executed;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1087,10 +1027,6 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1145,10 +1081,6 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1195,7 +1127,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -1205,10 +1137,6 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1261,10 +1189,6 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1317,10 +1241,6 @@ return (function(x)x)(1) === 1;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1373,10 +1293,6 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1433,10 +1349,6 @@ return str === &quot;foobarbaz&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1490,10 +1402,6 @@ return arr[1] === arr;
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1540,7 +1448,7 @@ return arr[1] === arr;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -1580,10 +1488,6 @@ catch(e) {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1676,10 +1580,6 @@ catch(e) {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1771,10 +1671,6 @@ global.test((function () {
         }</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1829,10 +1725,6 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1892,10 +1784,6 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1942,7 +1830,7 @@ return passed;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -1966,10 +1854,6 @@ try {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2028,10 +1912,6 @@ return RegExp.lastMatch === 'x';
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2092,10 +1972,6 @@ return true;
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2148,10 +2024,6 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2205,10 +2077,6 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2255,16 +2123,12 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2315,10 +2179,6 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2365,16 +2225,12 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2435,10 +2291,6 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2485,16 +2337,12 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2545,10 +2393,6 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 function () { return typeof Object.prototype.unwatch == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2599,10 +2443,6 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 function () { return typeof Object.prototype.eval == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2655,10 +2495,6 @@ return typeof Object.observe == &apos;function&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2705,7 +2541,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -2723,10 +2559,6 @@ try {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2781,10 +2613,6 @@ return 'lineNumber' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2839,10 +2667,6 @@ return 'columnNumber' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2897,10 +2721,6 @@ return 'fileName' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="no obsolete" data-browser="ie7">No</td>
-<td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2955,10 +2775,6 @@ return 'description' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
-<td class="yes obsolete" data-browser="ie7">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -3005,7 +2821,7 @@ return 'description' in new Error();
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="54" class="separator"></th>
+<tr><th colspan="50" class="separator"></th>
 </tr>
 </tbody>
       </table>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -105,6 +105,9 @@
             <!-- TABLE HEADERS -->
           <th class="platform konq44 desktop obsolete" data-browser="konq44"><a href="#konq44" class="browser-name"><abbr title="Konqueror 4.4">Konq 4.4</abbr></a></th>
 <th class="platform konq49 desktop obsolete" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></a></th>
+<th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
+<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
+<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -158,6 +161,9 @@
         <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq44" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="konq49" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/4</td>
@@ -210,6 +216,9 @@ return typeof uneval == &apos;function&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -270,6 +279,9 @@ return &apos;toSource&apos; in Object.prototype
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -322,6 +334,9 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -463,6 +478,9 @@ return true;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -516,6 +534,9 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -562,7 +583,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -572,6 +593,9 @@ return 'caller' in function(){};
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -630,6 +654,9 @@ return (function () {}).arity === 0 &&
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -690,6 +717,9 @@ return f(1, 'boo');
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -744,6 +774,9 @@ return typeof Function.prototype.isGenerator == 'function';
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -790,7 +823,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -799,6 +832,9 @@ return new C instanceof C;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -855,6 +891,9 @@ return typeof ({}).__count__ === 'number' &&
 }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -909,6 +948,9 @@ return typeof ({}).__parent__ !== 'undefined';
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -973,6 +1015,9 @@ return executed;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1027,6 +1072,9 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1081,6 +1129,9 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1127,7 +1178,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -1137,6 +1188,9 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1189,6 +1243,9 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1241,6 +1298,9 @@ return (function(x)x)(1) === 1;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1293,6 +1353,9 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1349,6 +1412,9 @@ return str === &quot;foobarbaz&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1402,6 +1468,9 @@ return arr[1] === arr;
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1448,7 +1517,7 @@ return arr[1] === arr;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -1488,6 +1557,9 @@ catch(e) {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1580,6 +1652,9 @@ catch(e) {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1671,6 +1746,9 @@ global.test((function () {
         }</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1725,6 +1803,9 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1784,6 +1865,9 @@ return passed;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1830,7 +1914,7 @@ return passed;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -1854,6 +1938,9 @@ try {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1912,6 +1999,9 @@ return RegExp.lastMatch === 'x';
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1972,6 +2062,9 @@ return true;
   }())</script></td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2024,6 +2117,9 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2077,6 +2173,9 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2123,12 +2222,15 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2179,6 +2281,9 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2225,12 +2330,15 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2291,6 +2399,9 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2337,12 +2448,15 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2393,6 +2507,9 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 function () { return typeof Object.prototype.unwatch == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2443,6 +2560,9 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 function () { return typeof Object.prototype.eval == 'function' }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2495,6 +2615,9 @@ return typeof Object.observe == &apos;function&apos;;
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2541,7 +2664,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -2559,6 +2682,9 @@ try {
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2613,6 +2739,9 @@ return 'lineNumber' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2667,6 +2796,9 @@ return 'columnNumber' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2721,6 +2853,9 @@ return 'fileName' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2775,6 +2910,9 @@ return 'description' in new Error();
   }())</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
+<td class="yes obsolete" data-browser="ie8">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -2821,7 +2959,7 @@ return 'description' in new Error();
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
-<tr><th colspan="50" class="separator"></th>
+<tr><th colspan="53" class="separator"></th>
 </tr>
 </tbody>
       </table>


### PR DESCRIPTION
Microsoft has EOLed all versions of IE but IE11 more than a year ago:
https://www.microsoft.com/en-us/windowsforbusiness/end-of-ie-support

I am retiring these ancient versions from all tables.