### PR TITLE
Update `Array#sort` `comparefn` data for Chrome 63

### DIFF
--- a/data-es5.js
+++ b/data-es5.js
@@ -743,6 +743,8 @@ exports.tests = [
       safari10_1: true,
       safaritp: false,
       webkit: false,
+      chrome1: false,
+      chrome63: true,
       opera10_10: null,
       opera10_50: true,
       konq4_3: null,

--- a/es5/index.html
+++ b/es5/index.html
@@ -1547,7 +1547,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally obsolete" data-browser="chrome60" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="chrome61" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally unstable" data-browser="chrome62" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
-<td class="tally unstable" data-browser="chrome63" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
+<td class="tally unstable" data-browser="chrome63" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="safari8" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="safari9" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="safari10" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
@@ -2324,7 +2324,7 @@ return true;
 <td class="no obsolete" data-browser="chrome60">No</td>
 <td class="no" data-browser="chrome61">No</td>
 <td class="no unstable" data-browser="chrome62">No</td>
-<td class="no unstable" data-browser="chrome63">No</td>
+<td class="yes unstable" data-browser="chrome63">Yes</td>
 <td class="no obsolete" data-browser="safari8">No</td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no" data-browser="safari10">No</td>


### PR DESCRIPTION
Ref. https://chromium.googlesource.com/v8/v8.git/+/a10e4a179e8a71b9e2c5470d3f50ec325cc1576e%5E%21/

(Note that this is not actually an ES5 test — see #1176.)