### PR TITLE
Update results for Duktape 2.2

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -1435,6 +1435,7 @@ exports.tests = [
           safari9: true,
           android4_0: true,
           duktape2_0: false,
+          duktape2_2: true,
         }
       },
       {
@@ -1458,6 +1459,7 @@ exports.tests = [
           safari5_1: true,
           safari9: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1484,6 +1486,7 @@ exports.tests = [
           android4_0: true,
           ios5_1: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1509,6 +1512,7 @@ exports.tests = [
           safari9: true,
           android4_0: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1532,6 +1536,7 @@ exports.tests = [
           safari5_1: true,
           safari9: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1560,6 +1565,7 @@ exports.tests = [
           android4_0: true,
           ios5_1: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1587,6 +1593,7 @@ exports.tests = [
           android4_0: true,
           ios5_1: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1614,6 +1621,7 @@ exports.tests = [
           safari9: true,
           android4_0: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1637,6 +1645,7 @@ exports.tests = [
           safari5_1: true,
           safari9: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1659,6 +1668,7 @@ exports.tests = [
           safari9: true,
           ios5_1: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1687,6 +1697,7 @@ exports.tests = [
           android4_0: true,
           ios5_1: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1714,6 +1725,7 @@ exports.tests = [
           android4_0: true,
           ios5_1: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1741,6 +1753,7 @@ exports.tests = [
           safari9: true,
           android4_0: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1764,6 +1777,7 @@ exports.tests = [
           safari5_1: true,
           safari9: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       },
       {
@@ -1786,6 +1800,7 @@ exports.tests = [
           safari9: true,
           ios5_1: true,
           duktape2_0: false,
+          duktape2_2: true,
         },
       }
     ]

--- a/data-es6.js
+++ b/data-es6.js
@@ -411,7 +411,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
-        duktape2_2: true,
+        duktape2_2: false,
       },
     },
   ],
@@ -8552,6 +8552,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        duktape2_2: true,
       },
     },
     {
@@ -8581,6 +8582,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        duktape2_2: true,
       },
     },
     {
@@ -8606,6 +8608,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        duktape2_2: true,
       },
     },
     {
@@ -8645,6 +8648,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        duktape2_2: true,
       },
     },
     {
@@ -8818,6 +8822,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        duktape2_2: true,
       },
     },
     {
@@ -12504,6 +12509,7 @@ exports.tests = [
         node8: true,
         safari9: false,
         safari10: true,
+        duktape2_2: false,
       },
     },
   ],
@@ -14193,6 +14199,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         duktape2_0: false,
+        duktape2_2: true,
       }
     },
     {
@@ -16303,6 +16310,7 @@ exports.tests = [
         node0_12: true,
         safari9: true,
         typescript: typescript.corejs,
+        duktape2_2: false,
       },
     },
     {
@@ -16322,6 +16330,7 @@ exports.tests = [
         node0_12: true,
         safari9: true,
         typescript: typescript.corejs,
+        duktape2_2: false,
       },
     },
     {
@@ -16424,6 +16433,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        duktape2_2: true,
       },
       'imul': {
         ejs: true,
@@ -16448,6 +16458,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        duktape2_2: true,
       },
       'sign': {
         ejs: true,
@@ -16467,6 +16478,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        duktape2_2: true,
       },
       'log10': {
         ejs: true,
@@ -17827,6 +17839,7 @@ exports.tests = [
         ejs: true,
         chrome49: true,
         duktape2_0: false,
+        duktape2_2: true,
       }
     },
   ],
@@ -17872,6 +17885,7 @@ exports.tests = [
         jxa: null,
         node0_10: null,
         duktape2_0: null,
+        duktape2_2: false,
         android1_5: null,
         ios4: null,
       },
@@ -17908,6 +17922,7 @@ exports.tests = [
         jxa: null,
         node0_10: null,
         duktape2_0: null,
+        duktape2_2: false,
         android1_5: null,
         ios4: null,
       },

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1758,6 +1758,7 @@ exports.tests = [
     jxa: null,
     node0_10: null,
     duktape2_0: null,
+    duktape2_2: false,
     android1_5: null,
     ios4: null,
   },
@@ -2281,6 +2282,7 @@ exports.tests = [
   res : {
     babel: babel.corejs,
     typescript: typescript.corejs,
+    duktape2_2: false,
   }
 },
 {
@@ -2298,6 +2300,7 @@ exports.tests = [
     res: {
       babel: babel.corejs,
       typescript: typescript.corejs,
+      duktape2_2: false,
     },
   }, {
     name: 'Math.DEG_PER_RAD',
@@ -2307,6 +2310,7 @@ exports.tests = [
     res: {
       babel: babel.corejs,
       typescript: typescript.corejs,
+      duktape2_2: false,
     },
   }, {
     name: 'Math.degrees',
@@ -2317,6 +2321,7 @@ exports.tests = [
     res: {
       babel: babel.corejs,
       typescript: typescript.corejs,
+      duktape2_2: false,
     },
   }, {
     name: 'Math.fscale',
@@ -2326,6 +2331,7 @@ exports.tests = [
     res: {
       babel: babel.corejs,
       typescript: typescript.corejs,
+      duktape2_2: false,
     },
   }, {
     name: 'Math.RAD_PER_DEG',
@@ -2335,6 +2341,7 @@ exports.tests = [
     res: {
       babel: babel.corejs,
       typescript: typescript.corejs,
+      duktape2_2: false,
     },
   }, {
     name: 'Math.radians',
@@ -2345,6 +2352,7 @@ exports.tests = [
     res: {
       babel: babel.corejs,
       typescript: typescript.corejs,
+      duktape2_2: false,
     },
   }, {
     name: 'Math.scale',
@@ -2354,6 +2362,7 @@ exports.tests = [
     res: {
       babel: babel.corejs,
       typescript: typescript.corejs,
+      duktape2_2: false,
     },
   }]
 },
@@ -2371,6 +2380,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2381,6 +2391,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2393,6 +2404,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2410,6 +2422,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2427,6 +2440,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2444,6 +2458,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2461,6 +2476,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     }
   ]
@@ -2509,6 +2525,7 @@ exports.tests = [
         chrome63: true,
         safaritp: true,
         webkit: true,
+        duktape2_2: false,
       }
     },
     {
@@ -2541,6 +2558,7 @@ exports.tests = [
         chrome63: true,
         safaritp: true,
         webkit: true,
+        duktape2_2: false,
       }
     },
     {
@@ -2575,6 +2593,7 @@ exports.tests = [
         chrome61: chrome.promise,
         chrome63: true,
         webkit: true,
+        duktape2_2: false,
       }
     }
   ]
@@ -2593,6 +2612,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2605,6 +2625,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     }
   ]
@@ -2626,6 +2647,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2641,6 +2663,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2654,6 +2677,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2667,6 +2691,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2680,6 +2705,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2695,6 +2721,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2708,6 +2735,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
     {
@@ -2721,6 +2749,7 @@ exports.tests = [
       res: {
         babel: babel.corejs,
         typescript: typescript.corejs,
+        duktape2_2: false,
       }
     },
   ]
@@ -2744,7 +2773,8 @@ exports.tests = [
       */},
       res: {
         safaritp: true,
-        webkit: true
+        webkit: true,
+        duktape2_2: false,
       },
     },
     {
@@ -2761,7 +2791,8 @@ exports.tests = [
       */},
       res: {
         safaritp: true,
-        webkit: true
+        webkit: true,
+        duktape2_2: false,
       },
     },
     {
@@ -2783,7 +2814,8 @@ exports.tests = [
       */},
       res: {
         safaritp: true,
-        webkit: true
+        webkit: true,
+        duktape2_2: false,
       }
     }
   ]

--- a/duktape.js
+++ b/duktape.js
@@ -26,6 +26,9 @@ var dukKey = (function () {
     });
     var dukVersion = Number(stdout);
     console.log('Duktape version is: ' + dukVersion);
+    if ((dukVersion % 100) == 99) {
+        dukVersion++;  // Treat e.g. 2.2.99 (built from master) as 2.3.0 for testing
+    }
     return 'duktape' + (Math.floor(dukVersion / 10000)) + '_' + (Math.floor(dukVersion / 100 % 100));
 })();
 console.log('Duktape result key is: test.res.' + dukKey);

--- a/environments.json
+++ b/environments.json
@@ -1993,6 +1993,7 @@
     "short": "DUK 1.1",
     "platformtype": "engine",
     "release": "2015-01-09",
+    "retire": "2015-04-05",
     "obsolete": "very",
     "test_suites": [
       "es5",
@@ -2005,6 +2006,7 @@
     "short": "DUK 1.2",
     "platformtype": "engine",
     "release": "2015-04-05",
+    "retire": "2016-04-19",
     "obsolete": "very",
     "test_suites": [
       "es5",
@@ -2017,6 +2019,7 @@
     "short": "DUK 1.3",
     "platformtype": "engine",
     "release": "2015-09-12",
+    "retire": "2016-04-17",
     "obsolete": "very",
     "test_suites": [
       "es5",
@@ -2029,6 +2032,7 @@
     "short": "DUK 1.4",
     "platformtype": "engine",
     "release": "2016-01-10",
+    "retire": "2016-08-29",
     "obsolete": "very",
     "test_suites": [
       "es5",
@@ -2091,8 +2095,8 @@
     "family": "Duktape",
     "short": "DUK 2.0",
     "platformtype": "engine",
-    "release": "2017-01-17",
-    "retire": "2017-04-15",
+    "release": "2017-01-02",
+    "retire": "2017-05-04",
     "obsolete": true
   },
   "duktape2_1": {
@@ -2101,14 +2105,16 @@
     "short": "DUK 2.1",
     "platformtype": "engine",
     "release": "2017-04-15",
-    "obsolete": false
+    "retire": "2017-09-23",
+    "obsolete": true
   },
   "duktape2_2": {
     "full": "Duktape 2.2",
     "family": "Duktape",
     "short": "DUK 2.2",
     "platformtype": "engine",
-    "unstable": true
+    "release": "2017-09-23",
+    "obsolete": false
   },
   "android1_5": {
     "full": "Android Browser 1.5 (Cupcake)",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -172,8 +172,8 @@
 <th class="platform node8 engine obsolete" data-browser="node8"><a href="#node8" class="browser-name"><abbr title="Node.js">Node 8.0-8.2</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform node8_3 engine" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
-<th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
-<th class="platform duktape2_2 engine unstable" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
+<th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
+<th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -240,8 +240,8 @@
 <td class="tally obsolete" data-browser="node8" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/3</td>
@@ -305,8 +305,8 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -370,8 +370,8 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -440,8 +440,8 @@ return true;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -502,8 +502,8 @@ return true;
 <td class="tally obsolete" data-browser="node8" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/3</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/3</td>
@@ -571,8 +571,8 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -658,8 +658,8 @@ return 24;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -728,8 +728,8 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -802,8 +802,8 @@ return true;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -880,8 +880,8 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -950,8 +950,8 @@ return true;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1016,8 +1016,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1083,8 +1083,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1155,8 +1155,8 @@ return passed;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1229,8 +1229,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1293,8 +1293,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="node8" data-tally="1">4/4</td>
 <td class="tally" data-browser="node8_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -1361,8 +1361,8 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1433,8 +1433,8 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1506,8 +1506,8 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1574,8 +1574,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1636,8 +1636,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="node8" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -1706,8 +1706,8 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1776,8 +1776,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1838,8 +1838,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="node8" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -1903,8 +1903,8 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1968,8 +1968,8 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2030,8 +2030,8 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="node8" data-tally="1">15/15</td>
 <td class="tally" data-browser="node8_3" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/15</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/15</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/15</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/15</td>
@@ -2106,8 +2106,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2182,8 +2182,8 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2248,8 +2248,8 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2314,8 +2314,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2386,8 +2386,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2460,8 +2460,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2526,8 +2526,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2597,8 +2597,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2663,8 +2663,8 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2739,8 +2739,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2815,8 +2815,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2889,8 +2889,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2957,8 +2957,8 @@ return passed;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3022,8 +3022,8 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3096,8 +3096,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3158,8 +3158,8 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="node8" data-tally="0" data-flagged-tally="0.8823529411764706">0/17</td>
 <td class="tally" data-browser="node8_3" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/17</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/17</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/17</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/17</td>
@@ -3223,8 +3223,8 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3288,8 +3288,8 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3353,8 +3353,8 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3418,8 +3418,8 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3483,8 +3483,8 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3548,8 +3548,8 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3613,8 +3613,8 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3678,8 +3678,8 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3743,8 +3743,8 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3808,8 +3808,8 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3873,8 +3873,8 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3938,8 +3938,8 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4003,8 +4003,8 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4068,8 +4068,8 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4133,8 +4133,8 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4198,8 +4198,8 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4263,8 +4263,8 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4335,8 +4335,8 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4403,8 +4403,8 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4471,8 +4471,8 @@ return (function(){
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4535,8 +4535,8 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.75">12/16</td>
 <td class="tally not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.75">12/16</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.0625">1/16</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.625">6/16</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.625">6/16</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
@@ -4605,8 +4605,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4676,8 +4676,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4747,8 +4747,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4817,8 +4817,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4888,8 +4888,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4959,8 +4959,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5031,8 +5031,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5103,8 +5103,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5176,8 +5176,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5246,8 +5246,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5315,8 +5315,8 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5387,8 +5387,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5459,8 +5459,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5532,8 +5532,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5602,8 +5602,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5671,8 +5671,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5733,8 +5733,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -5802,8 +5802,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5871,8 +5871,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5945,8 +5945,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6019,8 +6019,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6085,8 +6085,8 @@ return i === 0;
 <td class="yes obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -6159,8 +6159,8 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -182,8 +182,8 @@
 <th class="platform duktape1_7 engine obsolete" data-browser="duktape1_7"><a href="#duktape1_7" class="browser-name"><abbr title="Duktape 1.7">DUK 1.7</abbr></a></th>
 <th class="platform duktape1_8 engine" data-browser="duktape1_8"><a href="#duktape1_8" class="browser-name"><abbr title="Duktape 1.8">DUK 1.8</abbr></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
-<th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
-<th class="platform duktape2_2 engine unstable" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
+<th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
+<th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -256,8 +256,8 @@
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/5</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">5/5</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">5/5</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">5/5</td>
@@ -329,8 +329,8 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -404,8 +404,8 @@ return value === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -477,8 +477,8 @@ return { a: true, }.a === true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -550,8 +550,8 @@ return [1,].length === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -623,8 +623,8 @@ return ({ if: 1 }).if === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -695,8 +695,8 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/13</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">13/13</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">13/13</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">13/13</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">13/13</td>
@@ -770,8 +770,8 @@ return typeof Object.create == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -845,8 +845,8 @@ return typeof Object.defineProperty == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -920,8 +920,8 @@ return typeof Object.defineProperties == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -995,8 +995,8 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1070,8 +1070,8 @@ return typeof Object.keys == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1145,8 +1145,8 @@ return typeof Object.seal == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1220,8 +1220,8 @@ return typeof Object.freeze == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1295,8 +1295,8 @@ return typeof Object.preventExtensions == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1370,8 +1370,8 @@ return typeof Object.isSealed == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1445,8 +1445,8 @@ return typeof Object.isFrozen == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1520,8 +1520,8 @@ return typeof Object.isExtensible == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1595,8 +1595,8 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1670,8 +1670,8 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1740,8 +1740,8 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/12</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">12/12</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">12/12</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">12/12</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">12/12</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
@@ -1815,8 +1815,8 @@ return typeof Array.isArray == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1890,8 +1890,8 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1965,8 +1965,8 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2040,8 +2040,8 @@ return typeof Array.prototype.every == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2115,8 +2115,8 @@ return typeof Array.prototype.some == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2190,8 +2190,8 @@ return typeof Array.prototype.forEach == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2265,8 +2265,8 @@ return typeof Array.prototype.map == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2340,8 +2340,8 @@ return typeof Array.prototype.filter == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2415,8 +2415,8 @@ return typeof Array.prototype.reduce == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2490,8 +2490,8 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2605,8 +2605,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2690,8 +2690,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2760,8 +2760,8 @@ try {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">2/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">2/2</td>
@@ -2835,8 +2835,8 @@ return "foobar"[3] === "b";
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2910,8 +2910,8 @@ return typeof String.prototype.trim == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2980,8 +2980,8 @@ return typeof String.prototype.trim == 'function';
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">3/3</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">3/3</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -3055,8 +3055,8 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3130,8 +3130,8 @@ return typeof Date.now == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3213,8 +3213,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3288,8 +3288,8 @@ return typeof Function.prototype.bind == 'function';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3363,8 +3363,8 @@ return typeof JSON == 'object';
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3435,8 +3435,8 @@ return typeof JSON == 'object';
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">3/3</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">3/3</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">3/3</td>
@@ -3511,8 +3511,8 @@ return result;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3587,8 +3587,8 @@ return result;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3663,8 +3663,8 @@ return result;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3733,8 +3733,8 @@ return result;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -3808,8 +3808,8 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3883,8 +3883,8 @@ return parseInt('010') === 10;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3956,8 +3956,8 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4029,8 +4029,8 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4103,8 +4103,8 @@ return _\u200c\u200d;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4178,8 +4178,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4259,8 +4259,8 @@ return result;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4338,8 +4338,8 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4408,8 +4408,8 @@ catch(e) {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/19</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">19/19</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">19/19</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">19/19</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">19/19</td>
@@ -4486,8 +4486,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4560,8 +4560,8 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4636,8 +4636,8 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4726,8 +4726,8 @@ return test(String, &apos;&apos;)
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4802,8 +4802,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4876,8 +4876,8 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -4954,8 +4954,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5032,8 +5032,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5112,8 +5112,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5189,8 +5189,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5264,8 +5264,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5340,8 +5340,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5420,8 +5420,8 @@ return (function(x){
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5494,8 +5494,8 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5568,8 +5568,8 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5642,8 +5642,8 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5716,8 +5716,8 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5790,8 +5790,8 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5864,8 +5864,8 @@ return typeof foo === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -203,8 +203,8 @@
 <th class="platform duktape1_7 engine obsolete" data-browser="duktape1_7"><a href="#duktape1_7" class="browser-name"><abbr title="Duktape 1.7">DUK 1.7</abbr></a></th>
 <th class="platform duktape1_8 engine" data-browser="duktape1_8"><a href="#duktape1_8" class="browser-name"><abbr title="Duktape 1.8">DUK 1.8</abbr></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
-<th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
-<th class="platform duktape2_2 engine unstable" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
+<th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
+<th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -283,8 +283,8 @@
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">2/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -366,8 +366,8 @@ return (function f(n){
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -456,8 +456,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -532,8 +532,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/7</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/7</td>
@@ -609,8 +609,8 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -686,8 +686,8 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -763,8 +763,8 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -847,8 +847,8 @@ return (function (a = &quot;baz&quot;, b = &quot;qux&quot;, c = &quot;quux&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -934,8 +934,8 @@ return (function(x = 1) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1016,8 +1016,8 @@ return (function(a=function(){
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1095,8 +1095,8 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1169,8 +1169,8 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/5</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/5</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/5</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/5</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/5</td>
@@ -1248,8 +1248,8 @@ return (function (foo, ...args) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1325,8 +1325,8 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1410,8 +1410,8 @@ return (function (foo, ...args) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1493,8 +1493,8 @@ return (function (...args) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1572,8 +1572,8 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1646,8 +1646,8 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/15</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/15</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/15</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/15</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">5/15</td>
@@ -1723,8 +1723,8 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1800,8 +1800,8 @@ return [...[1, 2, 3]][2] === 3;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1878,8 +1878,8 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1956,8 +1956,8 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2033,8 +2033,8 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2110,8 +2110,8 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2187,8 +2187,8 @@ return Array(...&quot;&#x20BB7;&#x20BB6;&quot;)[0] === &quot;&#x20BB7;&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2264,8 +2264,8 @@ return [...&quot;&#x20BB7;&#x20BB6;&quot;][0] === &quot;&#x20BB7;&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2342,8 +2342,8 @@ return Math.max(...iterable) === 3;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2420,8 +2420,8 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2498,8 +2498,8 @@ return Math.max(...iterable) === 3;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2576,8 +2576,8 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2654,8 +2654,8 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2732,8 +2732,8 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2813,8 +2813,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2887,8 +2887,8 @@ try {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/6</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -2965,8 +2965,8 @@ return ({ [x]: 1 }).y === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3043,8 +3043,8 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3120,8 +3120,8 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3197,8 +3197,8 @@ return ({ &quot;foo bar&quot;() { return 4; } })[&quot;foo bar&quot;]() === 4;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3275,8 +3275,8 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3359,8 +3359,8 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3433,8 +3433,8 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/9</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/9</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/9</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/9</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
@@ -3512,8 +3512,8 @@ for (var item of arr)
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3593,8 +3593,8 @@ return count === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -3673,8 +3673,8 @@ return str === &quot;foo&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3753,8 +3753,8 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3835,8 +3835,8 @@ return result === &quot;123&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3917,8 +3917,8 @@ return result === &quot;123&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3999,8 +3999,8 @@ return result === &quot;123&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4081,8 +4081,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4165,8 +4165,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4239,8 +4239,8 @@ return closed;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">4/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">4/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -4316,8 +4316,8 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4393,8 +4393,8 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4470,8 +4470,8 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4547,8 +4547,8 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4621,8 +4621,8 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/5</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/5</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/5</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/5</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/5</td>
@@ -4700,8 +4700,8 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4781,8 +4781,8 @@ return `${a}` === &quot;foo&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4869,8 +4869,8 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4948,8 +4948,8 @@ return (function(parts) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5030,8 +5030,8 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5104,8 +5104,8 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/5</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/5</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/5</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/5</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/5</td>
@@ -5183,8 +5183,8 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5263,8 +5263,8 @@ return result === &apos;yy&apos; &amp;&amp; re.lastIndex === 5;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5340,8 +5340,8 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5417,8 +5417,8 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5494,8 +5494,8 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5568,8 +5568,8 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/22</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/22</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/22</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/22</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/22</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.4090909090909091" style="background-color:hsl(49,68%,50%)">9/22</td>
@@ -5646,8 +5646,8 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5724,8 +5724,8 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5802,8 +5802,8 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -5880,8 +5880,8 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5958,8 +5958,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6036,8 +6036,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6114,8 +6114,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6196,8 +6196,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6274,8 +6274,8 @@ return a === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6352,8 +6352,8 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -6432,8 +6432,8 @@ return toFixed === Number.prototype.toFixed
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -6510,8 +6510,8 @@ return a === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6601,8 +6601,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -6680,8 +6680,8 @@ return grault === &quot;garply&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6758,8 +6758,8 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6838,8 +6838,8 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -6917,8 +6917,8 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -6996,8 +6996,8 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -7081,8 +7081,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7161,8 +7161,8 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7241,8 +7241,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7327,8 +7327,8 @@ return a === 1 &amp;&amp; b === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7401,8 +7401,8 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/24</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/24</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/24</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/24</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">12/24</td>
@@ -7480,8 +7480,8 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -7559,8 +7559,8 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -7638,8 +7638,8 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -7717,8 +7717,8 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7796,8 +7796,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7875,8 +7875,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7954,8 +7954,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8037,8 +8037,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8115,8 +8115,8 @@ return ([a, b] = iterable) === iterable;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -8194,8 +8194,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -8273,8 +8273,8 @@ return a === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8352,8 +8352,8 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -8433,8 +8433,8 @@ return toFixed === Number.prototype.toFixed
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -8512,8 +8512,8 @@ return a === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8590,8 +8590,8 @@ return ({a,b} = obj) === obj;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -8674,8 +8674,8 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -8753,8 +8753,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -8845,8 +8845,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -8924,8 +8924,8 @@ return grault === &quot;garply&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9005,8 +9005,8 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -9086,8 +9086,8 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9165,8 +9165,8 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9244,8 +9244,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9325,8 +9325,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9399,8 +9399,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/24</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/24</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/24</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/24</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.4166666666666667" style="background-color:hsl(50,67%,50%)">10/24</td>
@@ -9478,8 +9478,8 @@ return function([a, , [b], c]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -9557,8 +9557,8 @@ return function([a, , b]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -9636,8 +9636,8 @@ return function([a, b, c]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -9715,8 +9715,8 @@ return function([c]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9794,8 +9794,8 @@ return function([a, b, c]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9873,8 +9873,8 @@ return function([a, b, c]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9952,8 +9952,8 @@ return function([a, b, c]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -10034,8 +10034,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -10113,8 +10113,8 @@ return function([a,]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -10192,8 +10192,8 @@ return function({c, x:d, e}) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -10272,8 +10272,8 @@ return function({toFixed}, {slice}) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -10351,8 +10351,8 @@ return function({a,}) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -10436,8 +10436,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -10516,8 +10516,8 @@ return function({ [qux]: grault }) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -10596,8 +10596,8 @@ return function([e, {x:f, g}], {h, x:[i]}) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -10676,8 +10676,8 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -10756,8 +10756,8 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -10833,8 +10833,8 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -10913,8 +10913,8 @@ return function([a, ...b], [c, ...d]) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -10992,8 +10992,8 @@ return function ([],{}){
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -11073,8 +11073,8 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5},
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -11155,8 +11155,8 @@ return (function({a=function(){
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -11234,8 +11234,8 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -11313,8 +11313,8 @@ return ((a, {b = 0, c = 3}) =&gt; {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -11387,8 +11387,8 @@ return ((a, {b = 0, c = 3}) =&gt; {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">2/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -11464,8 +11464,8 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -11542,8 +11542,8 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -11616,8 +11616,8 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -11700,8 +11700,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -11786,8 +11786,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -11862,8 +11862,8 @@ try {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0.0625" style="background-color:hsl(7,83%,50%)">1/16</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0.0625" style="background-color:hsl(7,83%,50%)">1/16</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.0625" style="background-color:hsl(7,83%,50%)" data-flagged-tally="0.375">1/16</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.0625" style="background-color:hsl(7,83%,50%)" data-flagged-tally="0.375">1/16</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.0625" style="background-color:hsl(7,83%,50%)">1/16</td>
@@ -11940,8 +11940,8 @@ return (foo === 123);
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -12019,8 +12019,8 @@ return bar === 123;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12101,8 +12101,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12183,8 +12183,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12262,8 +12262,8 @@ return baz === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12343,8 +12343,8 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12424,8 +12424,8 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12505,8 +12505,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12584,8 +12584,8 @@ return (foo === 123);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12664,8 +12664,8 @@ return bar === 123;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12747,8 +12747,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12830,8 +12830,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12910,8 +12910,8 @@ return baz === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -12992,8 +12992,8 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13074,8 +13074,8 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13156,8 +13156,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13230,8 +13230,8 @@ return passed;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/12</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/12</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/12</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/12</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0" data-flagged-tally="0.4166666666666667">0/12</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0" data-flagged-tally="0.4166666666666667">0/12</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/12</td>
@@ -13308,8 +13308,8 @@ return (foo === 123);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13387,8 +13387,8 @@ return bar === 123;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13469,8 +13469,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13548,8 +13548,8 @@ return baz === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13629,8 +13629,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13717,8 +13717,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13796,8 +13796,8 @@ return (foo === 123);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13876,8 +13876,8 @@ return bar === 123;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -13959,8 +13959,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14039,8 +14039,8 @@ return baz === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14121,8 +14121,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14210,8 +14210,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14296,8 +14296,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14372,8 +14372,8 @@ return true;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/13</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/13</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/13</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/13</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/13</td>
@@ -14449,8 +14449,8 @@ return (() =&gt; 5)() === 5;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14527,8 +14527,8 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14605,8 +14605,8 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14684,8 +14684,8 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14763,8 +14763,8 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14842,8 +14842,8 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14920,8 +14920,8 @@ return f(6) === 5;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -14999,8 +14999,8 @@ return (() =&gt; {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15078,8 +15078,8 @@ return (() =&gt; {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15156,8 +15156,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15246,8 +15246,8 @@ return new C instanceof C &amp;&amp; received === &apos;foo&apos;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15334,8 +15334,8 @@ return arrow() === &quot;quux&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15414,8 +15414,8 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15488,8 +15488,8 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/24</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/24</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/24</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/24</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/24</td>
@@ -15566,8 +15566,8 @@ return typeof C === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15649,8 +15649,8 @@ return C === c1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15726,8 +15726,8 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15803,8 +15803,8 @@ return typeof class {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15884,8 +15884,8 @@ return C.prototype.constructor === C
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -15965,8 +15965,8 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16046,8 +16046,8 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16128,8 +16128,8 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16213,8 +16213,8 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16294,8 +16294,8 @@ return typeof C.method === &quot;function&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16376,8 +16376,8 @@ return typeof C.method === &quot;function&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16459,8 +16459,8 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16542,8 +16542,8 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16625,8 +16625,8 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16708,8 +16708,8 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16790,8 +16790,8 @@ return C === undefined &amp;&amp; M();
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16873,8 +16873,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -16954,8 +16954,8 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17034,8 +17034,8 @@ return (0,C.method)();
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17117,8 +17117,8 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17197,8 +17197,8 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17277,8 +17277,8 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17358,8 +17358,8 @@ return Function.prototype.isPrototypeOf(C)
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17447,8 +17447,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17521,8 +17521,8 @@ return passed;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/8</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/8</td>
@@ -17606,8 +17606,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17689,8 +17689,8 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17773,8 +17773,8 @@ return new C().quux(&quot;bar&quot;) === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17856,8 +17856,8 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -17941,8 +17941,8 @@ return obj.qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18026,8 +18026,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18113,8 +18113,8 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18202,8 +18202,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18276,8 +18276,8 @@ return passed;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/27</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/27</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/27</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/27</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/27</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/27</td>
@@ -18363,8 +18363,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18450,8 +18450,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18537,8 +18537,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18622,8 +18622,8 @@ catch (e) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18707,8 +18707,8 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18793,8 +18793,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18883,8 +18883,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -18972,8 +18972,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19060,8 +19060,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19147,8 +19147,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19231,8 +19231,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19317,8 +19317,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19403,8 +19403,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19489,8 +19489,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19575,8 +19575,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19663,8 +19663,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19751,8 +19751,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19839,8 +19839,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -19928,8 +19928,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -20021,8 +20021,8 @@ return closed === &apos;ab&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -20113,8 +20113,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -20202,8 +20202,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -20291,8 +20291,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -20381,8 +20381,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -20470,8 +20470,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -20560,8 +20560,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -20646,8 +20646,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -20722,8 +20722,8 @@ try {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0.3695652173913043" style="background-color:hsl(44,69%,50%)">17/46</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0.3695652173913043" style="background-color:hsl(44,69%,50%)">17/46</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.41304347826086957" style="background-color:hsl(49,67%,50%)">19/46</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.43478260869565216" style="background-color:hsl(52,66%,50%)">20/46</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.43478260869565216" style="background-color:hsl(52,66%,50%)">20/46</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.43478260869565216" style="background-color:hsl(52,66%,50%)">20/46</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.43478260869565216" style="background-color:hsl(52,66%,50%)">20/46</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.41304347826086957" style="background-color:hsl(49,67%,50%)">19/46</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.41304347826086957" style="background-color:hsl(49,67%,50%)">19/46</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.391304347826087" style="background-color:hsl(46,68%,50%)">18/46</td>
@@ -20801,8 +20801,8 @@ return view[0] === -0x80;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -20880,8 +20880,8 @@ return view[0] === 0;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -20959,8 +20959,8 @@ return view[0] === 0xFF;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21038,8 +21038,8 @@ return view[0] === -0x8000;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21117,8 +21117,8 @@ return view[0] === 0;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21196,8 +21196,8 @@ return view[0] === -0x80000000;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21275,8 +21275,8 @@ return view[0] === 0;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21354,8 +21354,8 @@ return view[0] === 0.10000000149011612;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21433,8 +21433,8 @@ return view[0] === 0.1;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21513,8 +21513,8 @@ return view.getInt8(0) === -0x80;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21593,8 +21593,8 @@ return view.getUint8(0) === 0;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21673,8 +21673,8 @@ return view.getInt16(0) === -0x8000;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21753,8 +21753,8 @@ return view.getUint16(0) === 0;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21833,8 +21833,8 @@ return view.getInt32(0) === -0x80000000;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21913,8 +21913,8 @@ return view.getUint32(0) === 0;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -21993,8 +21993,8 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -22073,8 +22073,8 @@ return view.getFloat64(0) === 0.1;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -22150,8 +22150,8 @@ return typeof ArrayBuffer[Symbol.species] === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -22250,8 +22250,8 @@ return constructors.every(function (constructor) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -22342,8 +22342,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -22442,8 +22442,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -22527,8 +22527,8 @@ typeof Float64Array.from === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -22612,8 +22612,8 @@ typeof Float64Array.of === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -22697,8 +22697,8 @@ typeof Float64Array.prototype.subarray === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -22782,8 +22782,8 @@ typeof Float64Array.prototype.join === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -22867,8 +22867,8 @@ typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -22952,8 +22952,8 @@ typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23037,8 +23037,8 @@ typeof Float64Array.prototype.slice === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23122,8 +23122,8 @@ typeof Float64Array.prototype.every === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23207,8 +23207,8 @@ typeof Float64Array.prototype.filter === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23292,8 +23292,8 @@ typeof Float64Array.prototype.forEach === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23377,8 +23377,8 @@ typeof Float64Array.prototype.map === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23462,8 +23462,8 @@ typeof Float64Array.prototype.reduce === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23547,8 +23547,8 @@ typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23632,8 +23632,8 @@ typeof Float64Array.prototype.reverse === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23717,8 +23717,8 @@ typeof Float64Array.prototype.some === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23802,8 +23802,8 @@ typeof Float64Array.prototype.sort === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23887,8 +23887,8 @@ typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -23972,8 +23972,8 @@ typeof Float64Array.prototype.find === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24057,8 +24057,8 @@ typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24142,8 +24142,8 @@ typeof Float64Array.prototype.fill === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24227,8 +24227,8 @@ typeof Float64Array.prototype.keys === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24312,8 +24312,8 @@ typeof Float64Array.prototype.values === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24397,8 +24397,8 @@ typeof Float64Array.prototype.entries === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24482,8 +24482,8 @@ typeof Float64Array.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24567,8 +24567,8 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24641,8 +24641,8 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/19</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/19</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/19</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/19</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
@@ -24723,8 +24723,8 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -24805,8 +24805,8 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24888,8 +24888,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -24966,8 +24966,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -25053,8 +25053,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -25137,8 +25137,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -25215,8 +25215,8 @@ return map.set(0, 0) === map;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -25298,8 +25298,8 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -25380,8 +25380,8 @@ return map.size === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -25457,8 +25457,8 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -25534,8 +25534,8 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -25611,8 +25611,8 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -25688,8 +25688,8 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -25765,8 +25765,8 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -25842,8 +25842,8 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -25919,8 +25919,8 @@ return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -26003,8 +26003,8 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -26090,8 +26090,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -26168,8 +26168,8 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -26242,8 +26242,8 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/19</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/19</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/19</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/19</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
@@ -26325,8 +26325,8 @@ return set.has(123);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -26406,8 +26406,8 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -26489,8 +26489,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -26567,8 +26567,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -26654,8 +26654,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -26741,8 +26741,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -26819,8 +26819,8 @@ return set.add(0) === set;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -26902,8 +26902,8 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -26986,8 +26986,8 @@ return set.size === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -27063,8 +27063,8 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -27140,8 +27140,8 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -27217,8 +27217,8 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -27294,8 +27294,8 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -27371,8 +27371,8 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -27448,8 +27448,8 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -27525,8 +27525,8 @@ return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -27609,8 +27609,8 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -27696,8 +27696,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -27774,8 +27774,8 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -27848,8 +27848,8 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/12</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/12</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/12</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/12</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">7/12</td>
@@ -27930,8 +27930,8 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -28012,8 +28012,8 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -28095,8 +28095,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -28173,8 +28173,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -28260,8 +28260,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -28340,8 +28340,8 @@ return m.get(f) === 42;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -28424,8 +28424,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -28503,8 +28503,8 @@ return weakmap.set(key, 0) === weakmap;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -28580,8 +28580,8 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -28664,8 +28664,8 @@ return m.has(key);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -28744,8 +28744,8 @@ return m.has(1) === false
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -28828,8 +28828,8 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -28902,8 +28902,8 @@ catch(e) {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/11</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/11</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/11</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/11</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0" data-flagged-tally="0.36363636363636365">0/11</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0" data-flagged-tally="0.36363636363636365">0/11</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/11</td>
@@ -28985,8 +28985,8 @@ return weakset.has(obj1);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29065,8 +29065,8 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29148,8 +29148,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29226,8 +29226,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29313,8 +29313,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29397,8 +29397,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29476,8 +29476,8 @@ return weakset.add(obj) === weakset;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29553,8 +29553,8 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29637,8 +29637,8 @@ return s.has(key);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29716,8 +29716,8 @@ return s.has(1) === false
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29800,8 +29800,8 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -29874,8 +29874,8 @@ catch(e) {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0.029411764705882353" style="background-color:hsl(3,84%,50%)">1/34</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0.029411764705882353" style="background-color:hsl(3,84%,50%)">1/34</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.3235294117647059" style="background-color:hsl(38,71%,50%)">11/34</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.3235294117647059" style="background-color:hsl(38,71%,50%)">11/34</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.3235294117647059" style="background-color:hsl(38,71%,50%)">11/34</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.3235294117647059" style="background-color:hsl(38,71%,50%)">11/34</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.4411764705882353" style="background-color:hsl(52,66%,50%)">15/34</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/34</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/34</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/34</td>
@@ -29957,8 +29957,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30035,8 +30035,8 @@ return !Proxy.hasOwnProperty(&apos;prototype&apos;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30118,8 +30118,8 @@ return proxy.foo === 5;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30201,8 +30201,8 @@ return proxy.foo === 5;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30305,8 +30305,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30390,8 +30390,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30475,8 +30475,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30579,8 +30579,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30663,8 +30663,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30747,8 +30747,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30848,8 +30848,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -30932,8 +30932,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31024,8 +31024,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31114,8 +31114,8 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31241,8 +31241,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31330,8 +31330,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31435,8 +31435,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31519,8 +31519,8 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31609,8 +31609,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31698,8 +31698,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31790,8 +31790,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31876,8 +31876,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -31974,8 +31974,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32061,8 +32061,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32151,8 +32151,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32237,8 +32237,8 @@ return passed;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32344,8 +32344,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32431,8 +32431,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32521,8 +32521,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32606,8 +32606,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32706,8 +32706,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32791,8 +32791,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32868,8 +32868,8 @@ return Array.isArray(new Proxy([], {}));
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -32945,8 +32945,8 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33019,8 +33019,8 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0.3" style="background-color:hsl(36,72%,50%)">6/20</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0.3" style="background-color:hsl(36,72%,50%)">6/20</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/20</td>
@@ -33096,8 +33096,8 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33175,8 +33175,8 @@ return obj.quux === 654;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33252,8 +33252,8 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33331,8 +33331,8 @@ return !(&quot;bar&quot; in obj);
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33411,8 +33411,8 @@ return desc.value === 789 &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33491,8 +33491,8 @@ return obj.foo === 123 &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33568,8 +33568,8 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33647,8 +33647,8 @@ return obj instanceof Array;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33725,8 +33725,8 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33804,8 +33804,8 @@ return !Object.isExtensible(obj);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33885,8 +33885,8 @@ return Reflect.ownKeys(obj).sort() + &apos;&apos; === &quot;A,B&quot;;
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -33970,8 +33970,8 @@ return keys.indexOf(s2) &gt;-1 &amp;&amp; keys.indexOf(s3) &gt;-1 &amp;&amp; key
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34047,8 +34047,8 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34126,8 +34126,8 @@ return Reflect.construct(function(a, b, c) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34207,8 +34207,8 @@ return Reflect.construct(function(a, b, c) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34286,8 +34286,8 @@ return obj.y === 1 &amp;&amp; obj instanceof F;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34366,8 +34366,8 @@ return obj.length === 3 &amp;&amp; obj instanceof F;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34446,8 +34446,8 @@ return RegExp.prototype.exec.call(obj, &quot;foobarbaz&quot;)[0] === &quot;baz&q
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34525,8 +34525,8 @@ return obj() === 2 &amp;&amp; obj instanceof F;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34621,8 +34621,8 @@ function check() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34695,8 +34695,8 @@ function check() {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/8</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
@@ -34793,8 +34793,8 @@ function check() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -34876,8 +34876,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -34958,8 +34958,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -35049,8 +35049,8 @@ function check() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -35140,8 +35140,8 @@ function check() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -35231,8 +35231,8 @@ function check() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -35322,8 +35322,8 @@ function check() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -35400,8 +35400,8 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -35474,8 +35474,8 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/12</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">12/12</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">12/12</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">12/12</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0" data-flagged-tally="0.5">0/12</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0" data-flagged-tally="0.5">0/12</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/12</td>
@@ -35555,8 +35555,8 @@ return object[symbol] === value;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -35632,8 +35632,8 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -35721,8 +35721,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -35807,8 +35807,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -35889,8 +35889,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -35979,8 +35979,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36056,8 +36056,8 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36138,8 +36138,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36222,8 +36222,8 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36302,8 +36302,8 @@ return JSON.stringify(object) === &apos;{}&apos; &amp;&amp; JSON.stringify(array
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36392,8 +36392,8 @@ return testSymbolObject(objSym) &amp;&amp; testSymbolObject(symNoToJSON);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36471,8 +36471,8 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36545,8 +36545,8 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/26</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/26</td>
@@ -36629,8 +36629,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36709,8 +36709,8 @@ return a[0] === b;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36786,8 +36786,8 @@ return &quot;iterator&quot; in Symbol;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36866,8 +36866,8 @@ return (function() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -36943,8 +36943,8 @@ return &quot;species&quot; in Symbol;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37025,8 +37025,8 @@ return Array.prototype.concat.call(obj, []).foo === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37107,8 +37107,8 @@ return Array.prototype.filter.call(obj, Boolean).foo === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37189,8 +37189,8 @@ return Array.prototype.map.call(obj, Boolean).foo === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37271,8 +37271,8 @@ return Array.prototype.slice.call(obj, 0).foo === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37353,8 +37353,8 @@ return Array.prototype.splice.call(obj, 0).foo === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37438,8 +37438,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37519,8 +37519,8 @@ return promise.then(function(){}) instanceof FakePromise2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37600,8 +37600,8 @@ return &apos;&apos;.replace(O) === 42;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37681,8 +37681,8 @@ return &apos;&apos;.search(O) === 42;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37762,8 +37762,8 @@ return &apos;&apos;.split(O) === 42;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37843,8 +37843,8 @@ return &apos;&apos;.match(O) === 42;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -37924,8 +37924,8 @@ return RegExp(re) !== re &amp;&amp; RegExp(foo) === foo;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38007,8 +38007,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38090,8 +38090,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38173,8 +38173,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38259,8 +38259,8 @@ return passed === 3;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38338,8 +38338,8 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38432,8 +38432,8 @@ return passed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38533,8 +38533,8 @@ passed = passed
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38612,8 +38612,8 @@ return Math[s] === &quot;Math&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38693,8 +38693,8 @@ with (a) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38769,8 +38769,8 @@ with (a) {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">4/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">4/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -38847,8 +38847,8 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -38926,8 +38926,8 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -39011,8 +39011,8 @@ return result[0] === sym
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -39088,8 +39088,8 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -39162,8 +39162,8 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/17</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.4117647058823529" style="background-color:hsl(49,67%,50%)">7/17</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.4117647058823529" style="background-color:hsl(49,67%,50%)">7/17</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.4117647058823529" style="background-color:hsl(49,67%,50%)">7/17</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.4117647058823529" style="background-color:hsl(49,67%,50%)">7/17</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.4117647058823529" style="background-color:hsl(49,67%,50%)">7/17</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.11764705882352941" style="background-color:hsl(14,80%,50%)">2/17</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.11764705882352941" style="background-color:hsl(14,80%,50%)">2/17</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
@@ -39241,8 +39241,8 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -39319,8 +39319,8 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -39396,8 +39396,8 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -39475,8 +39475,8 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -39554,8 +39554,8 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -39635,8 +39635,8 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -39715,8 +39715,8 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -39793,8 +39793,8 @@ return o.foo.name === &quot;foo&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -39871,8 +39871,8 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -39956,8 +39956,8 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40036,8 +40036,8 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40114,8 +40114,8 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40196,8 +40196,8 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40277,8 +40277,8 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40355,8 +40355,8 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40433,8 +40433,8 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40513,8 +40513,8 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40587,8 +40587,8 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -40664,8 +40664,8 @@ return typeof String.raw === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40741,8 +40741,8 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40815,8 +40815,8 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/10</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0" data-flagged-tally="0.3">0/10</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0" data-flagged-tally="0.3">0/10</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/10</td>
@@ -40892,8 +40892,8 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -40971,8 +40971,8 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41049,8 +41049,8 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41127,8 +41127,8 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41208,8 +41208,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41286,8 +41286,8 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41367,8 +41367,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41445,8 +41445,8 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No<a href="#string-contains-note"><sup>[0]</sup></a></td>
 <td class="no obsolete" data-browser="android4_4_3">No<a href="#string-contains-note"><sup>[0]</sup></a></td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41522,8 +41522,8 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41609,8 +41609,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41683,8 +41683,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/6</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/6</td>
@@ -41760,8 +41760,8 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41837,8 +41837,8 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41914,8 +41914,8 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -41991,8 +41991,8 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42068,8 +42068,8 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42146,8 +42146,8 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42220,8 +42220,8 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/11</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/11</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/11</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/11</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/11</td>
@@ -42297,8 +42297,8 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42375,8 +42375,8 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42453,8 +42453,8 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42531,8 +42531,8 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42610,8 +42610,8 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, functio
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42690,8 +42690,8 @@ return Array.from(iterable, function(e, i) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42770,8 +42770,8 @@ return Array.from(iterable, function(e, i) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42850,8 +42850,8 @@ return Array.from(Object.create(iterable), function(e, i) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -42934,8 +42934,8 @@ return closed;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -43012,8 +43012,8 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -43090,8 +43090,8 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -43164,8 +43164,8 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/10</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/10</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/10</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/10</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0" data-flagged-tally="0.5">0/10</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0" data-flagged-tally="0.5">0/10</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
@@ -43241,8 +43241,8 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -43318,8 +43318,8 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -43395,8 +43395,8 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -43472,8 +43472,8 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -43549,8 +43549,8 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -43626,8 +43626,8 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -43703,8 +43703,8 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -43780,8 +43780,8 @@ return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -43867,8 +43867,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -43952,8 +43952,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44026,8 +44026,8 @@ return true;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/9</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/9</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/9</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/9</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/9</td>
@@ -44103,8 +44103,8 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44180,8 +44180,8 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44257,8 +44257,8 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44334,8 +44334,8 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44413,8 +44413,8 @@ return typeof Number.parseFloat === &apos;function&apos;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44492,8 +44492,8 @@ return typeof Number.parseInt === &apos;function&apos;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44569,8 +44569,8 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44646,8 +44646,8 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44723,8 +44723,8 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44797,8 +44797,8 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/17</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)">8/17</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)" data-flagged-tally="0.17647058823529413">1/17</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.8823529411764706" style="background-color:hsl(105,47%,50%)">15/17</td>
@@ -44874,8 +44874,8 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -44951,8 +44951,8 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45028,8 +45028,8 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -45105,8 +45105,8 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45182,8 +45182,8 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45259,8 +45259,8 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45336,8 +45336,8 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45413,8 +45413,8 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45490,8 +45490,8 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45567,8 +45567,8 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45644,8 +45644,8 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45721,8 +45721,8 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45798,8 +45798,8 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45875,8 +45875,8 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -45952,8 +45952,8 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -46029,8 +46029,8 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -46109,8 +46109,8 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -46189,8 +46189,8 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -46265,8 +46265,8 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/11</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/11</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/11</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/11</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/11</td>
@@ -46347,8 +46347,8 @@ return len1 === 0 &amp;&amp; len2 === 3;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -46428,8 +46428,8 @@ return c.length === 1 &amp;&amp; !(2 in c);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -46507,8 +46507,8 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -46585,8 +46585,8 @@ return Array.isArray(new C());
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -46664,8 +46664,8 @@ return c.concat(1) instanceof C;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -46743,8 +46743,8 @@ return c.filter(Boolean) instanceof C;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -46822,8 +46822,8 @@ return c.map(Boolean) instanceof C;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -46902,8 +46902,8 @@ return c.slice(1,2) instanceof C;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -46982,8 +46982,8 @@ return c.splice(1,2) instanceof C;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47060,8 +47060,8 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47138,8 +47138,8 @@ return C.of(0) instanceof C;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47212,8 +47212,8 @@ return C.of(0) instanceof C;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -47291,8 +47291,8 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47370,8 +47370,8 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47449,8 +47449,8 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47528,8 +47528,8 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47602,8 +47602,8 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/6</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/6</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/6</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/6</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/6</td>
@@ -47681,8 +47681,8 @@ return c() === &apos;foo&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47760,8 +47760,8 @@ return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getProt
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47840,8 +47840,8 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47919,8 +47919,8 @@ return c.call({bar:1}, 2) === 3;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -47998,8 +47998,8 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48077,8 +48077,8 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48151,8 +48151,8 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -48250,8 +48250,8 @@ function check() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48329,8 +48329,8 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48421,8 +48421,8 @@ function check() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48513,8 +48513,8 @@ function check() {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48587,8 +48587,8 @@ function check() {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/6</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/6</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/6</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/6</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/6</td>
@@ -48668,8 +48668,8 @@ return c instanceof Boolean
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48749,8 +48749,8 @@ return c instanceof Number
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48832,8 +48832,8 @@ return c instanceof String
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48913,8 +48913,8 @@ return c instanceof Error
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -48996,8 +48996,8 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -49080,8 +49080,8 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -49156,8 +49156,8 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/5</td>
@@ -49246,8 +49246,8 @@ return correctProtoBound(Function.prototype)
 <td class="yes obsolete" data-browser="duktape1_7">Yes</td>
 <td class="yes" data-browser="duktape1_8">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -49336,8 +49336,8 @@ return correctProtoBound(Function.prototype)
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -49426,8 +49426,8 @@ return correctProtoBound(Function.prototype)
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -49516,8 +49516,8 @@ return correctProtoBound(Function.prototype)
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -49604,8 +49604,8 @@ return correctProtoBound(function(){})
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -49678,8 +49678,8 @@ return correctProtoBound(function(){})
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/36</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.19444444444444445" style="background-color:hsl(23,77%,50%)">7/36</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.19444444444444445" style="background-color:hsl(23,77%,50%)">7/36</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.19444444444444445" style="background-color:hsl(23,77%,50%)">7/36</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.19444444444444445" style="background-color:hsl(23,77%,50%)">7/36</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">8/36</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/36</td>
@@ -49759,8 +49759,8 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -49840,8 +49840,8 @@ return get + &apos;&apos; === &quot;length,0,1&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -49922,8 +49922,8 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50006,8 +50006,8 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50087,8 +50087,8 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50168,8 +50168,8 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50260,8 +50260,8 @@ return get + &apos;&apos; === &quot;done,value,done,value&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50349,8 +50349,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50430,8 +50430,8 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50511,8 +50511,8 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50592,8 +50592,8 @@ return get + &apos;&apos; === &quot;length,name&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50673,8 +50673,8 @@ return get + &apos;&apos; === &quot;name,message&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50755,8 +50755,8 @@ return get + &apos;&apos; === &quot;raw,length,0,1&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50838,8 +50838,8 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -50919,8 +50919,8 @@ return get + &apos;&apos; === &quot;global,ignoreCase,multiline,unicode,sticky&q
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51000,8 +51000,8 @@ return get + &apos;&apos; === &quot;exec&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51081,8 +51081,8 @@ return get + &apos;&apos; === &quot;source,flags&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51164,8 +51164,8 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51247,8 +51247,8 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51328,8 +51328,8 @@ return get + &apos;&apos; === &quot;lastIndex,exec,lastIndex&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51411,8 +51411,8 @@ return get + &apos;&apos; === &quot;constructor,flags,exec&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51492,8 +51492,8 @@ return get[0] === Symbol.iterator &amp;&amp; get.slice(1) + &apos;&apos; === &qu
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51580,8 +51580,8 @@ return get[0] === &quot;constructor&quot;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51674,8 +51674,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51755,8 +51755,8 @@ return get + &apos;&apos; === &quot;length,3&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51836,8 +51836,8 @@ return get + &apos;&apos; === &quot;length,0,4,2&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51917,8 +51917,8 @@ return get + &apos;&apos; === &quot;length,0,1,2,3&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -51999,8 +51999,8 @@ return get + &apos;&apos; === &quot;length,constructor,1,2,3,length,constructor,
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52080,8 +52080,8 @@ return get + &apos;&apos; === &quot;join&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52161,8 +52161,8 @@ return get + &apos;&apos; === &quot;toJSON&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52242,8 +52242,8 @@ return get + &apos;&apos; === &quot;then&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52325,8 +52325,8 @@ return get[0] === Symbol.match &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52408,8 +52408,8 @@ return get[0] === Symbol.replace &amp;&amp; get[1] === Symbol.toPrimitive &amp;&
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52491,8 +52491,8 @@ return get[0] === Symbol.search &amp;&amp; get[1] === Symbol.toPrimitive &amp;&a
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52574,8 +52574,8 @@ return get[0] === Symbol.split &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52656,8 +52656,8 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52730,8 +52730,8 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/11</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/11</td>
@@ -52811,8 +52811,8 @@ return set + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52892,8 +52892,8 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -52973,8 +52973,8 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53054,8 +53054,8 @@ return set + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53135,8 +53135,8 @@ return set + &apos;&apos; === &quot;3,4,5&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53216,8 +53216,8 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53297,8 +53297,8 @@ return set + &apos;&apos; === &quot;0,1,2,length&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53378,8 +53378,8 @@ return set + &apos;&apos; === &quot;3,1,2&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53459,8 +53459,8 @@ return set + &apos;&apos; === &quot;0,2,length&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53540,8 +53540,8 @@ return set + &apos;&apos; === &quot;3,2,1,length&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53621,8 +53621,8 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53695,8 +53695,8 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -53776,8 +53776,8 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53857,8 +53857,8 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -53931,8 +53931,8 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/6</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/6</td>
@@ -54012,8 +54012,8 @@ return del + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54093,8 +54093,8 @@ return del + &apos;&apos; === &quot;2&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54174,8 +54174,8 @@ return del + &apos;&apos; === &quot;0,4,2&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54255,8 +54255,8 @@ return del + &apos;&apos; === &quot;0,2,5&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54336,8 +54336,8 @@ return del + &apos;&apos; === &quot;3,5&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54417,8 +54417,8 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54491,8 +54491,8 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -54573,8 +54573,8 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54655,8 +54655,8 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54737,8 +54737,8 @@ return gopd + &apos;&apos; === &quot;garply&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54819,8 +54819,8 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -54893,8 +54893,8 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/3</td>
@@ -54974,8 +54974,8 @@ return ownKeysCalled === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55055,8 +55055,8 @@ return ownKeysCalled === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55136,8 +55136,8 @@ return ownKeysCalled === 2;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55210,8 +55210,8 @@ return ownKeysCalled === 2;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/10</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">10/10</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">10/10</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">10/10</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">10/10</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/10</td>
@@ -55287,8 +55287,8 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55364,8 +55364,8 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55443,8 +55443,8 @@ return s.length === 2 &amp;&amp;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55520,8 +55520,8 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55597,8 +55597,8 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55674,8 +55674,8 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55751,8 +55751,8 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55828,8 +55828,8 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55905,8 +55905,8 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -55983,8 +55983,8 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -56057,8 +56057,8 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -56166,8 +56166,8 @@ return Object.keys(obj).join(&apos;&apos;) === forInOrder;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -56263,8 +56263,8 @@ return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1A
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -56365,8 +56365,8 @@ return result === &quot;012349 DB-1ACEFGHIJKLMNOPQRST&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -56463,8 +56463,8 @@ return JSON.stringify(obj) ===
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -56548,8 +56548,8 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -56645,8 +56645,8 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -56737,8 +56737,8 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -56811,8 +56811,8 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/3</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/3</td>
@@ -56892,8 +56892,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
-<td class="unknown" data-browser="duktape2_1">?</td>
-<td class="unknown unstable" data-browser="duktape2_2">?</td>
+<td class="unknown obsolete" data-browser="duktape2_1">?</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios8">?</td>
@@ -56970,8 +56970,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
-<td class="unknown" data-browser="duktape2_1">?</td>
-<td class="unknown unstable" data-browser="duktape2_2">?</td>
+<td class="unknown obsolete" data-browser="duktape2_1">?</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios8">?</td>
@@ -57052,8 +57052,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios8">?</td>
@@ -57126,8 +57126,8 @@ try {
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/9</td>
 <td class="tally" data-browser="duktape1_8" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
@@ -57204,8 +57204,8 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -57281,8 +57281,8 @@ do {} while (false) return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -57364,8 +57364,8 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -57446,8 +57446,8 @@ try {
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -57523,8 +57523,8 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -57600,8 +57600,8 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -57677,8 +57677,8 @@ return RegExp.prototype.toString.call({source: &apos;foo&apos;, flags: &apos;bar
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -57767,8 +57767,8 @@ return true;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -57852,8 +57852,8 @@ return false;
 <td class="no obsolete" data-browser="duktape1_7">No</td>
 <td class="no" data-browser="duktape1_8">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -57928,8 +57928,8 @@ return false;
 <td class="tally obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.6666666666666666">2/3</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.6666666666666666">2/3</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.6666666666666666">2/3</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.6666666666666666">2/3</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.6666666666666666">2/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -58019,8 +58019,8 @@ return passed;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -58100,8 +58100,8 @@ return foo() === 2;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -58184,8 +58184,8 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -58258,8 +58258,8 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="tally obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
@@ -58336,8 +58336,8 @@ return { __proto__ : [] } instanceof Array
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -58418,8 +58418,8 @@ catch(e) {
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -58499,8 +58499,8 @@ return !({ [a] : [] } instanceof Array);
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -58580,8 +58580,8 @@ return !({ __proto__ } instanceof Array);
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -58660,8 +58660,8 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -58734,8 +58734,8 @@ return !({ __proto__(){} } instanceof Function);
 <td class="tally obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.16666666666666666">1/6</td>
 <td class="tally not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.16666666666666666">1/6</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">6/6</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">6/6</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">6/6</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">6/6</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">6/6</td>
@@ -58812,8 +58812,8 @@ return (new A()).__proto__ === A.prototype;
 <td class="yes obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -58891,8 +58891,8 @@ return o instanceof Array;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -58970,8 +58970,8 @@ return Object.getPrototypeOf(o) !== p;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -59047,8 +59047,8 @@ return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -59131,8 +59131,8 @@ return (desc
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -59208,8 +59208,8 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -59282,8 +59282,8 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="tally obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">3/3</td>
@@ -59366,8 +59366,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -59450,8 +59450,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -59533,8 +59533,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -59607,8 +59607,8 @@ return true;
 <td class="tally obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -59688,8 +59688,8 @@ return rx.test(&apos;b&apos;);
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -59766,8 +59766,8 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -59840,8 +59840,8 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="tally obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.375">3/8</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.375">3/8</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.375">3/8</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.375">3/8</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.375">3/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">8/8</td>
@@ -59917,8 +59917,8 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -59995,8 +59995,8 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -60072,8 +60072,8 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -60150,8 +60150,8 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -60228,8 +60228,8 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -60306,8 +60306,8 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -60384,8 +60384,8 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -60462,8 +60462,8 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -60542,8 +60542,8 @@ return a === 3;
 <td class="no obsolete not-applicable" data-browser="duktape1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape1_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes unstable not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -179,8 +179,8 @@
 <th class="platform node8 engine obsolete" data-browser="node8"><a href="#node8" class="browser-name"><abbr title="Node.js">Node 8.0-8.2</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node8_3 engine" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
-<th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
-<th class="platform duktape2_2 engine unstable" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
+<th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
+<th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -243,8 +243,8 @@
 <td class="tally obsolete" data-browser="node8" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -306,8 +306,8 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -369,8 +369,8 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -429,8 +429,8 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="node8" data-tally="1">4/4</td>
 <td class="tally" data-browser="node8_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -492,8 +492,8 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -555,8 +555,8 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -618,8 +618,8 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -709,8 +709,8 @@ try {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -769,8 +769,8 @@ try {
 <td class="tally obsolete" data-browser="node8" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/1</td>
@@ -832,8 +832,8 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -892,8 +892,8 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/1</td>
@@ -955,8 +955,8 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1015,8 +1015,8 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8" data-tally="1">5/5</td>
 <td class="tally" data-browser="node8_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/5</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/5</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/5</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/5</td>
@@ -1078,8 +1078,8 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1141,8 +1141,8 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1204,8 +1204,8 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1267,8 +1267,8 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1358,8 +1358,8 @@ try {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1418,8 +1418,8 @@ try {
 <td class="tally obsolete" data-browser="node8" data-tally="1">6/6</td>
 <td class="tally" data-browser="node8_3" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/6</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/6</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/6</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/6</td>
@@ -1481,8 +1481,8 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1544,8 +1544,8 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1607,8 +1607,8 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1698,8 +1698,8 @@ try {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1762,8 +1762,8 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1833,8 +1833,8 @@ try {
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1893,8 +1893,8 @@ try {
 <td class="tally obsolete" data-browser="node8" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
@@ -1956,8 +1956,8 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2016,8 +2016,8 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
@@ -2079,8 +2079,8 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2139,8 +2139,8 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
@@ -2202,8 +2202,8 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2262,8 +2262,8 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
@@ -2325,8 +2325,8 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2385,8 +2385,8 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
@@ -2448,8 +2448,8 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2508,8 +2508,8 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
@@ -2571,8 +2571,8 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2631,8 +2631,8 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="1">1/1</td>
@@ -2694,8 +2694,8 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -176,8 +176,8 @@
 <th class="platform node8 engine obsolete" data-browser="node8"><a href="#node8" class="browser-name"><abbr title="Node.js">Node 8.0-8.2</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform node8_3 engine" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
-<th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
-<th class="platform duktape2_2 engine unstable" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
+<th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
+<th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -242,8 +242,8 @@
 <td class="tally obsolete" data-browser="node8" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -306,8 +306,8 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no flagged obsolete" data-browser="node8">Flag</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -371,8 +371,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no flagged obsolete" data-browser="node8">Flag</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -431,8 +431,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -496,8 +496,8 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -566,8 +566,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -626,8 +626,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -696,8 +696,8 @@ iterator.next().then(function(step){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -776,8 +776,8 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -846,8 +846,8 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -910,8 +910,8 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="unknown obsolete" data-browser="node8">?</td>
 <td class="unknown" data-browser="node8_3">?</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
-<td class="unknown" data-browser="duktape2_1">?</td>
-<td class="unknown unstable" data-browser="duktape2_2">?</td>
+<td class="unknown obsolete" data-browser="duktape2_1">?</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -974,8 +974,8 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1038,8 +1038,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1098,8 +1098,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/3</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/3</td>
@@ -1165,8 +1165,8 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1237,8 +1237,8 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1306,8 +1306,8 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1366,8 +1366,8 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="node8" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="node8_3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)" data-flagged-tally="1">4/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
@@ -1431,8 +1431,8 @@ return fn + &apos;&apos; === str;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1495,8 +1495,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1559,8 +1559,8 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -1623,8 +1623,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1687,8 +1687,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1751,8 +1751,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1815,8 +1815,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no flagged" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1875,8 +1875,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/3</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/3</td>
@@ -1964,8 +1964,8 @@ function check() {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2045,8 +2045,8 @@ function check() {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2128,8 +2128,8 @@ function check() {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2188,8 +2188,8 @@ function check() {
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/3</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/3</td>
@@ -2257,8 +2257,8 @@ return false;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2327,8 +2327,8 @@ return false;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2402,8 +2402,8 @@ return it.next().value;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2473,8 +2473,8 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2533,8 +2533,8 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/1</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/1</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/1</td>
@@ -2604,8 +2604,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2664,8 +2664,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="node8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="node8_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -2727,8 +2727,8 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2790,8 +2790,8 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes" data-browser="node8_3">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2853,8 +2853,8 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2916,8 +2916,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2989,8 +2989,8 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3049,8 +3049,8 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/2</td>
@@ -3112,8 +3112,8 @@ return [1, [2, 3], [4, [5, 6]]].flatten().join(&apos;&apos;) === &apos;12345,6&a
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3177,8 +3177,8 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3237,8 +3237,8 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/4</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -3306,8 +3306,8 @@ try {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3379,8 +3379,8 @@ try {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3447,8 +3447,8 @@ try {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3515,8 +3515,8 @@ try {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3583,8 +3583,8 @@ return do {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3643,8 +3643,8 @@ return do {
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/57</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/57</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/57</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/57</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/57</td>
@@ -3714,8 +3714,8 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3777,8 +3777,8 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3840,8 +3840,8 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3903,8 +3903,8 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3966,8 +3966,8 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4029,8 +4029,8 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4092,8 +4092,8 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4155,8 +4155,8 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4218,8 +4218,8 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4281,8 +4281,8 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4344,8 +4344,8 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4409,8 +4409,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4474,8 +4474,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4539,8 +4539,8 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4604,8 +4604,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4669,8 +4669,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4734,8 +4734,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4799,8 +4799,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4864,8 +4864,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4929,8 +4929,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -4994,8 +4994,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5059,8 +5059,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5124,8 +5124,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5189,8 +5189,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5254,8 +5254,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5319,8 +5319,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5384,8 +5384,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5449,8 +5449,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5514,8 +5514,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5579,8 +5579,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5644,8 +5644,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5709,8 +5709,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5774,8 +5774,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5839,8 +5839,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5904,8 +5904,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -5969,8 +5969,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6034,8 +6034,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6099,8 +6099,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6164,8 +6164,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6229,8 +6229,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6294,8 +6294,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6359,8 +6359,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6424,8 +6424,8 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6489,8 +6489,8 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6554,8 +6554,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6619,8 +6619,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6684,8 +6684,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6749,8 +6749,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6814,8 +6814,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6879,8 +6879,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -6944,8 +6944,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7009,8 +7009,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7074,8 +7074,8 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7139,8 +7139,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7204,8 +7204,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7269,8 +7269,8 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7332,8 +7332,8 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7398,8 +7398,8 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7458,8 +7458,8 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/8</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/8</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/8</td>
@@ -7521,8 +7521,8 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7584,8 +7584,8 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7647,8 +7647,8 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7720,8 +7720,8 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7784,8 +7784,8 @@ return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7848,8 +7848,8 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7911,8 +7911,8 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -7974,8 +7974,8 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8041,8 +8041,8 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8105,8 +8105,8 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8171,8 +8171,8 @@ return Math.signbit(-0) === false
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8231,8 +8231,8 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/7</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/7</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/7</td>
@@ -8296,8 +8296,8 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8359,8 +8359,8 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8423,8 +8423,8 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8486,8 +8486,8 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8549,8 +8549,8 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8613,8 +8613,8 @@ return Math.radians(90) === Math.PI / 2
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8676,8 +8676,8 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8736,8 +8736,8 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/7</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/7</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/7</td>
@@ -8799,8 +8799,8 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8862,8 +8862,8 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8927,8 +8927,8 @@ return score === 1;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -8997,8 +8997,8 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9067,8 +9067,8 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9137,8 +9137,8 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9207,8 +9207,8 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9267,8 +9267,8 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="node8" data-tally="0">0/8</td>
 <td class="tally" data-browser="node8_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/8</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/8</td>
@@ -9333,8 +9333,8 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9401,8 +9401,8 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9467,8 +9467,8 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9533,8 +9533,8 @@ return C.has(3) + C.has(4);
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9599,8 +9599,8 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9667,8 +9667,8 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9733,8 +9733,8 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9799,8 +9799,8 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9874,8 +9874,8 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -9941,8 +9941,8 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -10003,8 +10003,8 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -10068,8 +10068,8 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10132,8 +10132,8 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10195,8 +10195,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10255,8 +10255,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -10319,8 +10319,8 @@ return f();
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10382,8 +10382,8 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10450,8 +10450,8 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10524,8 +10524,8 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10594,8 +10594,8 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10654,8 +10654,8 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -10719,8 +10719,8 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10784,8 +10784,8 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10844,8 +10844,8 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -10907,8 +10907,8 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10970,8 +10970,8 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11033,8 +11033,8 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11096,8 +11096,8 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11159,8 +11159,8 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11222,8 +11222,8 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11285,8 +11285,8 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11351,8 +11351,8 @@ passed = true;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11411,8 +11411,8 @@ passed = true;
 <td class="tally obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -11480,8 +11480,8 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11556,8 +11556,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11618,8 +11618,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -11681,8 +11681,8 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11744,8 +11744,8 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11807,8 +11807,8 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11870,8 +11870,8 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11933,8 +11933,8 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11996,8 +11996,8 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12059,8 +12059,8 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12122,8 +12122,8 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12185,8 +12185,8 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -164,8 +164,8 @@
 <th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 2.0">PJS</abbr></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
-<th class="platform duktape2_1 engine" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
-<th class="platform duktape2_2 engine unstable" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
+<th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
+<th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios8 mobile obsolete" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS 8</abbr></a></th>
@@ -224,8 +224,8 @@
 <td class="tally" data-browser="besen" data-tally="0.25">1/4</td>
 <td class="tally" data-browser="phantom" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
@@ -283,8 +283,8 @@ return typeof uneval == &apos;function&apos;;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -350,8 +350,8 @@ return &apos;toSource&apos; in Object.prototype
 <td class="yes" data-browser="besen">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -409,8 +409,8 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -557,8 +557,8 @@ return true;
 <td class="unknown" data-browser="besen">?</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -617,8 +617,8 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -680,8 +680,8 @@ return 'caller' in function(){};
 <td class="no" data-browser="besen">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -745,8 +745,8 @@ return (function () {}).arity === 0 &&
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -812,8 +812,8 @@ return f(1, 'boo');
 <td class="no" data-browser="besen">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -873,8 +873,8 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -935,8 +935,8 @@ return new C instanceof C;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -998,8 +998,8 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1059,8 +1059,8 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1130,8 +1130,8 @@ return executed;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1191,8 +1191,8 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1252,8 +1252,8 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1315,8 +1315,8 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1374,8 +1374,8 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1433,8 +1433,8 @@ return (function(x)x)(1) === 1;
 <td class="yes" data-browser="besen">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1492,8 +1492,8 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1555,8 +1555,8 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1615,8 +1615,8 @@ return arr[1] === arr;
 <td class="unknown" data-browser="besen">?</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1708,8 +1708,8 @@ catch(e) {
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1807,8 +1807,8 @@ catch(e) {
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1905,8 +1905,8 @@ global.test((function () {
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -1966,8 +1966,8 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2032,8 +2032,8 @@ return passed;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2109,8 +2109,8 @@ try {
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2174,8 +2174,8 @@ return RegExp.lastMatch === 'x';
 <td class="no" data-browser="besen">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2241,8 +2241,8 @@ return true;
 <td class="no" data-browser="besen">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2300,8 +2300,8 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2360,8 +2360,8 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="unknown" data-browser="besen">?</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2419,8 +2419,8 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="unknown" data-browser="besen">?</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2476,8 +2476,8 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2535,8 +2535,8 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2602,8 +2602,8 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2661,8 +2661,8 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2718,8 +2718,8 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2775,8 +2775,8 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="yes" data-browser="besen">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2834,8 +2834,8 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -2905,8 +2905,8 @@ try {
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
@@ -2966,8 +2966,8 @@ return 'lineNumber' in new Error();
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3027,8 +3027,8 @@ return 'columnNumber' in new Error();
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3088,8 +3088,8 @@ return 'fileName' in new Error();
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
-<td class="yes" data-browser="duktape2_1">Yes</td>
-<td class="yes unstable" data-browser="duktape2_2">Yes</td>
+<td class="yes obsolete" data-browser="duktape2_1">Yes</td>
+<td class="yes" data-browser="duktape2_2">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>
@@ -3149,8 +3149,8 @@ return 'description' in new Error();
 <td class="no" data-browser="besen">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
-<td class="no" data-browser="duktape2_1">No</td>
-<td class="no unstable" data-browser="duktape2_2">No</td>
+<td class="no obsolete" data-browser="duktape2_1">No</td>
+<td class="no" data-browser="duktape2_2">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios8">No</td>


### PR DESCRIPTION
- Add Duktape 2.2 engine.
- Update results for Duktape 2.2.0 release.
- Change `duktape2_0: false` to `duktape_1.0: false` now that Duktape 1.x engine versions have been added; previously results started from Duktape 2.0.0.
- Remove a few redundancies, e.g. the 2.0 line for `duktape1_3: true` and  `duktape_2.0: true`.