### PR TITLE
Change unstable Chrome features to false instead of "flagged"

### DIFF
--- a/data-common.json
+++ b/data-common.json
@@ -64,19 +64,19 @@
       "note_html": "The feature have to be enabled via --js-flags=\"--harmony\" flag"
     },
     "tco": {
-      "val": "flagged",
+      "val": false,
       "note_id": "chrome-tco",
-      "note_html": "The feature have to be enabled via --js-flags=\"--harmony-tailcalls\" flag"
+      "note_html": "The feature is considered unstable, but can be enabled via --js-flags=\"--harmony-tailcalls\" flag"
     },
     "promise": {
-      "val": "flagged",
+      "val": false,
       "note_id": "chrome-promise",
-      "note_html": "The feature have to be enabled via --js-flags=\"--harmony-promise-finally\" flag"
+      "note_html": "The feature is considered unstable, but can be enabled via --js-flags=\"--harmony-promise-finally\" flag"
     },
     "simd": {
-      "val": "flagged",
+      "val": false,
       "note_id": "chrome-simd",
-      "note_html": "The feature have to be enabled via --js-flags=\"--harmony-simd\" flag"
+      "note_html": "The feature is considered unstable, but can be enabled via --js-flags=\"--harmony-simd\" flag"
     }
   },
   "sparseNote": {

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -1933,8 +1933,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="chrome58" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome59" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome60" data-tally="0">0/3</td>
-<td class="tally" data-browser="chrome61" data-tally="0" data-flagged-tally="1">0/3</td>
-<td class="tally unstable" data-browser="chrome62" data-tally="0" data-flagged-tally="1">0/3</td>
+<td class="tally" data-browser="chrome61" data-tally="0">0/3</td>
+<td class="tally unstable" data-browser="chrome62" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="chrome63" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally obsolete" data-browser="safari8" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="safari9" data-tally="0">0/3</td>
@@ -2025,8 +2025,8 @@ function check() {
 <td class="no obsolete" data-browser="chrome58">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
 <td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
@@ -2109,8 +2109,8 @@ function check() {
 <td class="no obsolete" data-browser="chrome58">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
 <td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
@@ -2195,8 +2195,8 @@ function check() {
 <td class="no obsolete" data-browser="chrome58">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-promise-note"><sup>[10]</sup></a></td>
 <td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
@@ -3145,17 +3145,17 @@ return do {
 <td class="tally" data-browser="firefox55" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="firefox56" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="firefox57" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="chrome53" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="chrome54" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="chrome55" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="chrome56" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="chrome57" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="chrome58" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="chrome59" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="chrome60" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally" data-browser="chrome61" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally unstable" data-browser="chrome62" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally unstable" data-browser="chrome63" data-tally="0" data-flagged-tally="1">0/57</td>
+<td class="tally obsolete" data-browser="chrome53" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome54" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome55" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome56" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome57" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome58" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome59" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome60" data-tally="0">0/57</td>
+<td class="tally" data-browser="chrome61" data-tally="0">0/57</td>
+<td class="tally unstable" data-browser="chrome62" data-tally="0">0/57</td>
+<td class="tally unstable" data-browser="chrome63" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="safari8" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="safari9" data-tally="0">0/57</td>
 <td class="tally" data-browser="safari10" data-tally="0">0/57</td>
@@ -3167,14 +3167,14 @@ return do {
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="iojs" data-tally="0">0/57</td>
-<td class="tally" data-browser="node4" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="node5" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="node6" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally" data-browser="node6_5" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="node7" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="node7_6" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="node8" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally" data-browser="node8_3" data-tally="0" data-flagged-tally="1">0/57</td>
+<td class="tally" data-browser="node4" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="node5" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="node6" data-tally="0">0/57</td>
+<td class="tally" data-browser="node6_5" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="node7_6" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="node8" data-tally="0">0/57</td>
+<td class="tally" data-browser="node8_3" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/57</td>
 <td class="tally" data-browser="duktape2_1" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/57</td>
@@ -3219,17 +3219,17 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3241,14 +3241,14 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3285,17 +3285,17 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3307,14 +3307,14 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3351,17 +3351,17 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3373,14 +3373,14 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3417,17 +3417,17 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3439,14 +3439,14 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3483,17 +3483,17 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3505,14 +3505,14 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3549,17 +3549,17 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3571,14 +3571,14 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3615,17 +3615,17 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3637,14 +3637,14 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3681,17 +3681,17 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3703,14 +3703,14 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3747,17 +3747,17 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3769,14 +3769,14 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3813,17 +3813,17 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3835,14 +3835,14 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3879,17 +3879,17 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3901,14 +3901,14 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -3947,17 +3947,17 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -3969,14 +3969,14 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4015,17 +4015,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4037,14 +4037,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4083,17 +4083,17 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4105,14 +4105,14 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4151,17 +4151,17 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4173,14 +4173,14 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4219,17 +4219,17 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4241,14 +4241,14 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4287,17 +4287,17 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4309,14 +4309,14 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4355,17 +4355,17 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4377,14 +4377,14 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4423,17 +4423,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4445,14 +4445,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4491,17 +4491,17 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4513,14 +4513,14 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4559,17 +4559,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4581,14 +4581,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4627,17 +4627,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4649,14 +4649,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4695,17 +4695,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4717,14 +4717,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4763,17 +4763,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4785,14 +4785,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4831,17 +4831,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4853,14 +4853,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4899,17 +4899,17 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4921,14 +4921,14 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -4967,17 +4967,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -4989,14 +4989,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5035,17 +5035,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5057,14 +5057,14 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5103,17 +5103,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5125,14 +5125,14 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5171,17 +5171,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5193,14 +5193,14 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5239,17 +5239,17 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5261,14 +5261,14 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5307,17 +5307,17 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5329,14 +5329,14 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5375,17 +5375,17 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5397,14 +5397,14 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5443,17 +5443,17 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5465,14 +5465,14 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5511,17 +5511,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5533,14 +5533,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5579,17 +5579,17 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5601,14 +5601,14 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5647,17 +5647,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5669,14 +5669,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5715,17 +5715,17 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5737,14 +5737,14 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5783,17 +5783,17 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5805,14 +5805,14 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5851,17 +5851,17 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5873,14 +5873,14 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5919,17 +5919,17 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -5941,14 +5941,14 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -5987,17 +5987,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6009,14 +6009,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6055,17 +6055,17 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6077,14 +6077,14 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6123,17 +6123,17 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6145,14 +6145,14 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6191,17 +6191,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6213,14 +6213,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6259,17 +6259,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6281,14 +6281,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6327,17 +6327,17 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6349,14 +6349,14 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6395,17 +6395,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6417,14 +6417,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6463,17 +6463,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6485,14 +6485,14 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6531,17 +6531,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6553,14 +6553,14 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6599,17 +6599,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6621,14 +6621,14 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6667,17 +6667,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6689,14 +6689,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6735,17 +6735,17 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6757,14 +6757,14 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6803,17 +6803,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6825,14 +6825,14 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6871,17 +6871,17 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6893,14 +6893,14 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -6939,17 +6939,17 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -6961,14 +6961,14 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -7005,17 +7005,17 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
 <td class="no unstable" data-browser="firefox57">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome53">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome54">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome55">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome56">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome57">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome58">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="chrome61">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome62">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome63">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome53">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome54">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome55">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome56">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome57">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome58">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome59">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="chrome60">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="chrome61">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome62">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no unstable" data-browser="chrome63">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>
@@ -7027,14 +7027,14 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="iojs">No</td>
-<td class="no flagged" data-browser="node4">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
-<td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node4">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="node8">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="node8_3">No<a href="#chrome-simd-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no" data-browser="duktape2_1">No</td>
 <td class="no unstable" data-browser="duktape2_2">No</td>
@@ -12253,7 +12253,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="babel-optional-note">  <sup>[2]</sup> Flagged features require an optional transformer setting.</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="babel-core-js-note">  <sup>[4]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[5]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="ffox-global-property-note">  <sup>[6]</sup> The feature was disabled due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1325907">some</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1326032">compatibility</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1328218">issues</a>.</p><p id="wk-global-property-note">  <sup>[7]</sup> The feature was disabled due to <a href="https://bugs.webkit.org/show_bug.cgi?id=165171">compatibility issues</a>.</p><p id="firefox-nightly-note">  <sup>[8]</sup> The feature is enabled by default only in Firefox Nightly.</p><p id="chrome-harmony-note">  <sup>[9]</sup> The feature have to be enabled via --js-flags=&quot;--harmony&quot; flag</p><p id="chrome-promise-note">  <sup>[10]</sup> The feature have to be enabled via --js-flags=&quot;--harmony-promise-finally&quot; flag</p><p id="regenerator-decorators-legacy-note">  <sup>[11]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/regenerator-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="edge-experimental-flag-note">  <sup>[12]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p><p id="chrome-simd-note">  <sup>[13]</sup> The feature have to be enabled via --js-flags=&quot;--harmony-simd&quot; flag</p></div>
+    <p id="experimental-flag-note">  <sup>[1]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag unless otherwise stated</p><p id="babel-optional-note">  <sup>[2]</sup> Flagged features require an optional transformer setting.</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="babel-core-js-note">  <sup>[4]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[5]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="ffox-global-property-note">  <sup>[6]</sup> The feature was disabled due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1325907">some</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1326032">compatibility</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1328218">issues</a>.</p><p id="wk-global-property-note">  <sup>[7]</sup> The feature was disabled due to <a href="https://bugs.webkit.org/show_bug.cgi?id=165171">compatibility issues</a>.</p><p id="firefox-nightly-note">  <sup>[8]</sup> The feature is enabled by default only in Firefox Nightly.</p><p id="chrome-harmony-note">  <sup>[9]</sup> The feature have to be enabled via --js-flags=&quot;--harmony&quot; flag</p><p id="chrome-promise-note">  <sup>[10]</sup> The feature is considered unstable, but can be enabled via --js-flags=&quot;--harmony-promise-finally&quot; flag</p><p id="regenerator-decorators-legacy-note">  <sup>[11]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/regenerator-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="edge-experimental-flag-note">  <sup>[12]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under about:flags</p><p id="chrome-simd-note">  <sup>[13]</sup> The feature is considered unstable, but can be enabled via --js-flags=&quot;--harmony-simd&quot; flag</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>


### PR DESCRIPTION
Addressing the issues on #1169.
If I understand correctly, what @gsathya is saying on #1170 is that when a feature is behind a specific flag, it is because it is not considered ready for testing. As soon as it is considered ready to test, it is moved to the `--harmony` flag.