### PR TITLE
Fix "unknown" results in esnext Stage0 with green background

### DIFF
--- a/master.css
+++ b/master.css
@@ -249,7 +249,7 @@ td:first-child, td:not([class]) {
 .not-applicable.no, .not-applicable[data-tally="0"] {
     background: hsl(  0,  14%,  67%); background: #b69f9f;
 }
-.not-applicable {
+.not-applicable.yes {
     background: hsl(120,  14%,  67%); background: #9fb79f;
 }
 


### PR DESCRIPTION
This fixes a css problem that was painting green all non-false results with "not-applicable" class.  This was affecting "unknown" results, which should not be green.  There are no such results currently, but they will appear if #1131 gets merged.