### PR TITLE
declare traceur, phantom.js, and besen as obsolete

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -12,7 +12,7 @@
     "full": "Traceur",
     "short": "Traceur",
     "platformtype": "compiler",
-    "obsolete": false,
+    "obsolete": true,
     "test_suites": [
       "es6",
       "es2016plus",
@@ -1661,7 +1661,7 @@
     "full": "Bero's EcmaScript Engine (version 1.0.0.489)",
     "short": "BESEN",
     "link": "http://besen.sourceforge.net/",
-    "obsolete": false,
+    "obsolete": true,
     "platformtype": "engine",
     "test_suites": [
       "es5",
@@ -1672,6 +1672,7 @@
     "full": "PhantomJS 2.0",
     "short": "PJS",
     "platformtype": "engine",
+    "obsolete": true,
     "equals": "safari6",
     "needs_annex_b": true
   },

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -121,7 +121,7 @@
           <th></th>
 
           <!-- TABLE HEADERS -->
-        <th class="platform tr compiler" data-browser="tr"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></a></th>
+        <th class="platform tr compiler obsolete" data-browser="tr"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></a></th>
 <th class="platform babel compiler" data-browser="babel"><a href="#babel" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel +<br><nobr>core-js</nobr></abbr></a><a href="#babel-optional-note"><sup>[2]</sup></a></th>
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20170806">Closure</abbr></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
@@ -162,7 +162,7 @@
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 36">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r219218 (July 6, 2017)">WK</abbr></a></th>
-<th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
+<th class="platform phantom engine obsolete" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
@@ -192,7 +192,7 @@
       <tr class="category"><td colspan="66">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="babel" data-tally="1">3/3</td>
 <td class="tally" data-browser="closure" data-tally="1">3/3</td>
 <td class="tally" data-browser="typescript" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -233,7 +233,7 @@
 <td class="tally unstable" data-browser="safari11" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/3</td>
@@ -260,7 +260,7 @@
 return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nreturn 2 ** 3 === 8 && -(5 ** 2) === -25 && (-5) ** 2 === 25;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nreturn 2 ** 3 === 8 && -(5 ** 2) === -25 && (-5) ** 2 === 25;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
+<td class="yes obsolete" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -301,7 +301,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -328,7 +328,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 var a = 2; a **= 3; return a === 8;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nvar a = 2; a **= 3; return a === 8;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nvar a = 2; a **= 3; return a === 8;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
+<td class="yes obsolete" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -369,7 +369,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -401,7 +401,7 @@ return true;
 }
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("3");try{return Function("asyncTestPassed","\nif (2 ** 3 !== 8) { return false; }\ntry {\nFunction(\"-5 ** 2\")();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("3");return Function("asyncTestPassed","'use strict';"+"\nif (2 ** 3 !== 8) { return false; }\ntry {\nFunction(\"-5 ** 2\")();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
@@ -442,7 +442,7 @@ return true;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -466,7 +466,7 @@ return true;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array.prototype.includes"><span><a class="anchor" href="#test-Array.prototype.includes">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-array.prototype.includes">Array.prototype.includes</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel" data-tally="1">3/3</td>
 <td class="tally" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="typescript" data-tally="1">3/3</td>
@@ -507,7 +507,7 @@ return true;
 <td class="tally unstable" data-browser="safari11" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/3</td>
@@ -538,7 +538,7 @@ return [1, 2, 3].includes(1)
 &amp;&amp; Array(1).includes();
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].includes(1)\n&& ![1, 2, 3].includes(4)\n&& ![1, 2, 3].includes(1, 1)\n&& [NaN].includes(NaN)\n&& Array(1).includes();\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].includes(1)\n&& ![1, 2, 3].includes(4)\n&& ![1, 2, 3].includes(1, 1)\n&& [NaN].includes(NaN)\n&& Array(1).includes();\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -579,7 +579,7 @@ return [1, 2, 3].includes(1)
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -628,7 +628,7 @@ return 24;
 }, &apos;foo&apos;, 6) === true &amp;&amp; passed === 3;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");try{return Function("asyncTestPassed","\nvar passed = 0;\nreturn [].includes.call({\nget \"0\"() {\npassed = NaN;\nreturn 'foo';\n},\nget \"11\"() {\npassed += 1;\nreturn 0;\n},\nget \"19\"() {\npassed += 1;\nreturn 'foo';\n},\nget \"21\"() {\npassed = NaN;\nreturn 'foo';\n},\nget length() {\npassed += 1;\nreturn 24;\n}\n}, 'foo', 6) === true && passed === 3;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("6");return Function("asyncTestPassed","'use strict';"+"\nvar passed = 0;\nreturn [].includes.call({\nget \"0\"() {\npassed = NaN;\nreturn 'foo';\n},\nget \"11\"() {\npassed += 1;\nreturn 0;\n},\nget \"19\"() {\npassed += 1;\nreturn 'foo';\n},\nget \"21\"() {\npassed = NaN;\nreturn 'foo';\n},\nget length() {\npassed += 1;\nreturn 24;\n}\n}, 'foo', 6) === true && passed === 3;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -669,7 +669,7 @@ return 24;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -701,7 +701,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 });
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\nreturn [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,\nInt32Array, Uint32Array, Float32Array, Float64Array].every(function(TypedArray){\nreturn new TypedArray([1, 2, 3]).includes(1)\n&& !new TypedArray([1, 2, 3]).includes(4)\n&& !new TypedArray([1, 2, 3]).includes(1, 1);\n});\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\nreturn [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,\nInt32Array, Uint32Array, Float32Array, Float64Array].every(function(TypedArray){\nreturn new TypedArray([1, 2, 3]).includes(1)\n&& !new TypedArray([1, 2, 3]).includes(4)\n&& !new TypedArray([1, 2, 3]).includes(1, 1);\n});\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -742,7 +742,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -778,7 +778,7 @@ return true;
 }
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("8");try{return Function("asyncTestPassed","\nfunction * generator() {\nyield 3;\n}\ntry {\nnew generator();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("8");return Function("asyncTestPassed","'use strict';"+"\nfunction * generator() {\nyield 3;\n}\ntry {\nnew generator();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -819,7 +819,7 @@ return true;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -859,7 +859,7 @@ iter.next();
 return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nfunction * generator() {\nyield * (function * () {\ntry {\nyield 'foo';\n}\ncatch(e) {\nreturn;\n}\n}());\nyield 'bar';\n}\nvar iter = generator();\niter.next();\nreturn iter['throw']().value === 'bar';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nfunction * generator() {\nyield * (function * () {\ntry {\nyield 'foo';\n}\ncatch(e) {\nreturn;\n}\n}());\nyield 'bar';\n}\nvar iter = generator();\niter.next();\nreturn iter['throw']().value === 'bar';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -900,7 +900,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no flagged obsolete" data-browser="node0_12">Flag</td>
 <td class="no flagged obsolete" data-browser="iojs">Flag</td>
@@ -932,7 +932,7 @@ return true;
 }
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("10");try{return Function("asyncTestPassed","\nfunction foo(...a){}\ntry {\nFunction(\"function bar(...a){'use strict';}\")();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("10");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(...a){}\ntry {\nFunction(\"function bar(...a){'use strict';}\")();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -973,7 +973,7 @@ return true;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1001,7 +1001,7 @@ var [x, ...[y, ...z]] = [1,2,3,4];
 return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -1042,7 +1042,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1071,7 +1071,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 }([1,2,3,4]);
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("12");try{return Function("asyncTestPassed","\nreturn function([x, ...[y, ...z]]) {\nreturn x === 1 && y === 2 && z + '' === '3,4';\n}([1,2,3,4]);\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("12");return Function("asyncTestPassed","'use strict';"+"\nreturn function([x, ...[y, ...z]]) {\nreturn x === 1 && y === 2 && z + '' === '3,4';\n}([1,2,3,4]);\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -1112,7 +1112,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1146,7 +1146,7 @@ for(var key in proxy); // Should not throw, nor execute the &apos;enumerate&apos
 return passed;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nvar passed = true;\nvar proxy = new Proxy({}, {\nenumerate: function() {\npassed = false;\n}\n});\nfor(var key in proxy); // Should not throw, nor execute the 'enumerate' method.\nreturn passed;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nvar passed = true;\nvar proxy = new Proxy({}, {\nenumerate: function() {\npassed = false;\n}\n});\nfor(var key in proxy); // Should not throw, nor execute the 'enumerate' method.\nreturn passed;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1187,7 +1187,7 @@ return passed;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1223,7 +1223,7 @@ Array.prototype.includes.call(p, NaN, 1);
 return (get + &apos;&apos; === &quot;length,1,2&quot;);
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\n// Array.prototype.includes -> Get -> [[Get]]\nvar get = [];\nvar p = new Proxy({length: 3, 0: '', 1: '', 2: '', 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});\nArray.prototype.includes.call(p, {});\nif (get + '' !== \"length,0,1,2\") return;\n\nget = [];\np = new Proxy({length: 4, 0: NaN, 1: '', 2: NaN, 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});\nArray.prototype.includes.call(p, NaN, 1);\nreturn (get + '' === \"length,1,2\");\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\n// Array.prototype.includes -> Get -> [[Get]]\nvar get = [];\nvar p = new Proxy({length: 3, 0: '', 1: '', 2: '', 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});\nArray.prototype.includes.call(p, {});\nif (get + '' !== \"length,0,1,2\") return;\n\nget = [];\np = new Proxy({length: 4, 0: NaN, 1: '', 2: NaN, 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});\nArray.prototype.includes.call(p, NaN, 1);\nreturn (get + '' === \"length,1,2\");\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1264,7 +1264,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1290,7 +1290,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <tr class="category"><td colspan="66">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
 <td class="tally" data-browser="babel" data-tally="1">4/4</td>
 <td class="tally" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
@@ -1331,7 +1331,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally unstable" data-browser="safari11" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/4</td>
@@ -1361,7 +1361,7 @@ var v = Object.values(obj);
 return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar v = Object.values(obj);\nreturn Array.isArray(v) && String(v) === \"foo,bar,baz\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar v = Object.values(obj);\nreturn Array.isArray(v) && String(v) === \"foo,bar,baz\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -1402,7 +1402,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1436,7 +1436,7 @@ return Array.isArray(e)
 &amp;&amp; String(e[2]) === &quot;c,baz&quot;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar e = Object.entries(obj);\nreturn Array.isArray(e)\n&& e.length === 3\n&& String(e[0]) === \"a,foo\"\n&& String(e[1]) === \"b,bar\"\n&& String(e[2]) === \"c,baz\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar e = Object.entries(obj);\nreturn Array.isArray(e)\n&& e.length === 3\n&& String(e[0]) === \"a,foo\"\n&& String(e[1]) === \"b,bar\"\n&& String(e[2]) === \"c,baz\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -1477,7 +1477,7 @@ return Array.isArray(e)
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1512,7 +1512,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 &amp;&amp; D.c.value === 3 &amp;&amp; D.c.enumerable === false &amp;&amp; D.c.configurable === false &amp;&amp; D.c.writable === false;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n&& D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n&& D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n&& D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n&& D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -1553,7 +1553,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1583,7 +1583,7 @@ var P = new Proxy({a:1}, {
 return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nvar P = new Proxy({a:1}, {\n  getOwnPropertyDescriptor: function(t, k) {}\n});\nreturn !Object.getOwnPropertyDescriptors(P).hasOwnProperty('a');\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nvar P = new Proxy({a:1}, {\n  getOwnPropertyDescriptor: function(t, k) {}\n});\nreturn !Object.getOwnPropertyDescriptors(P).hasOwnProperty('a');\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -1624,7 +1624,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1648,7 +1648,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String_padding"><span><a class="anchor" href="#test-String_padding">&#xA7;</a><a href="https://github.com/tc39/proposal-string-pad-start-end">String padding</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
@@ -1689,7 +1689,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally unstable" data-browser="safari11" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/2</td>
@@ -1721,7 +1721,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 &amp;&amp; &apos;hello&apos;.padStart(3, &apos;123&apos;) === &apos;hello&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn 'hello'.padStart(10) === '     hello'\n&& 'hello'.padStart(10, '1234') === '12341hello'\n&& 'hello'.padStart() === 'hello'\n&& 'hello'.padStart(6, '123') === '1hello'\n&& 'hello'.padStart(3) === 'hello'\n&& 'hello'.padStart(3, '123') === 'hello';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn 'hello'.padStart(10) === '     hello'\n&& 'hello'.padStart(10, '1234') === '12341hello'\n&& 'hello'.padStart() === 'hello'\n&& 'hello'.padStart(6, '123') === '1hello'\n&& 'hello'.padStart(3) === 'hello'\n&& 'hello'.padStart(3, '123') === 'hello';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -1762,7 +1762,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1794,7 +1794,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 &amp;&amp; &apos;hello&apos;.padEnd(3, &apos;123&apos;) === &apos;hello&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\nreturn 'hello'.padEnd(10) === 'hello     '\n&& 'hello'.padEnd(10, '1234') === 'hello12341'\n&& 'hello'.padEnd() === 'hello'\n&& 'hello'.padEnd(6, '123') === 'hello1'\n&& 'hello'.padEnd(3) === 'hello'\n&& 'hello'.padEnd(3, '123') === 'hello';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\nreturn 'hello'.padEnd(10) === 'hello     '\n&& 'hello'.padEnd(10, '1234') === 'hello12341'\n&& 'hello'.padEnd() === 'hello'\n&& 'hello'.padEnd(6, '123') === 'hello1'\n&& 'hello'.padEnd(3) === 'hello'\n&& 'hello'.padEnd(3, '123') === 'hello';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -1835,7 +1835,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1859,7 +1859,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-trailing_commas_in_function_syntax"><span><a class="anchor" href="#test-trailing_commas_in_function_syntax">&#xA7;</a><a href="https://github.com/tc39/proposal-trailing-function-commas">trailing commas in function syntax</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
@@ -1900,7 +1900,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally unstable" data-browser="safari11" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/2</td>
@@ -1927,7 +1927,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 return typeof function f( a, b, ){} === &apos;function&apos;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\nreturn typeof function f( a, b, ){} === 'function';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof function f( a, b, ){} === 'function';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -1968,7 +1968,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1995,7 +1995,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 return Math.min(1,2,3,) === 1;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("25");try{return Function("asyncTestPassed","\nreturn Math.min(1,2,3,) === 1;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("25");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.min(1,2,3,) === 1;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -2036,7 +2036,7 @@ return Math.min(1,2,3,) === 1;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2060,7 +2060,7 @@ return Math.min(1,2,3,) === 1;
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-async_functions"><span><a class="anchor" href="#test-async_functions">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-async-function-definitions">async functions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally" data-browser="tr" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally" data-browser="babel" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally" data-browser="closure" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally" data-browser="typescript" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
@@ -2101,7 +2101,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally unstable" data-browser="safari11" data-tally="1">15/15</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">15/15</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">15/15</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/15</td>
@@ -2139,7 +2139,7 @@ p.then(function(result) {
 });
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nasync function a(){\n  return \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){\n  return \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
+<td class="yes obsolete" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
@@ -2180,7 +2180,7 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2218,7 +2218,7 @@ p.catch(function(result) {
 });
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nasync function a(){\n  throw \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.catch(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){\n  throw \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.catch(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -2259,7 +2259,7 @@ p.catch(function(result) {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2287,7 +2287,7 @@ async function a(){}
 try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; }
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\nasync function a(){}\ntry { Function(\"async\\n function a(){}\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){}\ntry { Function(\"async\\n function a(){}\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -2328,7 +2328,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2356,7 +2356,7 @@ async function a(){};
 return !a.hasOwnProperty(&quot;prototype&quot;);
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nasync function a(){};\nreturn !a.hasOwnProperty(\"prototype\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){};\nreturn !a.hasOwnProperty(\"prototype\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -2397,7 +2397,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2431,7 +2431,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 }());
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\n(async function (){\n  await Promise.resolve();\n  var a1 = await new Promise(function(resolve) { setTimeout(resolve,800,\"foo\"); });\n  var a2 = await new Promise(function(resolve) { setTimeout(resolve,800,\"bar\"); });\n  if (a1 + a2 === \"foobar\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\n(async function (){\n  await Promise.resolve();\n  var a1 = await new Promise(function(resolve) { setTimeout(resolve,800,\"foo\"); });\n  var a2 = await new Promise(function(resolve) { setTimeout(resolve,800,\"bar\"); });\n  if (a1 + a2 === \"foobar\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
+<td class="yes obsolete" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
@@ -2472,7 +2472,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2508,7 +2508,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 }());
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\n(async function (){\n  await Promise.resolve();\n  try {\n    var a1 = await new Promise(function(_, reject) { setTimeout(reject,800,\"foo\"); });\n  } catch(e) {\n    if (e === \"foo\") {\n      asyncTestPassed();\n    }\n  }\n}());\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\n(async function (){\n  await Promise.resolve();\n  try {\n    var a1 = await new Promise(function(_, reject) { setTimeout(reject,800,\"foo\"); });\n  } catch(e) {\n    if (e === \"foo\") {\n      asyncTestPassed();\n    }\n  }\n}());\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -2549,7 +2549,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2577,7 +2577,7 @@ async function a(){ await Promise.resolve(); }
 try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { return true; }
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nasync function a(){ await Promise.resolve(); }\ntry { Function(\"(async function a(){ await; }())\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){ await Promise.resolve(); }\ntry { Function(\"(async function a(){ await; }())\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -2618,7 +2618,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2651,7 +2651,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 }());
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\n(async function (){\n  await Promise.resolve();\n  var e = await \"foo\";\n  if (e === \"foo\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\n(async function (){\n  await Promise.resolve();\n  var e = await \"foo\";\n  if (e === \"foo\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -2692,7 +2692,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2720,7 +2720,7 @@ async function a(){ await Promise.resolve(); }
 try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(); } catch(e) { return true; }
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("35");try{return Function("asyncTestPassed","\nasync function a(){ await Promise.resolve(); }\ntry { Function(\"(async function a(b = await Promise.resolve()){}())\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("35");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){ await Promise.resolve(); }\ntry { Function(\"(async function a(b = await Promise.resolve()){}())\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -2761,7 +2761,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2799,7 +2799,7 @@ p.then(function(result) {
 });
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nvar o = {\n  async a(){ return await Promise.resolve(\"foo\"); }\n};\nvar p = o.a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nvar o = {\n  async a(){ return await Promise.resolve(\"foo\"); }\n};\nvar p = o.a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -2840,7 +2840,7 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2878,7 +2878,7 @@ p.then(function(result) {
 });
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nclass C {\n  async a(){ return await Promise.resolve(\"foo\"); }\n};\nvar p = new C().a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  async a(){ return await Promise.resolve(\"foo\"); }\n};\nvar p = new C().a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -2919,7 +2919,7 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2955,7 +2955,7 @@ p.then(function(result) {
 });
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nvar a = async () => await Promise.resolve(\"foo\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nvar a = async () => await Promise.resolve(\"foo\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
+<td class="yes obsolete" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="typescript">No</td>
@@ -2996,7 +2996,7 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3026,7 +3026,7 @@ return asyncFunctionProto !== function(){}.prototype
 return passed;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nvar asyncFunctionProto = Object.getPrototypeOf(async function (){});\nreturn asyncFunctionProto !== function(){}.prototype\n  && Object.getPrototypeOf(asyncFunctionProto) === Function.prototype;\nreturn passed;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nvar asyncFunctionProto = Object.getPrototypeOf(async function (){});\nreturn asyncFunctionProto !== function(){}.prototype\n  && Object.getPrototypeOf(asyncFunctionProto) === Function.prototype;\nreturn passed;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -3067,7 +3067,7 @@ return passed;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3094,7 +3094,7 @@ return passed;
 return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;AsyncFunction&quot;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nreturn Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == \"AsyncFunction\";\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == \"AsyncFunction\";\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -3135,7 +3135,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3171,7 +3171,7 @@ p.then(function(result) {
 });
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nvar a = async function (){}.constructor(\"return 'foo';\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nvar a = async function (){}.constructor(\"return 'foo';\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -3212,7 +3212,7 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3236,7 +3236,7 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-shared_memory_and_atomics"><span><a class="anchor" href="#test-shared_memory_and_atomics">&#xA7;</a>shared memory and atomics</span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/17</td>
 <td class="tally" data-browser="babel" data-tally="0">0/17</td>
 <td class="tally" data-browser="closure" data-tally="0">0/17</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/17</td>
@@ -3277,7 +3277,7 @@ p.then(function(result) {
 <td class="tally unstable" data-browser="safari11" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">17/17</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/17</td>
@@ -3304,7 +3304,7 @@ p.then(function(result) {
 return typeof SharedArrayBuffer === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("43");try{return Function("asyncTestPassed","\nreturn typeof SharedArrayBuffer === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("43");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SharedArrayBuffer === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3345,7 +3345,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3372,7 +3372,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");try{return Function("asyncTestPassed","\nreturn SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("44");return Function("asyncTestPassed","'use strict';"+"\nreturn SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3413,7 +3413,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3440,7 +3440,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\nreturn 'byteLength' in SharedArrayBuffer.prototype;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\nreturn 'byteLength' in SharedArrayBuffer.prototype;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3481,7 +3481,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3508,7 +3508,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\nreturn typeof SharedArrayBuffer.prototype.slice === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SharedArrayBuffer.prototype.slice === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3549,7 +3549,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3576,7 +3576,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuffer&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\nreturn SharedArrayBuffer.prototype[Symbol.toStringTag] === 'SharedArrayBuffer';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\nreturn SharedArrayBuffer.prototype[Symbol.toStringTag] === 'SharedArrayBuffer';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3617,7 +3617,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3644,7 +3644,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 return typeof Atomics.add == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("48");try{return Function("asyncTestPassed","\nreturn typeof Atomics.add == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("48");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.add == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3685,7 +3685,7 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3712,7 +3712,7 @@ return typeof Atomics.add == &apos;function&apos;;
 return typeof Atomics.and == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("49");try{return Function("asyncTestPassed","\nreturn typeof Atomics.and == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("49");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.and == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3753,7 +3753,7 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3780,7 +3780,7 @@ return typeof Atomics.and == &apos;function&apos;;
 return typeof Atomics.compareExchange == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("50");try{return Function("asyncTestPassed","\nreturn typeof Atomics.compareExchange == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("50");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.compareExchange == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3821,7 +3821,7 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3848,7 +3848,7 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 return typeof Atomics.exchange == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("51");try{return Function("asyncTestPassed","\nreturn typeof Atomics.exchange == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("51");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.exchange == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3889,7 +3889,7 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3916,7 +3916,7 @@ return typeof Atomics.exchange == &apos;function&apos;;
 return typeof Atomics.wait == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("52");try{return Function("asyncTestPassed","\nreturn typeof Atomics.wait == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("52");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.wait == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3957,7 +3957,7 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3984,7 +3984,7 @@ return typeof Atomics.wait == &apos;function&apos;;
 return typeof Atomics.wake == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("53");try{return Function("asyncTestPassed","\nreturn typeof Atomics.wake == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("53");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.wake == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4025,7 +4025,7 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4052,7 +4052,7 @@ return typeof Atomics.wake == &apos;function&apos;;
 return typeof Atomics.isLockFree == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");try{return Function("asyncTestPassed","\nreturn typeof Atomics.isLockFree == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("54");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.isLockFree == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4093,7 +4093,7 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4120,7 +4120,7 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 return typeof Atomics.load == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("55");try{return Function("asyncTestPassed","\nreturn typeof Atomics.load == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("55");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.load == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4161,7 +4161,7 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4188,7 +4188,7 @@ return typeof Atomics.load == &apos;function&apos;;
 return typeof Atomics.or == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");try{return Function("asyncTestPassed","\nreturn typeof Atomics.or == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("56");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.or == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4229,7 +4229,7 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4256,7 +4256,7 @@ return typeof Atomics.or == &apos;function&apos;;
 return typeof Atomics.store == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("57");try{return Function("asyncTestPassed","\nreturn typeof Atomics.store == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("57");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.store == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4297,7 +4297,7 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4324,7 +4324,7 @@ return typeof Atomics.store == &apos;function&apos;;
 return typeof Atomics.sub == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("58");try{return Function("asyncTestPassed","\nreturn typeof Atomics.sub == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("58");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.sub == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4365,7 +4365,7 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4392,7 +4392,7 @@ return typeof Atomics.sub == &apos;function&apos;;
 return typeof Atomics.xor == &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");try{return Function("asyncTestPassed","\nreturn typeof Atomics.xor == 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("59");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.xor == 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4433,7 +4433,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4467,7 +4467,7 @@ return [&apos;a&apos;,&apos;a&apos;,&apos;b&apos;,&apos;b&apos;];
 return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");try{return Function("asyncTestPassed","\nvar P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, \"b\", {value:1})), {\nownKeys: function() {\nreturn ['a','a','b','b'];\n}\n});\nreturn Object.getOwnPropertyNames(P) + '' === \"a,a,b,b\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("60");return Function("asyncTestPassed","'use strict';"+"\nvar P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, \"b\", {value:1})), {\nownKeys: function() {\nreturn ['a','a','b','b'];\n}\n});\nreturn Object.getOwnPropertyNames(P) + '' === \"a,a,b,b\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4508,7 +4508,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4538,7 +4538,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 &amp;&amp; !&quot;\u212a&quot;.match(/.\B/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/.\B/iu);
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");try{return Function("asyncTestPassed","\nreturn \"ſ\".match(/\\w/iu) && !\"ſ\".match(/\\W/iu)\n&& \"\\u212a\".match(/\\w/iu) && !\"\\u212a\".match(/\\W/iu)\n&& \"\\u212a\".match(/.\\b/iu) && \"ſ\".match(/.\\b/iu)\n&& !\"\\u212a\".match(/.\\B/iu) && !\"ſ\".match(/.\\B/iu);\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("61");return Function("asyncTestPassed","'use strict';"+"\nreturn \"ſ\".match(/\\w/iu) && !\"ſ\".match(/\\W/iu)\n&& \"\\u212a\".match(/\\w/iu) && !\"\\u212a\".match(/\\W/iu)\n&& \"\\u212a\".match(/.\\b/iu) && \"ſ\".match(/.\\b/iu)\n&& !\"\\u212a\".match(/.\\B/iu) && !\"ſ\".match(/.\\B/iu);\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4579,7 +4579,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4609,7 +4609,7 @@ return (function(){
 })();
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");try{return Function("asyncTestPassed","\nreturn (function(){\n  'use strict';\n  return !Object.getOwnPropertyDescriptor(arguments,'caller');\n})();\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("62");return Function("asyncTestPassed","'use strict';"+"\nreturn (function(){\n  'use strict';\n  return !Object.getOwnPropertyDescriptor(arguments,'caller');\n})();\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4650,7 +4650,7 @@ return (function(){
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4676,7 +4676,7 @@ return (function(){
 <tr class="category"><td colspan="66">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
-<td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -4717,7 +4717,7 @@ return (function(){
 <td class="tally unstable" data-browser="safari11" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">16/16</td>
-<td class="tally" data-browser="phantom" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
 <td class="tally obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
@@ -4749,7 +4749,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 &amp;&amp; prop.enumerable;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\nvar obj = {};\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -4790,7 +4790,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -4823,7 +4823,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 &amp;&amp; prop.enumerable;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");try{return Function("asyncTestPassed","\nvar obj = {};\nvar sym = Symbol();\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("65");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nvar sym = Symbol();\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -4864,7 +4864,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -4897,7 +4897,7 @@ return true;
 }
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\nvar key = '__accessors_test__';\n__defineGetter__.call(1, key, function(){});\ntry {\n__defineGetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\nvar key = '__accessors_test__';\n__defineGetter__.call(1, key, function(){});\ntry {\n__defineGetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -4938,7 +4938,7 @@ return true;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -4970,7 +4970,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 &amp;&amp; prop.enumerable;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\nvar obj = {};\nfunction bar() {}\nObject.prototype.__defineSetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nfunction bar() {}\nObject.prototype.__defineSetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5011,7 +5011,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -5044,7 +5044,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 &amp;&amp; prop.enumerable;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nvar obj = {};\nvar sym = Symbol();\nfunction bar(baz) {}\nObject.prototype.__defineSetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nvar sym = Symbol();\nfunction bar(baz) {}\nObject.prototype.__defineSetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5085,7 +5085,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -5118,7 +5118,7 @@ return true;
 }
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nvar key = '__accessors_test__';\n__defineSetter__.call(1, key, function(){});\ntry {\n__defineSetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nvar key = '__accessors_test__';\n__defineSetter__.call(1, key, function(){});\ntry {\n__defineSetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5159,7 +5159,7 @@ return true;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -5193,7 +5193,7 @@ return foo() === &quot;bar&quot;
 &amp;&amp; Object.prototype.__lookupGetter__.call(obj, &quot;baz&quot;) === undefined;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5234,7 +5234,7 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -5268,7 +5268,7 @@ return foo() === &quot;bar&quot;
 &amp;&amp; Object.prototype.__lookupGetter__.call(obj, &quot;baz&quot;) === undefined;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5309,7 +5309,7 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -5344,7 +5344,7 @@ return foo() === &quot;bar&quot;
 &amp;&amp; Object.prototype.__lookupGetter__.call(obj, Symbol()) === undefined;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { get: function() { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupGetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupGetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { get: function() { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupGetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupGetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5385,7 +5385,7 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -5417,7 +5417,7 @@ return true;
 }
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\n__lookupGetter__.call(1, 'key');\ntry {\n__lookupGetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\n__lookupGetter__.call(1, 'key');\ntry {\n__lookupGetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5458,7 +5458,7 @@ return true;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -5489,7 +5489,7 @@ a.__defineGetter__(&quot;foo&quot;, function () {})
 return b.__lookupGetter__(&quot;foo&quot;) === undefined
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");try{return Function("asyncTestPassed","\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineGetter__(\"foo\", function () {})\nreturn b.__lookupGetter__(\"foo\") === undefined\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("74");return Function("asyncTestPassed","'use strict';"+"\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineGetter__(\"foo\", function () {})\nreturn b.__lookupGetter__(\"foo\") === undefined\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5530,7 +5530,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -5564,7 +5564,7 @@ return foo() === &quot;bar&quot;
 &amp;&amp; Object.prototype.__lookupSetter__.call(obj, &quot;baz&quot;) === undefined;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("75");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("75");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5605,7 +5605,7 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -5639,7 +5639,7 @@ return foo() === &quot;bar&quot;
 &amp;&amp; Object.prototype.__lookupSetter__.call(obj, &quot;baz&quot;) === undefined;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5680,7 +5680,7 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -5715,7 +5715,7 @@ return foo() === &quot;bar&quot;
 &amp;&amp; Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");try{return Function("asyncTestPassed","\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("77");return Function("asyncTestPassed","'use strict';"+"\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5756,7 +5756,7 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -5788,7 +5788,7 @@ return true;
 }
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");try{return Function("asyncTestPassed","\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("78");return Function("asyncTestPassed","'use strict';"+"\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5829,7 +5829,7 @@ return true;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -5860,7 +5860,7 @@ a.__defineSetter__(&quot;foo&quot;, function () {})
 return b.__lookupSetter__(&quot;foo&quot;) === undefined
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");try{return Function("asyncTestPassed","\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineSetter__(\"foo\", function () {})\nreturn b.__lookupSetter__(\"foo\") === undefined\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("79");return Function("asyncTestPassed","'use strict';"+"\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineSetter__(\"foo\", function () {})\nreturn b.__lookupSetter__(\"foo\") === undefined\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[7]</sup></a></td>
@@ -5901,7 +5901,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -5925,7 +5925,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes unstable" data-browser="ios11">Yes</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Proxy_internal_calls,_getter/setter_methods"><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Proxy internal calls, getter/setter methods</a></span></td>
-<td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -5966,7 +5966,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally unstable" data-browser="safari11" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -5997,7 +5997,7 @@ Object.prototype.__defineGetter__.call(p, &quot;foo&quot;, Object);
 return def + &apos;&apos; === &quot;foo&quot;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("81");try{return Function("asyncTestPassed","\n// Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineGetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("81");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineGetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6038,7 +6038,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6069,7 +6069,7 @@ Object.prototype.__defineSetter__.call(p, &quot;foo&quot;, Object);
 return def + &apos;&apos; === &quot;foo&quot;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");try{return Function("asyncTestPassed","\n// Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineSetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("82");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineSetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6110,7 +6110,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6146,7 +6146,7 @@ Object.prototype.__lookupGetter__.call(p, &quot;foo&quot;);
 return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");try{return Function("asyncTestPassed","\n// Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupGetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("83");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupGetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6187,7 +6187,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6223,7 +6223,7 @@ Object.prototype.__lookupSetter__.call(p, &quot;foo&quot;);
 return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\n// Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupSetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupSetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6264,7 +6264,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6292,7 +6292,7 @@ for (var i = 0 in {}) {}
 return i === 0;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\nfor (var i = 0 in {}) {}\nreturn i === 0;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\nfor (var i = 0 in {}) {}\nreturn i === 0;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6333,7 +6333,7 @@ return i === 0;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6369,7 +6369,7 @@ a === 0;
 return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("86");try{return Function("asyncTestPassed","\nfunction tag(strings, a) {\nreturn strings[0] === void 0 &&\nstrings.raw[0] === \"\\\\01\\\\1\\\\xg\\\\xAg\\\\u0\\\\u0g\\\\u00g\\\\u000g\\\\u{g\\\\u{0\\\\u{110000}\" &&\nstrings[1] === \"\\0\" &&\nstrings.raw[1] === \"\\\\0\" &&\na === 0;\n}\nreturn tag`\\01\\1\\xg\\xAg\\u0\\u0g\\u00g\\u000g\\u{g\\u{0\\u{110000}${0}\\0`;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("86");return Function("asyncTestPassed","'use strict';"+"\nfunction tag(strings, a) {\nreturn strings[0] === void 0 &&\nstrings.raw[0] === \"\\\\01\\\\1\\\\xg\\\\xAg\\\\u0\\\\u0g\\\\u00g\\\\u000g\\\\u{g\\\\u{0\\\\u{110000}\" &&\nstrings[1] === \"\\0\" &&\nstrings.raw[1] === \"\\\\0\" &&\na === 0;\n}\nreturn tag`\\01\\1\\xg\\xAg\\u0\\u0g\\u00g\\u000g\\u{g\\u{0\\u{110000}${0}\\0`;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6410,7 +6410,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -166,8 +166,8 @@
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 36">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r219218 (July 6, 2017)">WK</abbr></a></th>
 <th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
-<th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
-<th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
+<th class="platform besen engine obsolete" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
+<th class="platform phantom engine obsolete" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform ejs engine unstable" data-browser="ejs"><a href="#ejs" class="browser-name"><abbr title="Echo JS">Echo JS</abbr></a></th>
 <th class="platform duktape1_5 engine obsolete" data-browser="duktape1_5"><a href="#duktape1_5" class="browser-name"><abbr title="Duktape 1.5">DUK 1.5</abbr></a></th>
 <th class="platform duktape1_6 engine obsolete" data-browser="duktape1_6"><a href="#duktape1_6" class="browser-name"><abbr title="Duktape 1.6">DUK 1.6</abbr></a></th>
@@ -232,8 +232,8 @@
 <td class="tally unstable" data-browser="safaritp" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="rhino1_7" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
-<td class="tally" data-browser="besen" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
-<td class="tally" data-browser="phantom" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="besen" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/5</td>
@@ -297,8 +297,8 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -364,8 +364,8 @@ return value === 1;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -429,8 +429,8 @@ return { a: true, }.a === true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -494,8 +494,8 @@ return [1,].length === 1;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -559,8 +559,8 @@ return ({ if: 1 }).if === 1;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -623,8 +623,8 @@ return ({ if: 1 }).if === 1;
 <td class="tally unstable" data-browser="safaritp" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="rhino1_7" data-tally="1">13/13</td>
-<td class="tally" data-browser="besen" data-tally="1">13/13</td>
-<td class="tally" data-browser="phantom" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="besen" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/13</td>
@@ -690,8 +690,8 @@ return typeof Object.create == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -757,8 +757,8 @@ return typeof Object.defineProperty == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -824,8 +824,8 @@ return typeof Object.defineProperties == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -891,8 +891,8 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -958,8 +958,8 @@ return typeof Object.keys == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1025,8 +1025,8 @@ return typeof Object.seal == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1092,8 +1092,8 @@ return typeof Object.freeze == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1159,8 +1159,8 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1226,8 +1226,8 @@ return typeof Object.isSealed == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1293,8 +1293,8 @@ return typeof Object.isFrozen == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1360,8 +1360,8 @@ return typeof Object.isExtensible == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1427,8 +1427,8 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1494,8 +1494,8 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1556,8 +1556,8 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally unstable" data-browser="safaritp" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="rhino1_7" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
-<td class="tally" data-browser="besen" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
-<td class="tally" data-browser="phantom" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
+<td class="tally obsolete" data-browser="besen" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/12</td>
@@ -1623,8 +1623,8 @@ return typeof Array.isArray == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1690,8 +1690,8 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1757,8 +1757,8 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1824,8 +1824,8 @@ return typeof Array.prototype.every == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1891,8 +1891,8 @@ return typeof Array.prototype.some == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -1958,8 +1958,8 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2025,8 +2025,8 @@ return typeof Array.prototype.map == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2092,8 +2092,8 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2159,8 +2159,8 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2226,8 +2226,8 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2333,8 +2333,8 @@ return true;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2410,8 +2410,8 @@ try {
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2472,8 +2472,8 @@ try {
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7" data-tally="1">2/2</td>
-<td class="tally" data-browser="besen" data-tally="1">2/2</td>
-<td class="tally" data-browser="phantom" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="besen" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/2</td>
@@ -2539,8 +2539,8 @@ return "foobar"[3] === "b";
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2606,8 +2606,8 @@ return typeof String.prototype.trim == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2668,8 +2668,8 @@ return typeof String.prototype.trim == 'function';
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7" data-tally="1">3/3</td>
-<td class="tally" data-browser="besen" data-tally="1">3/3</td>
-<td class="tally" data-browser="phantom" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="besen" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/3</td>
@@ -2735,8 +2735,8 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2802,8 +2802,8 @@ return typeof Date.now == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2877,8 +2877,8 @@ try {
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -2944,8 +2944,8 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3011,8 +3011,8 @@ return typeof JSON == 'object';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3075,8 +3075,8 @@ return typeof JSON == 'object';
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7" data-tally="1">3/3</td>
-<td class="tally" data-browser="besen" data-tally="1">3/3</td>
-<td class="tally" data-browser="phantom" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="besen" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/3</td>
@@ -3143,8 +3143,8 @@ return result;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3211,8 +3211,8 @@ return result;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3279,8 +3279,8 @@ return result;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3341,8 +3341,8 @@ return result;
 <td class="tally unstable" data-browser="safaritp" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="rhino1_7" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td class="tally" data-browser="besen" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td class="tally" data-browser="phantom" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally obsolete" data-browser="besen" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/8</td>
@@ -3408,8 +3408,8 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3475,8 +3475,8 @@ return parseInt('010') === 10;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3540,8 +3540,8 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3605,8 +3605,8 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3671,8 +3671,8 @@ return _\u200c\u200d;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3738,8 +3738,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3811,8 +3811,8 @@ return result;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3882,8 +3882,8 @@ catch(e) {
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -3944,8 +3944,8 @@ catch(e) {
 <td class="tally unstable" data-browser="safaritp" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/19</td>
-<td class="tally" data-browser="besen" data-tally="1">19/19</td>
-<td class="tally" data-browser="phantom" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="besen" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/19</td>
@@ -4014,8 +4014,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4080,8 +4080,8 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4148,8 +4148,8 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4230,8 +4230,8 @@ return test(String, &apos;&apos;)
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4298,8 +4298,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4364,8 +4364,8 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4434,8 +4434,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4504,8 +4504,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4576,8 +4576,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4645,8 +4645,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4712,8 +4712,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4780,8 +4780,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4852,8 +4852,8 @@ return (function(x){
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4918,8 +4918,8 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -4984,8 +4984,8 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -5050,8 +5050,8 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -5116,8 +5116,8 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -5182,8 +5182,8 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
@@ -5248,8 +5248,8 @@ return typeof foo === &apos;function&apos;;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -169,7 +169,7 @@
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 36">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r219218 (July 6, 2017)">WK</abbr></a></th>
-<th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
+<th class="platform phantom engine obsolete" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
@@ -236,7 +236,7 @@
 <td class="tally unstable" data-browser="safari11" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">2/2</td>
@@ -302,7 +302,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -368,7 +368,7 @@ return Intl.constructor === Object;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -431,7 +431,7 @@ return Intl.constructor === Object;
 <td class="tally unstable" data-browser="safari11" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">4/4</td>
@@ -497,7 +497,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -563,7 +563,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -629,7 +629,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -723,7 +723,7 @@ try {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -786,7 +786,7 @@ try {
 <td class="tally unstable" data-browser="safari11" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">1/1</td>
@@ -852,7 +852,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -915,7 +915,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally unstable" data-browser="safari11" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">1/1</td>
@@ -981,7 +981,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1044,7 +1044,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally unstable" data-browser="safari11" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">5/5</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">5/5</td>
@@ -1110,7 +1110,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1176,7 +1176,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1242,7 +1242,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1308,7 +1308,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1402,7 +1402,7 @@ try {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1465,7 +1465,7 @@ try {
 <td class="tally unstable" data-browser="safari11" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">6/6</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">6/6</td>
@@ -1531,7 +1531,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1597,7 +1597,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1663,7 +1663,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1757,7 +1757,7 @@ try {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1824,7 +1824,7 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="unknown" data-browser="phantom">?</td>
+<td class="unknown obsolete" data-browser="phantom">?</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1898,7 +1898,7 @@ try {
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -1961,7 +1961,7 @@ try {
 <td class="tally unstable" data-browser="safari11" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally" data-browser="phantom" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">1/1</td>
@@ -2027,7 +2027,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -2090,7 +2090,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally unstable" data-browser="safari11" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally" data-browser="phantom" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">1/1</td>
@@ -2156,7 +2156,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -2219,7 +2219,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally unstable" data-browser="safari11" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally" data-browser="phantom" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">1/1</td>
@@ -2285,7 +2285,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -2348,7 +2348,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally unstable" data-browser="safari11" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally" data-browser="phantom" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">1/1</td>
@@ -2414,7 +2414,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -2477,7 +2477,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally unstable" data-browser="safari11" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally" data-browser="phantom" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">1/1</td>
@@ -2543,7 +2543,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -2606,7 +2606,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally unstable" data-browser="safari11" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally" data-browser="phantom" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">1/1</td>
@@ -2672,7 +2672,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -2735,7 +2735,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally unstable" data-browser="safari11" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally" data-browser="phantom" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="1">1/1</td>
@@ -2801,7 +2801,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -127,7 +127,7 @@
           <th></th>
 
           <!-- TABLE HEADERS -->
-        <th class="platform tr compiler" data-browser="tr"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></a></th>
+        <th class="platform tr compiler obsolete" data-browser="tr"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></a></th>
 <th class="platform babel compiler" data-browser="babel"><a href="#babel" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel +<br><nobr>core-js</nobr></abbr></a><a href="#babel-optional-note"><sup>[2]</sup></a></th>
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20170806">Closure</abbr></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
@@ -166,7 +166,7 @@
 <th class="platform safari11 desktop unstable" data-browser="safari11"><a href="#safari11" class="browser-name"><abbr title="Safari 11">SF 11</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 36">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r219218 (July 6, 2017)">WK</abbr></a></th>
-<th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
+<th class="platform phantom engine obsolete" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform iojs engine obsolete" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js">io.js</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
@@ -196,7 +196,7 @@
       <tr class="category"><td colspan="64">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
@@ -235,7 +235,7 @@
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/2</td>
@@ -263,7 +263,7 @@ var {a, ...rest} = {a: 1, b: 2, c: 3};
 return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp; rest.c === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === undefined && rest.b === 2 && rest.c === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === undefined && rest.b === 2 && rest.c === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -302,7 +302,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -331,7 +331,7 @@ var O = {a: 1, ...spread};
 return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nvar spread = {b: 2, c: 3};\nvar O = {a: 1, ...spread};\nreturn O !== spread && (O.a + O.b + O.c) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nvar spread = {b: 2, c: 3};\nvar O = {a: 1, ...spread};\nreturn O !== spread && (O.a + O.b + O.c) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -370,7 +370,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -394,7 +394,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a><a href="https://github.com/tc39/proposal-global">global</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
@@ -433,7 +433,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/2</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -462,7 +462,7 @@ actualGlobal.__system_global_test__ = 42;
 return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global === actualGlobal &amp;&amp; !global.lacksGlobal &amp;&amp; global.__system_global_test__ === 42;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");try{return Function("asyncTestPassed","\nvar actualGlobal = Function('return this')();\nactualGlobal.__system_global_test__ = 42;\nreturn typeof global === 'object' && global && global === actualGlobal && !global.lacksGlobal && global.__system_global_test__ === 42;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("4");return Function("asyncTestPassed","'use strict';"+"\nvar actualGlobal = Function('return this')();\nactualGlobal.__system_global_test__ = 42;\nreturn typeof global === 'object' && global && global === actualGlobal && !global.lacksGlobal && global.__system_global_test__ === 42;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -501,7 +501,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No<a href="#wk-global-property-note"><sup>[7]</sup></a></td>
 <td class="no unstable" data-browser="webkit">No<a href="#wk-global-property-note"><sup>[7]</sup></a></td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -535,7 +535,7 @@ var descriptor = Object.getOwnPropertyDescriptor(actualGlobal, &apos;global&apos
 return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;&amp; descriptor.configurable &amp;&amp; descriptor.writable;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nvar actualGlobal = Function('return this')();\nif (typeof global !== 'object') { return false; }\nif (!('global' in actualGlobal)) { return false; }\nif (Object.prototype.propertyIsEnumerable.call(actualGlobal, 'global')) { return false; }\nif (typeof Object.getOwnPropertyDescriptor !== 'function') { return true; } // ES3\n\nvar descriptor = Object.getOwnPropertyDescriptor(actualGlobal, 'global');\nreturn descriptor.value === actualGlobal && !descriptor.enumerable && descriptor.configurable && descriptor.writable;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nvar actualGlobal = Function('return this')();\nif (typeof global !== 'object') { return false; }\nif (!('global' in actualGlobal)) { return false; }\nif (Object.prototype.propertyIsEnumerable.call(actualGlobal, 'global')) { return false; }\nif (typeof Object.getOwnPropertyDescriptor !== 'function') { return true; } // ES3\n\nvar descriptor = Object.getOwnPropertyDescriptor(actualGlobal, 'global');\nreturn descriptor.value === actualGlobal && !descriptor.enumerable && descriptor.configurable && descriptor.writable;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -574,7 +574,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No<a href="#wk-global-property-note"><sup>[7]</sup></a></td>
 <td class="no unstable" data-browser="webkit">No<a href="#wk-global-property-note"><sup>[7]</sup></a></td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -598,7 +598,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Asynchronous_Iterators"><span><a class="anchor" href="#test-Asynchronous_Iterators">&#xA7;</a><a href="https://github.com/tc39/proposal-async-iteration">Asynchronous Iterators</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
@@ -637,7 +637,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/2</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/2</td>
@@ -671,7 +671,7 @@ iterator.next().then(function(step){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\nasync function*generator(){\n  yield 42;\n}\n\nvar iterator = generator();\niterator.next().then(function(step){\n  if(iterator[Symbol.asyncIterator]() === iterator && step.done === false && step.value === 42)asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\nasync function*generator(){\n  yield 42;\n}\n\nvar iterator = generator();\niterator.next().then(function(step){\n  if(iterator[Symbol.asyncIterator]() === iterator && step.done === false && step.value === 42)asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -710,7 +710,7 @@ iterator.next().then(function(step){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -754,7 +754,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 })();
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("8");try{return Function("asyncTestPassed","\nvar asyncIterable = {};\nasyncIterable[Symbol.asyncIterator] = function(){\n  var i = 0;\n  return {\n    next: function(){\n      switch(++i){\n        case 1: return Promise.resolve({done: false, value: 'a'});\n        case 2: return Promise.resolve({done: false, value: 'b'});\n      } return Promise.resolve({done: true});\n    }\n  };\n};\n\n(async function(){\n  var result = '';\n  for await(var value of asyncIterable)result += value;\n  if(result === 'ab')asyncTestPassed();\n})();\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("8");return Function("asyncTestPassed","'use strict';"+"\nvar asyncIterable = {};\nasyncIterable[Symbol.asyncIterator] = function(){\n  var i = 0;\n  return {\n    next: function(){\n      switch(++i){\n        case 1: return Promise.resolve({done: false, value: 'a'});\n        case 2: return Promise.resolve({done: false, value: 'b'});\n      } return Promise.resolve({done: true});\n    }\n  };\n};\n\n(async function(){\n  var result = '';\n  for await(var value of asyncIterable)result += value;\n  if(result === 'ab')asyncTestPassed();\n})();\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -793,7 +793,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -827,7 +827,7 @@ return result.groups.year === &apos;2016&apos;
   &amp;&amp; result.groups[3] === &apos;11&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nvar result = /(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})/.exec('2016-03-11');\nreturn result.groups.year === '2016'\n  && result.groups.month === '03'\n  && result.groups.day === '11'\n  && result.groups[0] === '2016-03-11'\n  && result.groups[1] === '2016'\n  && result.groups[2] === '03'\n  && result.groups[3] === '11';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nvar result = /(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})/.exec('2016-03-11');\nreturn result.groups.year === '2016'\n  && result.groups.month === '03'\n  && result.groups.day === '11'\n  && result.groups[0] === '2016-03-11'\n  && result.groups[1] === '2016'\n  && result.groups[2] === '03'\n  && result.groups[3] === '11';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -866,7 +866,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -894,7 +894,7 @@ const regex = /foo.bar/s;
 return regex.test(&apos;foo\nbar&apos;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("10");try{return Function("asyncTestPassed","\nconst regex = /foo.bar/s;\nreturn regex.test('foo\\nbar');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("10");return Function("asyncTestPassed","'use strict';"+"\nconst regex = /foo.bar/s;\nreturn regex.test('foo\\nbar');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="unknown" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown" data-browser="babel">?</td>
 <td class="unknown" data-browser="closure">?</td>
 <td class="unknown" data-browser="typescript">?</td>
@@ -933,7 +933,7 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="unknown unstable" data-browser="safari11">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="unknown" data-browser="phantom">?</td>
+<td class="unknown obsolete" data-browser="phantom">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="iojs">?</td>
@@ -961,7 +961,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
        !/(?&lt;=a)b/.test(&apos;b&apos;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&\n       !/(?<=a)b/.test('b');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&\n       !/(?<=a)b/.test('b');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1000,7 +1000,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1028,7 +1028,7 @@ const regexGreekSymbol = /\p{Script=Greek}/u;
 return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("12");try{return Function("asyncTestPassed","\nconst regexGreekSymbol = /\\p{Script=Greek}/u;\nreturn regexGreekSymbol.test('π');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("12");return Function("asyncTestPassed","'use strict';"+"\nconst regexGreekSymbol = /\\p{Script=Greek}/u;\nreturn regexGreekSymbol.test('π');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1067,7 +1067,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1091,7 +1091,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-class_fields"><span><a class="anchor" href="#test-class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-class-fields">class fields</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -1130,7 +1130,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/3</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/3</td>
@@ -1161,7 +1161,7 @@ class C {
 return new C().x + C.y === &apos;xy&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\nclass C {\n  x = 'x';\n  static y = 'y';\n}\nreturn new C().x + C.y === 'xy';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  x = 'x';\n  static y = 'y';\n}\nreturn new C().x + C.y === 'xy';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
+<td class="yes obsolete" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -1200,7 +1200,7 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1236,7 +1236,7 @@ class C {
 return new C(42).x() === 42;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nclass C {\n  #x;\n  constructor(x){\n    this.#x = x;\n  }\n  x(){\n    return this.#x;\n  }\n}\nreturn new C(42).x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  #x;\n  constructor(x){\n    this.#x = x;\n  }\n  x(){\n    return this.#x;\n  }\n}\nreturn new C(42).x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1275,7 +1275,7 @@ return new C(42).x() === 42;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1308,7 +1308,7 @@ class C {
 return new C().x() === 42;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nclass C {\n  #x = 42;\n  x(){\n    return this.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  #x = 42;\n  x(){\n    return this.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1347,7 +1347,7 @@ return new C().x() === 42;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1371,7 +1371,7 @@ return new C().x() === 42;
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Function.prototype.toString_revision"><span><a class="anchor" href="#test-Function.prototype.toString_revision">&#xA7;</a><a href="https://github.com/tc39/Function-prototype-toString-revision">Function.prototype.toString revision</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel" data-tally="0">0/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/7</td>
@@ -1410,7 +1410,7 @@ return new C().x() === 42;
 <td class="tally unstable" data-browser="safari11" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
-<td class="tally" data-browser="phantom" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/7</td>
@@ -1439,7 +1439,7 @@ var str = &apos;function anonymous(a, /\x2A a \x2A/ b, c /\x2A b \x2A/ //\n) {\n
 return fn + &apos;&apos; === str;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nvar fn = Function('a', ' /\\x2A a \\x2A/ b, c /\\x2A b \\x2A/ //', '/\\x2A c \\x2A/ ; /\\x2A d \\x2A/ //');\nvar str = 'function anonymous(a, /\\x2A a \\x2A/ b, c /\\x2A b \\x2A/ //\\n) {\\n/\\x2A c \\x2A/ ; /\\x2A d \\x2A/ //\\n}';\nreturn fn + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nvar fn = Function('a', ' /\\x2A a \\x2A/ b, c /\\x2A b \\x2A/ //', '/\\x2A c \\x2A/ ; /\\x2A d \\x2A/ //');\nvar str = 'function anonymous(a, /\\x2A a \\x2A/ b, c /\\x2A b \\x2A/ //\\n) {\\n/\\x2A c \\x2A/ ; /\\x2A d \\x2A/ //\\n}';\nreturn fn + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1478,7 +1478,7 @@ return fn + &apos;&apos; === str;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1506,7 +1506,7 @@ var str = &apos;a =&gt; b&apos;;
 return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nvar str = 'a => b';\nreturn eval('(' + str + ')') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nvar str = 'a => b';\nreturn eval('(' + str + ')') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1545,7 +1545,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1573,7 +1573,7 @@ const NATIVE_EVAL_RE = /\bfunction\b[\s\S]*\beval\b[\s\S]*\([\s\S]*\)[\s\S]*\{[\
 return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("20");try{return Function("asyncTestPassed","\nconst NATIVE_EVAL_RE = /\\bfunction\\b[\\s\\S]*\\beval\\b[\\s\\S]*\\([\\s\\S]*\\)[\\s\\S]*\\{[\\s\\S]*\\[[\\s\\S]*\\bnative\\b[\\s\\S]+\\bcode\\b[\\s\\S]*\\][\\s\\S]*\\}/;\nreturn NATIVE_EVAL_RE.test(eval + '');\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("20");return Function("asyncTestPassed","'use strict';"+"\nconst NATIVE_EVAL_RE = /\\bfunction\\b[\\s\\S]*\\beval\\b[\\s\\S]*\\([\\s\\S]*\\)[\\s\\S]*\\{[\\s\\S]*\\[[\\s\\S]*\\bnative\\b[\\s\\S]+\\bcode\\b[\\s\\S]*\\][\\s\\S]*\\}/;\nreturn NATIVE_EVAL_RE.test(eval + '');\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1612,7 +1612,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1640,7 +1640,7 @@ var str = &apos;class A {}&apos;;
 return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nvar str = 'class A {}';\nreturn eval('(' + str + ')') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nvar str = 'class A {}';\nreturn eval('(' + str + ')') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1679,7 +1679,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1707,7 +1707,7 @@ var str = &apos;class /\x2A a \x2A/ A /\x2A b \x2A/ extends /\x2A c \x2A/ functi
 return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apos;) + &apos;&apos; === str;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\nvar str = 'class /\\x2A a \\x2A/ A /\\x2A b \\x2A/ extends /\\x2A c \\x2A/ function B(){} /\\x2A d \\x2A/ { /\\x2A e \\x2A/ constructor /\\x2A f \\x2A/ ( /\\x2A g \\x2A/ ) /\\x2A h \\x2A/ { /\\x2A i \\x2A/ ; /\\x2A j \\x2A/ } /\\x2A k \\x2A/ m /\\x2A l \\x2A/ ( /\\x2A m \\x2A/ ) /\\x2A n \\x2A/ { /\\x2A o \\x2A/ } /\\x2A p \\x2A/ }';\nreturn eval('(/\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/)') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\nvar str = 'class /\\x2A a \\x2A/ A /\\x2A b \\x2A/ extends /\\x2A c \\x2A/ function B(){} /\\x2A d \\x2A/ { /\\x2A e \\x2A/ constructor /\\x2A f \\x2A/ ( /\\x2A g \\x2A/ ) /\\x2A h \\x2A/ { /\\x2A i \\x2A/ ; /\\x2A j \\x2A/ } /\\x2A k \\x2A/ m /\\x2A l \\x2A/ ( /\\x2A m \\x2A/ ) /\\x2A n \\x2A/ { /\\x2A o \\x2A/ } /\\x2A p \\x2A/ }';\nreturn eval('(/\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/)') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1746,7 +1746,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1774,7 +1774,7 @@ var str = &apos;function \\u0061(\\u{62}, \\u0063) { \\u0062 = \\u{00063}; retur
 return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apos;) + &apos;&apos; === str;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nvar str = 'function \\\\u0061(\\\\u{62}, \\\\u0063) { \\\\u0062 = \\\\u{00063}; return b; }';\nreturn eval('(/\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/)') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nvar str = 'function \\\\u0061(\\\\u{62}, \\\\u0063) { \\\\u0062 = \\\\u{00063}; return b; }';\nreturn eval('(/\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/)') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1813,7 +1813,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1841,7 +1841,7 @@ var str = &apos;[ /\x2A a \x2A/ &quot;f&quot; /\x2A b \x2A/ ] /\x2A c \x2A/ ( /\
 return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.f)&apos;) + &apos;&apos; === str;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\nvar str = '[ /\\x2A a \\x2A/ \"f\" /\\x2A b \\x2A/ ] /\\x2A c \\x2A/ ( /\\x2A d \\x2A/ ) /\\x2A e \\x2A/ { /\\x2A f \\x2A/ }';\nreturn eval('({ /\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/ }.f)') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\nvar str = '[ /\\x2A a \\x2A/ \"f\" /\\x2A b \\x2A/ ] /\\x2A c \\x2A/ ( /\\x2A d \\x2A/ ) /\\x2A e \\x2A/ { /\\x2A f \\x2A/ }';\nreturn eval('({ /\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/ }.f)') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1880,7 +1880,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -1904,7 +1904,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Promise.prototype.finally"><span><a class="anchor" href="#test-Promise.prototype.finally">&#xA7;</a><a href="https://github.com/tc39/proposal-promise-finally">Promise.prototype.finally</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel" data-tally="1">3/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="1">3/3</td>
@@ -1943,7 +1943,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/3</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/3</td>
@@ -1996,7 +1996,7 @@ function check() {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nvar p1 = Promise.resolve(\"foo\");\nvar p2 = Promise.reject(\"bar\");\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score += (arguments.length === 0);\n  check();\n}\np1.then(thenFn);\np1.finally(finallyFn);\np1.finally(function() {\n  // should return a new Promise\n  score += p1.finally() !== p1;\n  check();\n});\np2.catch(catchFn);\np2.finally(finallyFn);\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nvar p1 = Promise.resolve(\"foo\");\nvar p2 = Promise.reject(\"bar\");\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score += (arguments.length === 0);\n  check();\n}\np1.then(thenFn);\np1.finally(finallyFn);\np1.finally(function() {\n  // should return a new Promise\n  score += p1.finally() !== p1;\n  check();\n});\np2.catch(catchFn);\np2.finally(finallyFn);\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -2035,7 +2035,7 @@ function check() {
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2080,7 +2080,7 @@ function check() {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score++;\n  check();\n  return Promise.resolve(\"foobar\");\n}\nPromise.resolve(\"foo\").finally(finallyFn).then(thenFn);\nPromise.reject(\"bar\").finally(finallyFn).catch(catchFn);\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score++;\n  check();\n  return Promise.resolve(\"foobar\");\n}\nPromise.resolve(\"foo\").finally(finallyFn).then(thenFn);\nPromise.reject(\"bar\").finally(finallyFn).catch(catchFn);\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -2119,7 +2119,7 @@ function check() {
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2166,7 +2166,7 @@ function check() {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise\n  .reject(\"foobar\")\n  .finally(function() {\n    return Promise.reject(\"foo\");\n  })\n  .catch(function(result) {\n    score += (result === \"foo\");\n    check();\n    return Promise.reject(\"foobar\");\n  })\n  .finally(function() {\n    throw new Error('bar');\n  })\n  .catch(function(result) {\n    score += (result.message === \"bar\");\n    check();\n  });\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise\n  .reject(\"foobar\")\n  .finally(function() {\n    return Promise.reject(\"foo\");\n  })\n  .catch(function(result) {\n    score += (result === \"foo\");\n    check();\n    return Promise.reject(\"foobar\");\n  })\n  .finally(function() {\n    throw new Error('bar');\n  })\n  .catch(function(result) {\n    score += (result.message === \"bar\");\n    check();\n  });\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -2205,7 +2205,7 @@ function check() {
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2229,7 +2229,7 @@ function check() {
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.125"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://tc39.github.io/proposal-optional-catch-binding/">optional catch binding</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel" data-tally="0">0/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/3</td>
@@ -2268,7 +2268,7 @@ function check() {
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/3</td>
@@ -2301,7 +2301,7 @@ catch {
 return false;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\ntry {\n  throw new Error();\n}\ncatch {\n  return true;\n}\nreturn false;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  throw new Error();\n}\ncatch {\n  return true;\n}\nreturn false;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -2340,7 +2340,7 @@ return false;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2374,7 +2374,7 @@ return false;
 })();
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\n(async function (){\n  try {\n    await Promise.reject();\n  }\n  catch {\n    asyncTestPassed();\n  }\n})();\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\n(async function (){\n  try {\n    await Promise.reject();\n  }\n  catch {\n    asyncTestPassed();\n  }\n})();\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -2413,7 +2413,7 @@ return false;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2452,7 +2452,7 @@ it.next();
 return it.next().value;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nfunction *foo() {\n  try {\n    yield;\n    throw new Error();\n  }\n  catch {\n    return true;\n  }\n}\n\nvar it = foo();\nit.next();\nreturn it.next().value;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nfunction *foo() {\n  try {\n    yield;\n    throw new Error();\n  }\n  catch {\n    return true;\n  }\n}\n\nvar it = foo();\nit.next();\nreturn it.next().value;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -2491,7 +2491,7 @@ return it.next().value;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2526,7 +2526,7 @@ iter.next(&apos;tromple&apos;);
 return result === &apos;tromple&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -2565,7 +2565,7 @@ return result === &apos;tromple&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2589,7 +2589,7 @@ return result === &apos;tromple&apos;;
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Class_and_Property_Decorators"><span><a class="anchor" href="#test-Class_and_Property_Decorators">&#xA7;</a><a href="http://tc39.github.io/proposal-decorators/">Class and Property Decorators</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/1</td>
 <td class="tally" data-browser="babel" data-tally="0">0/1</td>
 <td class="tally" data-browser="closure" data-tally="0">0/1</td>
 <td class="tally" data-browser="typescript" data-tally="1">1/1</td>
@@ -2628,7 +2628,7 @@ return result === &apos;tromple&apos;;
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/1</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/1</td>
@@ -2663,7 +2663,7 @@ function nonconf(target, name, descriptor) {
 return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable === false;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("35");try{return Function("asyncTestPassed","\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("35");return Function("asyncTestPassed","'use strict';"+"\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No<a href="#regenerator-decorators-legacy-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
@@ -2702,7 +2702,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2726,7 +2726,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-string-left-right-trim">string trimming</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
 <td class="tally" data-browser="babel" data-tally="1">4/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
@@ -2765,7 +2765,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally unstable" data-browser="safari11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally" data-browser="phantom" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -2792,7 +2792,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -2831,7 +2831,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -2858,7 +2858,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -2897,7 +2897,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes unstable" data-browser="safari11">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
 <td class="yes obsolete" data-browser="iojs">Yes</td>
@@ -2924,7 +2924,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimStart() === 'abc   \\t\\n';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimStart() === 'abc   \\t\\n';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -2963,7 +2963,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -2990,7 +2990,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimEnd() === ' \\t \\n abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimEnd() === ' \\t \\n abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -3029,7 +3029,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3061,7 +3061,7 @@ return do {
 } === 42;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3100,7 +3100,7 @@ return do {
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3124,7 +3124,7 @@ return do {
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-SIMD_(Single_Instruction,_Multiple_Data)"><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/">SIMD (Single Instruction, Multiple Data)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/57</td>
 <td class="tally" data-browser="babel" data-tally="0">0/57</td>
 <td class="tally" data-browser="closure" data-tally="0">0/57</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/57</td>
@@ -3163,7 +3163,7 @@ return do {
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/57</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/57</td>
@@ -3198,7 +3198,7 @@ simdAllTypes=simdFloatTypes.concat(simdIntTypes,simdBoolTypes);
 return typeof SIMD !== &apos;undefined&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("43");try{return Function("asyncTestPassed","\nsimdFloatTypes=['Float32x4'];\nsimdBoolTypes=['Bool32x4','Bool16x8','Bool8x16'];\nsimdIntTypes=['Int32x4','Int16x8','Int8x16','Uint32x4','Uint16x8','Uint8x16'];\nsimd32bitFloatIntTypes=['Float32x4','Int32x4','Uint32x4'];\nsimdSmallIntTypes=['Int16x8','Int8x16','Uint16x8','Uint8x16'];\nsimdBoolIntTypes=simdBoolTypes.concat(simdIntTypes);\nsimdFloatIntTypes=simdFloatTypes.concat(simdIntTypes);\nsimdAllTypes=simdFloatTypes.concat(simdIntTypes,simdBoolTypes);\nreturn typeof SIMD !== 'undefined';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("43");return Function("asyncTestPassed","'use strict';"+"\nsimdFloatTypes=['Float32x4'];\nsimdBoolTypes=['Bool32x4','Bool16x8','Bool8x16'];\nsimdIntTypes=['Int32x4','Int16x8','Int8x16','Uint32x4','Uint16x8','Uint8x16'];\nsimd32bitFloatIntTypes=['Float32x4','Int32x4','Uint32x4'];\nsimdSmallIntTypes=['Int16x8','Int8x16','Uint16x8','Uint8x16'];\nsimdBoolIntTypes=simdBoolTypes.concat(simdIntTypes);\nsimdFloatIntTypes=simdFloatTypes.concat(simdIntTypes);\nsimdAllTypes=simdFloatTypes.concat(simdIntTypes,simdBoolTypes);\nreturn typeof SIMD !== 'undefined';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3237,7 +3237,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3264,7 +3264,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 return typeof SIMD.Float32x4 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Float32x4 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("44");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Float32x4 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3303,7 +3303,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3330,7 +3330,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 return typeof SIMD.Int32x4 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Int32x4 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Int32x4 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3369,7 +3369,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3396,7 +3396,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 return typeof SIMD.Int16x8 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Int16x8 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Int16x8 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3435,7 +3435,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3462,7 +3462,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 return typeof SIMD.Int8x16 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Int8x16 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Int8x16 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3501,7 +3501,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3528,7 +3528,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 return typeof SIMD.Uint32x4 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("48");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Uint32x4 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("48");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Uint32x4 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3567,7 +3567,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3594,7 +3594,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 return typeof SIMD.Uint16x8 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("49");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Uint16x8 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("49");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Uint16x8 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3633,7 +3633,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3660,7 +3660,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 return typeof SIMD.Uint8x16 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("50");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Uint8x16 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("50");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Uint8x16 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3699,7 +3699,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3726,7 +3726,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 return typeof SIMD.Bool32x4 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("51");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Bool32x4 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("51");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Bool32x4 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3765,7 +3765,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3792,7 +3792,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 return typeof SIMD.Bool16x8 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("52");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Bool16x8 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("52");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Bool16x8 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3831,7 +3831,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3858,7 +3858,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 return typeof SIMD.Bool8x16 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("53");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Bool8x16 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("53");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Bool8x16 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3897,7 +3897,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3926,7 +3926,7 @@ return simdFloatTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");try{return Function("asyncTestPassed","\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].abs === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("54");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].abs === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -3965,7 +3965,7 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -3994,7 +3994,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("55");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].add === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("55");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].add === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4033,7 +4033,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4062,7 +4062,7 @@ return simdSmallIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");try{return Function("asyncTestPassed","\nreturn simdSmallIntTypes.every(function(type){\n  return typeof SIMD[type].addSaturate === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("56");return Function("asyncTestPassed","'use strict';"+"\nreturn simdSmallIntTypes.every(function(type){\n  return typeof SIMD[type].addSaturate === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4101,7 +4101,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4130,7 +4130,7 @@ return simdBoolIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("57");try{return Function("asyncTestPassed","\nreturn simdBoolIntTypes.every(function(type){\n  return typeof SIMD[type].and === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("57");return Function("asyncTestPassed","'use strict';"+"\nreturn simdBoolIntTypes.every(function(type){\n  return typeof SIMD[type].and === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4169,7 +4169,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4198,7 +4198,7 @@ return simdBoolTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("58");try{return Function("asyncTestPassed","\nreturn simdBoolTypes.every(function(type){\n  return typeof SIMD[type].anyTrue === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("58");return Function("asyncTestPassed","'use strict';"+"\nreturn simdBoolTypes.every(function(type){\n  return typeof SIMD[type].anyTrue === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4237,7 +4237,7 @@ return simdBoolTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4266,7 +4266,7 @@ return simdBoolTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");try{return Function("asyncTestPassed","\nreturn simdBoolTypes.every(function(type){\n  return typeof SIMD[type].allTrue === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("59");return Function("asyncTestPassed","'use strict';"+"\nreturn simdBoolTypes.every(function(type){\n  return typeof SIMD[type].allTrue === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4305,7 +4305,7 @@ return simdBoolTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4334,7 +4334,7 @@ return simdAllTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");try{return Function("asyncTestPassed","\nreturn simdAllTypes.every(function(type){\n  return typeof SIMD[type].check === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("60");return Function("asyncTestPassed","'use strict';"+"\nreturn simdAllTypes.every(function(type){\n  return typeof SIMD[type].check === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4373,7 +4373,7 @@ return simdAllTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4402,7 +4402,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].equal === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("61");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].equal === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4441,7 +4441,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4470,7 +4470,7 @@ return simdAllTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");try{return Function("asyncTestPassed","\nreturn simdAllTypes.every(function(type){\n  return typeof SIMD[type].extractLane === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("62");return Function("asyncTestPassed","'use strict';"+"\nreturn simdAllTypes.every(function(type){\n  return typeof SIMD[type].extractLane === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4509,7 +4509,7 @@ return simdAllTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4538,7 +4538,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("63");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].greaterThan === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("63");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].greaterThan === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4577,7 +4577,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4606,7 +4606,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].greaterThanOrEqual === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].greaterThanOrEqual === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4645,7 +4645,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4674,7 +4674,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].lessThan === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("65");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].lessThan === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4713,7 +4713,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4742,7 +4742,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].lessThanOrEqual === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].lessThanOrEqual === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4781,7 +4781,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4810,7 +4810,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].mul === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].mul === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4849,7 +4849,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4878,7 +4878,7 @@ return simdFloatTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].div === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].div === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4917,7 +4917,7 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -4946,7 +4946,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].load === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].load === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -4985,7 +4985,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5014,7 +5014,7 @@ return simd32bitFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].load1 === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].load1 === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5053,7 +5053,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5082,7 +5082,7 @@ return simd32bitFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].load2 === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].load2 === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5121,7 +5121,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5150,7 +5150,7 @@ return simd32bitFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].load3 === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].load3 === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5189,7 +5189,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5218,7 +5218,7 @@ return simdFloatTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].max === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].max === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5257,7 +5257,7 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5286,7 +5286,7 @@ return simdFloatTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");try{return Function("asyncTestPassed","\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].maxNum === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("74");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].maxNum === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5325,7 +5325,7 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5354,7 +5354,7 @@ return simdFloatTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("75");try{return Function("asyncTestPassed","\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].min === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("75");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].min === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5393,7 +5393,7 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5422,7 +5422,7 @@ return simdFloatTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].minNum === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].minNum === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5461,7 +5461,7 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5490,7 +5490,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].neg === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("77");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].neg === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5529,7 +5529,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5558,7 +5558,7 @@ return simdBoolTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");try{return Function("asyncTestPassed","\nreturn simdBoolTypes.every(function(type){\n  return typeof SIMD[type].not === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("78");return Function("asyncTestPassed","'use strict';"+"\nreturn simdBoolTypes.every(function(type){\n  return typeof SIMD[type].not === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5597,7 +5597,7 @@ return simdBoolTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5626,7 +5626,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].notEqual === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("79");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].notEqual === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5665,7 +5665,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5694,7 +5694,7 @@ return simdBoolIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");try{return Function("asyncTestPassed","\nreturn simdBoolIntTypes.every(function(type){\n  return typeof SIMD[type].or === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("80");return Function("asyncTestPassed","'use strict';"+"\nreturn simdBoolIntTypes.every(function(type){\n  return typeof SIMD[type].or === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5733,7 +5733,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5762,7 +5762,7 @@ return simdFloatTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("81");try{return Function("asyncTestPassed","\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].reciprocalApproximation === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("81");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].reciprocalApproximation === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5801,7 +5801,7 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5830,7 +5830,7 @@ return simdFloatTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");try{return Function("asyncTestPassed","\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].reciprocalSqrtApproximation === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("82");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].reciprocalSqrtApproximation === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5869,7 +5869,7 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5898,7 +5898,7 @@ return simdAllTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");try{return Function("asyncTestPassed","\nreturn simdAllTypes.every(function(type){\n  return typeof SIMD[type].replaceLane === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("83");return Function("asyncTestPassed","'use strict';"+"\nreturn simdAllTypes.every(function(type){\n  return typeof SIMD[type].replaceLane === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -5937,7 +5937,7 @@ return simdAllTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -5966,7 +5966,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].select === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].select === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6005,7 +6005,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6034,7 +6034,7 @@ return simdIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\nreturn simdIntTypes.every(function(type){\n  return typeof SIMD[type].shiftLeftByScalar === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\nreturn simdIntTypes.every(function(type){\n  return typeof SIMD[type].shiftLeftByScalar === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6073,7 +6073,7 @@ return simdIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6102,7 +6102,7 @@ return simdIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("86");try{return Function("asyncTestPassed","\nreturn simdIntTypes.every(function(type){\n  return typeof SIMD[type].shiftRightByScalar === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("86");return Function("asyncTestPassed","'use strict';"+"\nreturn simdIntTypes.every(function(type){\n  return typeof SIMD[type].shiftRightByScalar === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6141,7 +6141,7 @@ return simdIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6170,7 +6170,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].shuffle === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("87");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].shuffle === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6209,7 +6209,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6238,7 +6238,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].splat === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].splat === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6277,7 +6277,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6306,7 +6306,7 @@ return simdFloatTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("89");try{return Function("asyncTestPassed","\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].sqrt === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("89");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatTypes.every(function(type){\n  return typeof SIMD[type].sqrt === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6345,7 +6345,7 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6374,7 +6374,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("90");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].store === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("90");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].store === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6413,7 +6413,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6442,7 +6442,7 @@ return simd32bitFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("91");try{return Function("asyncTestPassed","\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].store1 === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("91");return Function("asyncTestPassed","'use strict';"+"\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].store1 === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6481,7 +6481,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6510,7 +6510,7 @@ return simd32bitFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");try{return Function("asyncTestPassed","\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].store2 === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("92");return Function("asyncTestPassed","'use strict';"+"\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].store2 === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6549,7 +6549,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6578,7 +6578,7 @@ return simd32bitFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("93");try{return Function("asyncTestPassed","\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].store3 === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("93");return Function("asyncTestPassed","'use strict';"+"\nreturn simd32bitFloatIntTypes.every(function(type){\n  return typeof SIMD[type].store3 === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6617,7 +6617,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6646,7 +6646,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("94");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].sub === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("94");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].sub === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6685,7 +6685,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6714,7 +6714,7 @@ return simdSmallIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("95");try{return Function("asyncTestPassed","\nreturn simdSmallIntTypes.every(function(type){\n  return typeof SIMD[type].subSaturate === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("95");return Function("asyncTestPassed","'use strict';"+"\nreturn simdSmallIntTypes.every(function(type){\n  return typeof SIMD[type].subSaturate === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6753,7 +6753,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6782,7 +6782,7 @@ return simdFloatIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("96");try{return Function("asyncTestPassed","\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].swizzle === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("96");return Function("asyncTestPassed","'use strict';"+"\nreturn simdFloatIntTypes.every(function(type){\n  return typeof SIMD[type].swizzle === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6821,7 +6821,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6850,7 +6850,7 @@ return simdBoolIntTypes.every(function(type){
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("97");try{return Function("asyncTestPassed","\nreturn simdBoolIntTypes.every(function(type){\n  return typeof SIMD[type].xor === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("97");return Function("asyncTestPassed","'use strict';"+"\nreturn simdBoolIntTypes.every(function(type){\n  return typeof SIMD[type].xor === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6889,7 +6889,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6918,7 +6918,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("98");try{return Function("asyncTestPassed","\nreturn ['Float32x4','Int32x4','Int8x16','Uint32x4','Uint16x8','Uint8x16'].every(function(type){\n  return typeof SIMD.Int16x8['from' + type + 'Bits'] === 'function';\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("98");return Function("asyncTestPassed","'use strict';"+"\nreturn ['Float32x4','Int32x4','Int8x16','Uint32x4','Uint16x8','Uint8x16'].every(function(type){\n  return typeof SIMD.Int16x8['from' + type + 'Bits'] === 'function';\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -6957,7 +6957,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -6984,7 +6984,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typeof SIMD.Float32x4.fromUint32x4 === &apos;function&apos; &amp;&amp; typeof SIMD.Int32x4.fromFloat32x4 === &apos;function&apos; &amp;&amp; typeof SIMD.Uint32x4.fromFloat32x4 === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("99");try{return Function("asyncTestPassed","\nreturn typeof SIMD.Float32x4.fromInt32x4 === 'function' && typeof SIMD.Float32x4.fromUint32x4 === 'function' && typeof SIMD.Int32x4.fromFloat32x4 === 'function' && typeof SIMD.Uint32x4.fromFloat32x4 === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("99");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SIMD.Float32x4.fromInt32x4 === 'function' && typeof SIMD.Float32x4.fromUint32x4 === 'function' && typeof SIMD.Int32x4.fromFloat32x4 === 'function' && typeof SIMD.Uint32x4.fromFloat32x4 === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -7023,7 +7023,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7053,7 +7053,7 @@ return typeof Realm === &quot;function&quot;
   });
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("100");try{return Function("asyncTestPassed","\nreturn typeof Realm === \"function\"\n  && [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\", \"indirectEval\", \"initGlobal\", \"nonEval\"].every(function(key){\n    return key in Realm.prototype;\n  });\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("100");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Realm === \"function\"\n  && [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\", \"indirectEval\", \"initGlobal\", \"nonEval\"].every(function(key){\n    return key in Realm.prototype;\n  });\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -7092,7 +7092,7 @@ return typeof Realm === &quot;function&quot;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7116,7 +7116,7 @@ return typeof Realm === &quot;function&quot;
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Observable"><span><a class="anchor" href="#test-Observable">&#xA7;</a><a href="https://github.com/tc39/proposal-observable">Observable</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel" data-tally="1">8/8</td>
 <td class="tally" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript" data-tally="1">8/8</td>
@@ -7155,7 +7155,7 @@ return typeof Realm === &quot;function&quot;
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/8</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/8</td>
@@ -7182,7 +7182,7 @@ return typeof Realm === &quot;function&quot;
 return typeof Observable !== &apos;undefined&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("102");try{return Function("asyncTestPassed","\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("102");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7221,7 +7221,7 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7248,7 +7248,7 @@ return typeof Observable !== &apos;undefined&apos;;
 return typeof Symbol.observable === &apos;symbol&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("103");try{return Function("asyncTestPassed","\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("103");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7287,7 +7287,7 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7314,7 +7314,7 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 return &apos;subscribe&apos; in Observable.prototype;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("104");try{return Function("asyncTestPassed","\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("104");return Function("asyncTestPassed","'use strict';"+"\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7353,7 +7353,7 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7390,7 +7390,7 @@ try { Observable(function() { }) } catch(e) { newCheckPassed = true }
 return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newCheckPassed;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("105");try{return Function("asyncTestPassed","\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("105");return Function("asyncTestPassed","'use strict';"+"\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7429,7 +7429,7 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7457,7 +7457,7 @@ var o = new Observable(function() { });
 return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function(e){return true}) instanceof Promise;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("106");try{return Function("asyncTestPassed","\nvar o = new Observable(function() { });\nreturn 'forEach' in Observable.prototype && o.forEach(function(e){return true}) instanceof Promise;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("106");return Function("asyncTestPassed","'use strict';"+"\nvar o = new Observable(function() { });\nreturn 'forEach' in Observable.prototype && o.forEach(function(e){return true}) instanceof Promise;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7496,7 +7496,7 @@ return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7524,7 +7524,7 @@ var o = new Observable(function() { });
 return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]() === o;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("107");try{return Function("asyncTestPassed","\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("107");return Function("asyncTestPassed","'use strict';"+"\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7563,7 +7563,7 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7590,7 +7590,7 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 return Observable.of(1, 2, 3) instanceof Observable;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("108");try{return Function("asyncTestPassed","\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("108");return Function("asyncTestPassed","'use strict';"+"\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7629,7 +7629,7 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7656,7 +7656,7 @@ return Observable.of(1, 2, 3) instanceof Observable;
 return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable.from(new Set([1, 2, 3])) instanceof Observable);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("109");try{return Function("asyncTestPassed","\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("109");return Function("asyncTestPassed","'use strict';"+"\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7695,7 +7695,7 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7732,7 +7732,7 @@ return a === &apos;1a2b&apos;
   &amp;&amp; c === &apos;ab&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("110");try{return Function("asyncTestPassed","\nvar iterator = '11a2bb'.matchAll(/(\\d)(\\D)/);\nif(iterator[Symbol.iterator]() !== iterator)return false;\nvar a = '', b = '', c = '', step;\nwhile(!(step = iterator.next()).done){\n  a += step.value[0];\n  b += step.value[1];\n  c += step.value[2];\n}\nreturn a === '1a2b'\n  && b === '12'\n  && c === 'ab';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("110");return Function("asyncTestPassed","'use strict';"+"\nvar iterator = '11a2bb'.matchAll(/(\\d)(\\D)/);\nif(iterator[Symbol.iterator]() !== iterator)return false;\nvar a = '', b = '', c = '', step;\nwhile(!(step = iterator.next()).done){\n  a += step.value[0];\n  b += step.value[1];\n  c += step.value[2];\n}\nreturn a === '1a2b'\n  && b === '12'\n  && c === 'ab';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7771,7 +7771,7 @@ return a === &apos;1a2b&apos;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7802,7 +7802,7 @@ weakref.clear();
 return works &amp;&amp; weakref.get() === undefined;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("111");try{return Function("asyncTestPassed","\nvar O = {};\nvar weakref = System.makeWeakRef(O);\nvar works = weakref.get() === O;\nweakref.clear();\nreturn works && weakref.get() === undefined;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("111");return Function("asyncTestPassed","'use strict';"+"\nvar O = {};\nvar weakref = System.makeWeakRef(O);\nvar works = weakref.get() === O;\nweakref.clear();\nreturn works && weakref.get() === undefined;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -7841,7 +7841,7 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7869,7 +7869,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
   &amp;&amp; typeof Reflect.Realm.prototype.spawn === &apos;function&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("112");try{return Function("asyncTestPassed","\nreturn typeof Reflect.Realm.immutableRoot === 'function'\n  && typeof Reflect.Realm.prototype.spawn === 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("112");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.Realm.immutableRoot === 'function'\n  && typeof Reflect.Realm.prototype.spawn === 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -7908,7 +7908,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -7938,7 +7938,7 @@ return Math.signbit(-0) === false
   &amp;&amp; Math.signbit(42) === true;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("113");try{return Function("asyncTestPassed","\nreturn Math.signbit(-0) === false\n  && Math.signbit(0) === true\n  && Math.signbit(-42) === false\n  && Math.signbit(42) === true;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("113");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.signbit(-0) === false\n  && Math.signbit(0) === true\n  && Math.signbit(-42) === false\n  && Math.signbit(42) === true;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7977,7 +7977,7 @@ return Math.signbit(-0) === false
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8001,7 +8001,7 @@ return Math.signbit(-0) === false
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Math_extensions_proposal"><span><a class="anchor" href="#test-Math_extensions_proposal">&#xA7;</a><a href="https://github.com/rwaldron/proposal-math-extensions">Math extensions proposal</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel" data-tally="1">7/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript" data-tally="1">7/7</td>
@@ -8040,7 +8040,7 @@ return Math.signbit(-0) === false
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/7</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/7</td>
@@ -8069,7 +8069,7 @@ return Math.clamp(2, 4, 6) === 4
   &amp;&amp; Math.clamp(6, 2, 4) === 4;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");try{return Function("asyncTestPassed","\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("115");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8108,7 +8108,7 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8135,7 +8135,7 @@ return Math.clamp(2, 4, 6) === 4
 return Math.DEG_PER_RAD === Math.PI / 180;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("116");try{return Function("asyncTestPassed","\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("116");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8174,7 +8174,7 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8202,7 +8202,7 @@ return Math.degrees(Math.PI / 2) === 90
   &amp;&amp; Math.degrees(Math.PI) === 180;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("117");try{return Function("asyncTestPassed","\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("117");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8241,7 +8241,7 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8268,7 +8268,7 @@ return Math.degrees(Math.PI / 2) === 90
 return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("118");try{return Function("asyncTestPassed","\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("118");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8307,7 +8307,7 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8334,7 +8334,7 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 return Math.RAD_PER_DEG === 180 / Math.PI;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("119");try{return Function("asyncTestPassed","\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("119");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8373,7 +8373,7 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8401,7 +8401,7 @@ return Math.radians(90) === Math.PI / 2
   &amp;&amp; Math.radians(180) === Math.PI;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("120");try{return Function("asyncTestPassed","\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("120");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8440,7 +8440,7 @@ return Math.radians(90) === Math.PI / 2
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8467,7 +8467,7 @@ return Math.radians(90) === Math.PI / 2
 return Math.scale(0, 3, 5, 8, 10) === 5;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("121");try{return Function("asyncTestPassed","\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("121");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8506,7 +8506,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8530,7 +8530,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Promise.try"><span><a class="anchor" href="#test-Promise.try">&#xA7;</a><a href="https://github.com/tc39/proposal-promise-try">Promise.try</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel" data-tally="1">7/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript" data-tally="1">7/7</td>
@@ -8569,7 +8569,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/7</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/7</td>
@@ -8596,7 +8596,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 return typeof Promise.try === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("123");try{return Function("asyncTestPassed","\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("123");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8635,7 +8635,7 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8662,7 +8662,7 @@ return typeof Promise.try === &apos;function&apos;;
 return Promise.try(function () {}) instanceof Promise;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("124");try{return Function("asyncTestPassed","\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("124");return Function("asyncTestPassed","'use strict';"+"\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8701,7 +8701,7 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8730,7 +8730,7 @@ Promise.try(function () { score++ });
 return score === 1;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("125");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("125");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8769,7 +8769,7 @@ return score === 1;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8803,7 +8803,7 @@ Promise.try(function() {
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("126");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("126");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8842,7 +8842,7 @@ Promise.try(function() {
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8876,7 +8876,7 @@ Promise.try(function() {
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("127");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("127");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8915,7 +8915,7 @@ Promise.try(function() {
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -8949,7 +8949,7 @@ Promise.try(function() {
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("128");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("128");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8988,7 +8988,7 @@ Promise.try(function() {
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9022,7 +9022,7 @@ Promise.try(function() {
 });
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("129");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("129");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9061,7 +9061,7 @@ Promise.try(function() {
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9085,7 +9085,7 @@ Promise.try(function() {
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flatten,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flatten,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flatten, flatMap}</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
@@ -9124,7 +9124,7 @@ Promise.try(function() {
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/2</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/2</td>
@@ -9151,7 +9151,7 @@ Promise.try(function() {
 return [1, [2, 3], [4, [5, 6]]].flatten().join(&apos;&apos;) === &apos;12345,6&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("131");try{return Function("asyncTestPassed","\nreturn [1, [2, 3], [4, [5, 6]]].flatten().join('') === '12345,6';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("131");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, [2, 3], [4, [5, 6]]].flatten().join('') === '12345,6';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9190,7 +9190,7 @@ return [1, [2, 3], [4, [5, 6]]].flatten().join(&apos;&apos;) === &apos;12345,6&a
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9219,7 +9219,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 }).join(&apos;&apos;) === &apos;1234&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("132");try{return Function("asyncTestPassed","\nreturn [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {\n  return [it.a, it.b];\n}).join('') === '1234';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("132");return Function("asyncTestPassed","'use strict';"+"\nreturn [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {\n  return [it.a, it.b];\n}).join('') === '1234';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9258,7 +9258,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9282,7 +9282,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no unstable" data-browser="ios11">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-`.of`_and_`.from`_on_collection_constructors"><span><a class="anchor" href="#test-`.of`_and_`.from`_on_collection_constructors">&#xA7;</a><a href="https://github.com/tc39/proposal-setmap-offrom">`.of` and `.from` on collection constructors</a></span></td>
-<td class="tally" data-browser="tr" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel" data-tally="1">8/8</td>
 <td class="tally" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript" data-tally="1">8/8</td>
@@ -9321,7 +9321,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="tally unstable" data-browser="safari11" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/8</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/8</td>
@@ -9351,7 +9351,7 @@ var C = Map.of([A, 1], [B, 2]);
 return C.get(A) + C.get(B) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("134");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("134");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9390,7 +9390,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9422,7 +9422,7 @@ var C = Map.from([[A, 1], [B, 2]], function (it) {
 return C.get(A) + C.get(B) === 5;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("135");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("135");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9461,7 +9461,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9491,7 +9491,7 @@ var C = Set.of(A, B);
 return C.has(A) + C.has(B);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("136");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("136");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9530,7 +9530,7 @@ return C.has(A) + C.has(B);
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9560,7 +9560,7 @@ var C = Set.from([1, 2], function (it) {
 return C.has(3) + C.has(4);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("137");try{return Function("asyncTestPassed","\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("137");return Function("asyncTestPassed","'use strict';"+"\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9599,7 +9599,7 @@ return C.has(3) + C.has(4);
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9629,7 +9629,7 @@ var C = WeakMap.of([A, 1], [B, 2]);
 return C.get(A) + C.get(B) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("138");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("138");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9668,7 +9668,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9700,7 +9700,7 @@ var C = WeakMap.from([[A, 1], [B, 2]], function (it) {
 return C.get(A) + C.get(B) === 5;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("139");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("139");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9739,7 +9739,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9769,7 +9769,7 @@ var C = WeakSet.of(A, B);
 return C.has(A) + C.has(B);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("140");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("140");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9808,7 +9808,7 @@ return C.has(A) + C.has(B);
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9838,7 +9838,7 @@ var C = WeakSet.from([A, B]);
 return C.has(A) + C.has(B);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("141");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no obsolete" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -9877,7 +9877,7 @@ return C.has(A) + C.has(B);
 <td class="no unstable" data-browser="safari11">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
@@ -9903,7 +9903,7 @@ return C.has(A) + C.has(B);
 <tr class="category"><td colspan="64">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
-<td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -9942,7 +9942,7 @@ return C.has(A) + C.has(B);
 <td class="tally unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -9971,7 +9971,7 @@ var obj = { garply: &quot;bar&quot; };
 return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply === &quot;barfoo&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("143");try{return Function("asyncTestPassed","\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("143");return Function("asyncTestPassed","'use strict';"+"\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10010,7 +10010,7 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10038,7 +10038,7 @@ var obj = { garply: &quot;bar&quot;, foo: function() { this.garply += &quot;foo&
 return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply === &quot;barfoo&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("144");try{return Function("asyncTestPassed","\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("144");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10077,7 +10077,7 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10104,7 +10104,7 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("145");try{return Function("asyncTestPassed","\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("145");return Function("asyncTestPassed","'use strict';"+"\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -10143,7 +10143,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10167,7 +10167,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no unstable not-applicable" data-browser="ios11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-additional_meta_properties"><span><a class="anchor" href="#test-additional_meta_properties">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/ES7MetaProps.md">additional meta properties</a></span></td>
-<td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -10206,7 +10206,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -10234,7 +10234,7 @@ var f = _ =&gt; function.callee === f;
 return f();
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("147");try{return Function("asyncTestPassed","\nvar f = _ => function.callee === f;\nreturn f();\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("147");return Function("asyncTestPassed","'use strict';"+"\nvar f = _ => function.callee === f;\nreturn f();\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10273,7 +10273,7 @@ return f();
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10300,7 +10300,7 @@ return f();
 return (_ =&gt; function.count)(1, 2, 3) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("148");try{return Function("asyncTestPassed","\nreturn (_ => function.count)(1, 2, 3) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("148");return Function("asyncTestPassed","'use strict';"+"\nreturn (_ => function.count)(1, 2, 3) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10339,7 +10339,7 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10371,7 +10371,7 @@ return Array.isArray(arr)
   &amp;&amp; arr[2] === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("149");try{return Function("asyncTestPassed","\nvar arr =  (_ => function.arguments)(1, 2, 3);\nreturn Array.isArray(arr)\n  && arr.length === 3\n  && arr[0] === 1\n  && arr[1] === 2\n  && arr[2] === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("149");return Function("asyncTestPassed","'use strict';"+"\nvar arr =  (_ => function.arguments)(1, 2, 3);\nreturn Array.isArray(arr)\n  && arr.length === 3\n  && arr[0] === 1\n  && arr[1] === 2\n  && arr[2] === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10410,7 +10410,7 @@ return Array.isArray(arr)
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10448,7 +10448,7 @@ return target === C.prototype
   &amp;&amp; index === 0;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("150");try{return Function("asyncTestPassed","\nvar target, key, index;\nfunction decorator(_target, _key, _index){\n  target = _target;\n  key    = _key;\n  index  = _index;\n}\nclass C {\n  method(@decorator foo){ }\n}\nreturn target === C.prototype\n  && key === 'method'\n  && index === 0;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("150");return Function("asyncTestPassed","'use strict';"+"\nvar target, key, index;\nfunction decorator(_target, _key, _index){\n  target = _target;\n  key    = _key;\n  index  = _index;\n}\nclass C {\n  method(@decorator foo){ }\n}\nreturn target === C.prototype\n  && key === 'method'\n  && index === 0;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -10487,7 +10487,7 @@ return target === C.prototype
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10521,7 +10521,7 @@ return (@inverse function(it){
 })(2);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("151");try{return Function("asyncTestPassed","\nfunction inverse(f){\n  return function(){\n    return !f.apply(this, arguments);\n  };\n}\nreturn (@inverse function(it){\n  return it % 2;\n})(2);\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("151");return Function("asyncTestPassed","'use strict';"+"\nfunction inverse(f){\n  return function(){\n    return !f.apply(this, arguments);\n  };\n}\nreturn (@inverse function(it){\n  return it % 2;\n})(2);\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10560,7 +10560,7 @@ return (@inverse function(it){
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10584,7 +10584,7 @@ return (@inverse function(it){
 <td class="no unstable not-applicable" data-browser="ios11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.25"><td id="test-Reflect.isCallable_/_Reflect.isConstructor"><span><a class="anchor" href="#test-Reflect.isCallable_/_Reflect.isConstructor">&#xA7;</a><a href="https://github.com/caitp/TC39-Proposals/blob/master/tc39-reflect-isconstructor-iscallable.md">Reflect.isCallable / Reflect.isConstructor</a></span></td>
-<td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -10623,7 +10623,7 @@ return (@inverse function(it){
 <td class="tally unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -10652,7 +10652,7 @@ return Reflect.isCallable(function(){})
   &amp;&amp; !Reflect.isCallable(class {});
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");try{return Function("asyncTestPassed","\nreturn Reflect.isCallable(function(){})\n  && Reflect.isCallable(_ => _)\n  && !Reflect.isCallable(class {});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("153");return Function("asyncTestPassed","'use strict';"+"\nreturn Reflect.isCallable(function(){})\n  && Reflect.isCallable(_ => _)\n  && !Reflect.isCallable(class {});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10691,7 +10691,7 @@ return Reflect.isCallable(function(){})
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10720,7 +10720,7 @@ return Reflect.isConstructor(function(){})
   &amp;&amp; Reflect.isConstructor(class {});
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("154");try{return Function("asyncTestPassed","\nreturn Reflect.isConstructor(function(){})\n  && !Reflect.isConstructor(_ => _)\n  && Reflect.isConstructor(class {});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("154");return Function("asyncTestPassed","'use strict';"+"\nreturn Reflect.isConstructor(function(){})\n  && !Reflect.isConstructor(_ => _)\n  && Reflect.isConstructor(class {});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10759,7 +10759,7 @@ return Reflect.isConstructor(function(){})
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10783,7 +10783,7 @@ return Reflect.isConstructor(function(){})
 <td class="no unstable not-applicable" data-browser="ios11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="1"><td id="test-zones"><span><a class="anchor" href="#test-zones">&#xA7;</a><a href="https://github.com/domenic/zones">zones</a></span></td>
-<td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -10822,7 +10822,7 @@ return Reflect.isConstructor(function(){})
 <td class="tally unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -10849,7 +10849,7 @@ return Reflect.isConstructor(function(){})
 return typeof Zone == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("156");try{return Function("asyncTestPassed","\nreturn typeof Zone == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("156");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10888,7 +10888,7 @@ return typeof Zone == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10915,7 +10915,7 @@ return typeof Zone == &apos;function&apos;;
 return &apos;current&apos; in Zone;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("157");try{return Function("asyncTestPassed","\nreturn 'current' in Zone;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("157");return Function("asyncTestPassed","'use strict';"+"\nreturn 'current' in Zone;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10954,7 +10954,7 @@ return &apos;current&apos; in Zone;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10981,7 +10981,7 @@ return &apos;current&apos; in Zone;
 return &apos;name&apos; in Zone.prototype;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("158");try{return Function("asyncTestPassed","\nreturn 'name' in Zone.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("158");return Function("asyncTestPassed","'use strict';"+"\nreturn 'name' in Zone.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11020,7 +11020,7 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11047,7 +11047,7 @@ return &apos;name&apos; in Zone.prototype;
 return &apos;parent&apos; in Zone.prototype;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("159");try{return Function("asyncTestPassed","\nreturn 'parent' in Zone.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("159");return Function("asyncTestPassed","'use strict';"+"\nreturn 'parent' in Zone.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11086,7 +11086,7 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11113,7 +11113,7 @@ return &apos;parent&apos; in Zone.prototype;
 return typeof Zone.prototype.fork == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("160");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.fork == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("160");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.fork == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11152,7 +11152,7 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11179,7 +11179,7 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 return typeof Zone.prototype.run == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("161");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.run == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("161");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.run == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11218,7 +11218,7 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11245,7 +11245,7 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 return typeof Zone.prototype.wrap == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("162");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.wrap == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("162");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.wrap == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11284,7 +11284,7 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11314,7 +11314,7 @@ asap(function(){ if(passed)asyncTestPassed(); });
 passed = true;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("163");try{return Function("asyncTestPassed","\nvar passed = false;\nsetTimeout(function(){ passed = false; }, 1);\nasap(function(){ if(passed)asyncTestPassed(); });\npassed = true;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("163");return Function("asyncTestPassed","'use strict';"+"\nvar passed = false;\nsetTimeout(function(){ passed = false; }, 1);\nasap(function(){ if(passed)asyncTestPassed(); });\npassed = true;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -11353,7 +11353,7 @@ passed = true;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11377,7 +11377,7 @@ passed = true;
 <td class="no unstable not-applicable" data-browser="ios11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-syntactic_tail_calls"><span><a class="anchor" href="#test-syntactic_tail_calls">&#xA7;</a><a href="https://github.com/tc39/proposal-ptc-syntax">syntactic tail calls</a></span></td>
-<td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -11416,7 +11416,7 @@ passed = true;
 <td class="tally unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -11449,7 +11449,7 @@ return (function f(n){
 }(1e6)) === &quot;foo&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");try{return Function("asyncTestPassed","\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("165");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11488,7 +11488,7 @@ return (function f(n){
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11528,7 +11528,7 @@ function g(n){
 return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("166");try{return Function("asyncTestPassed","\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return continue f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("166");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return continue f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11567,7 +11567,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11593,7 +11593,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <tr class="category"><td colspan="64">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
-<td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
@@ -11632,7 +11632,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -11659,7 +11659,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 return typeof Reflect.defineMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("168");try{return Function("asyncTestPassed","\nreturn typeof Reflect.defineMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("168");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.defineMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -11698,7 +11698,7 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11725,7 +11725,7 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 return typeof Reflect.hasMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("169");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("169");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -11764,7 +11764,7 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11791,7 +11791,7 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("170");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasOwnMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("170");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasOwnMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -11830,7 +11830,7 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11857,7 +11857,7 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 return typeof Reflect.getMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("171");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -11896,7 +11896,7 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11923,7 +11923,7 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 return typeof Reflect.getOwnMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("172");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("172");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -11962,7 +11962,7 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11989,7 +11989,7 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 return typeof Reflect.getMetadataKeys == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("173");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadataKeys == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("173");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadataKeys == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -12028,7 +12028,7 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12055,7 +12055,7 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("174");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadataKeys == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("174");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadataKeys == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -12094,7 +12094,7 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12121,7 +12121,7 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 return typeof Reflect.deleteMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");try{return Function("asyncTestPassed","\nreturn typeof Reflect.deleteMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("175");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.deleteMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -12160,7 +12160,7 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12187,7 +12187,7 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 return typeof Reflect.metadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("176");try{return Function("asyncTestPassed","\nreturn typeof Reflect.metadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("176");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.metadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -12226,7 +12226,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="safari11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="safaritp" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="webkit" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="phantom" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="iojs" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -161,8 +161,8 @@
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 36">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r219218 (July 6, 2017)">WK</abbr></a></th>
 <th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
-<th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
-<th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
+<th class="platform besen engine obsolete" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
+<th class="platform phantom engine obsolete" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine unstable" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
@@ -221,8 +221,8 @@
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="rhino1_7" data-tally="0.5">2/4</td>
-<td class="tally" data-browser="besen" data-tally="0.25">1/4</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="besen" data-tally="0.25">1/4</td>
+<td class="tally obsolete" data-browser="phantom" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -280,8 +280,8 @@ return typeof uneval == &apos;function&apos;;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -347,8 +347,8 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -406,8 +406,8 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -554,8 +554,8 @@ return true;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -614,8 +614,8 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="unknown obsolete" data-browser="rhino1_7">?</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -677,8 +677,8 @@ return 'caller' in function(){};
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -742,8 +742,8 @@ return (function () {}).arity === 0 &&
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -809,8 +809,8 @@ return f(1, 'boo');
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -870,8 +870,8 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -932,8 +932,8 @@ return new C instanceof C;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -995,8 +995,8 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1056,8 +1056,8 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1127,8 +1127,8 @@ return executed;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1188,8 +1188,8 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1249,8 +1249,8 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1312,8 +1312,8 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1371,8 +1371,8 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1430,8 +1430,8 @@ return (function(x)x)(1) === 1;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1489,8 +1489,8 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1552,8 +1552,8 @@ return str === &quot;foobarbaz&quot;;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1612,8 +1612,8 @@ return arr[1] === arr;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1705,8 +1705,8 @@ catch(e) {
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1804,8 +1804,8 @@ catch(e) {
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1902,8 +1902,8 @@ global.test((function () {
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -1963,8 +1963,8 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2029,8 +2029,8 @@ return passed;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2106,8 +2106,8 @@ try {
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2171,8 +2171,8 @@ return RegExp.lastMatch === 'x';
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2238,8 +2238,8 @@ return true;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2297,8 +2297,8 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2357,8 +2357,8 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2416,8 +2416,8 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="unknown" data-browser="besen">?</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="unknown obsolete" data-browser="besen">?</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2473,8 +2473,8 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2532,8 +2532,8 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2599,8 +2599,8 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="yes obsolete" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2658,8 +2658,8 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2715,8 +2715,8 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2772,8 +2772,8 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="yes" data-browser="besen">Yes</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="yes obsolete" data-browser="besen">Yes</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2831,8 +2831,8 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -2902,8 +2902,8 @@ try {
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes" data-browser="duktape2_1">Yes</td>
 <td class="yes unstable" data-browser="duktape2_2">Yes</td>
@@ -2963,8 +2963,8 @@ return 'lineNumber' in new Error();
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes" data-browser="duktape2_1">Yes</td>
 <td class="yes unstable" data-browser="duktape2_2">Yes</td>
@@ -3024,8 +3024,8 @@ return 'columnNumber' in new Error();
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3085,8 +3085,8 @@ return 'fileName' in new Error();
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="rhino1_7">Yes</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes" data-browser="duktape2_1">Yes</td>
 <td class="yes unstable" data-browser="duktape2_2">Yes</td>
@@ -3146,8 +3146,8 @@ return 'description' in new Error();
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="rhino1_7">No</td>
-<td class="no" data-browser="besen">No</td>
-<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="besen">No</td>
+<td class="no obsolete" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>


### PR DESCRIPTION
I think it's pretty safe to say that we won't expect any additions, changes from Traceur, Phantom.js, and Besen. As a bonus it'll also create more space for the test result table to display.

**Traceur**, last commit Sep 15, 2016
https://github.com/google/traceur-compiler

**Phantom.js** (unmaintained, some sporadic commits in June)
maintainer stepped down with the advent of Headless Chrome.
https://groups.google.com/forum/#!topic/phantomjs/9aI5d-LDuNE
https://github.com/ariya/phantomjs

**Besen**, last commit April 23, 2016
https://github.com/BeRo1985/besen