### PR TITLE
Object rest and Object spread were removed from Safari and Safari TP

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1045,7 +1045,7 @@ exports.tests = [
         chrome60: true,
         safari11: false,
         safaritp: false,
-        webkit: true,
+        webkit: false,
         duktape2_0: false,
       }
     },
@@ -1065,7 +1065,7 @@ exports.tests = [
         typescript: true,
         safari11: false,
         safaritp: false,
-        webkit: true,
+        webkit: false,
         duktape2_0: false,
       }
     },

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1043,8 +1043,8 @@ exports.tests = [
         firefox55: true,
         chrome58: 'flagged',
         chrome60: true,
-        safari11: true,
-        safaritp: true,
+        safari11: false,
+        safaritp: false,
         webkit: true,
         duktape2_0: false,
       }
@@ -1063,8 +1063,8 @@ exports.tests = [
         chrome58: 'flagged',
         chrome60: true,
         typescript: true,
-        safari11: true,
-        safaritp: true,
+        safari11: false,
+        safaritp: false,
         webkit: true,
         duktape2_0: false,
       }

--- a/environments.json
+++ b/environments.json
@@ -1413,7 +1413,7 @@
     "unstable": true
   },
   "safaritp": {
-    "full": "Safari Technology Preview Release 32",
+    "full": "Safari Technology Preview Release 33",
     "family": "JavaScriptCore",
     "short": "SF TP",
     "unstable": true

--- a/environments.json
+++ b/environments.json
@@ -1419,7 +1419,7 @@
     "unstable": true
   },
   "webkit": {
-    "full": "Webkit r217877 (June 7, 2017)",
+    "full": "Webkit r218633 (June 21, 2017)",
     "family": "JavaScriptCore",
     "short": "WK",
     "unstable": true

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -145,7 +145,7 @@
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r218633 (June 21, 2017)">WK</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -144,7 +144,7 @@
 <th class="platform safari10 desktop" data-browser="safari10"><a href="#safari10" class="browser-name"><abbr title="Safari 10">SF 10</abbr></a></th>
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
-<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 32">SF TP</abbr></a></th>
+<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>

--- a/es5/index.html
+++ b/es5/index.html
@@ -156,7 +156,7 @@
 <th class="platform safari10 desktop" data-browser="safari10"><a href="#safari10" class="browser-name"><abbr title="Safari 10">SF 10</abbr></a></th>
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
-<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 32">SF TP</abbr></a></th>
+<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
 <th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
 <th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>

--- a/es5/index.html
+++ b/es5/index.html
@@ -157,7 +157,7 @@
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r218633 (June 21, 2017)">WK</abbr></a></th>
 <th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
 <th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>

--- a/es6/index.html
+++ b/es6/index.html
@@ -186,7 +186,7 @@
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r218633 (June 21, 2017)">WK</abbr></a></th>
 <th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform ejs engine unstable" data-browser="ejs"><a href="#ejs" class="browser-name"><abbr title="Echo JS">Echo JS</abbr></a></th>

--- a/es6/index.html
+++ b/es6/index.html
@@ -185,7 +185,7 @@
 <th class="platform safari10 desktop" data-browser="safari10"><a href="#safari10" class="browser-name"><abbr title="Safari 10">SF 10</abbr></a></th>
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
-<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 32">SF TP</abbr></a></th>
+<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
 <th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -159,7 +159,7 @@
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r218633 (June 21, 2017)">WK</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -158,7 +158,7 @@
 <th class="platform safari10 desktop" data-browser="safari10"><a href="#safari10" class="browser-name"><abbr title="Safari 10">SF 10</abbr></a></th>
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
-<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 32">SF TP</abbr></a></th>
+<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -149,7 +149,7 @@
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r218633 (June 21, 2017)">WK</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
@@ -3846,7 +3846,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally" data-browser="safari10_1" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="webkit" data-tally="0">0/2</td>
 <td class="tally" data-browser="phantom" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -3908,7 +3908,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no" data-browser="safari10_1">No</td>
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
-<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no unstable" data-browser="webkit">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -3971,7 +3971,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no" data-browser="safari10_1">No</td>
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
-<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no unstable" data-browser="webkit">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -148,7 +148,7 @@
 <th class="platform safari10 desktop" data-browser="safari10"><a href="#safari10" class="browser-name"><abbr title="Safari 10">SF 10</abbr></a></th>
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
-<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 32">SF TP</abbr></a></th>
+<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
@@ -3844,8 +3844,8 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="safari9" data-tally="0">0/2</td>
 <td class="tally" data-browser="safari10" data-tally="0">0/2</td>
 <td class="tally" data-browser="safari10_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="safari11" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="safari11" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
 <td class="tally" data-browser="phantom" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
@@ -3863,7 +3863,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally" data-browser="ios9" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios10_3" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="ios11" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="ios11" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="object_rest/spread_properties" id="test-object_rest/spread_properties_object_rest_properties"><td><span><a class="anchor" href="#test-object_rest/spread_properties_object_rest_properties">&#xA7;</a>object rest properties</span><script data-source="
 var {a, ...rest} = {a: 1, b: 2, c: 3};
@@ -3906,8 +3906,8 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
 <td class="no" data-browser="safari10_1">No</td>
-<td class="yes unstable" data-browser="safari11">Yes</td>
-<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="no unstable" data-browser="safari11">No</td>
+<td class="no unstable" data-browser="safaritp">No</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -3925,7 +3925,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 <td class="no" data-browser="ios10_3">No</td>
-<td class="yes unstable" data-browser="ios11">Yes</td>
+<td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="subtest" data-parent="object_rest/spread_properties" id="test-object_rest/spread_properties_object_spread_properties"><td><span><a class="anchor" href="#test-object_rest/spread_properties_object_spread_properties">&#xA7;</a>object spread properties</span><script data-source="
 var spread = {b: 2, c: 3};
@@ -3969,8 +3969,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
 <td class="no" data-browser="safari10_1">No</td>
-<td class="yes unstable" data-browser="safari11">Yes</td>
-<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="no unstable" data-browser="safari11">No</td>
+<td class="no unstable" data-browser="safaritp">No</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -3988,7 +3988,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 <td class="no" data-browser="ios10_3">No</td>
-<td class="yes unstable" data-browser="ios11">Yes</td>
+<td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a><a href="https://github.com/tc39/proposal-global">global</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -141,7 +141,7 @@
 <th class="platform safari10 desktop" data-browser="safari10"><a href="#safari10" class="browser-name"><abbr title="Safari 10">SF 10</abbr></a></th>
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
-<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 32">SF TP</abbr></a></th>
+<th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
 <th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
 <th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -142,7 +142,7 @@
 <th class="platform safari10_1 desktop" data-browser="safari10_1"><a href="#safari10_1" class="browser-name"><abbr title="Safari 10.1">SF 10.1</abbr></a></th>
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 33">SF TP</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r217877 (June 7, 2017)">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r218633 (June 21, 2017)">WK</abbr></a></th>
 <th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
 <th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>


### PR DESCRIPTION
For some reason Object rest and Object spread were removed from Safari 11 and Safari TP 33. I think it's also applies to Webkit Nightly but I can't check this (Webkit Nightly doesn't work on macOS 10.13 yet) 