### PR TITLE
Hide ie10 from "es2016plus" tab and ie11 from "esnext" tab

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -480,7 +480,6 @@
     "test_suites": [
       "es5",
       "es6",
-      "es2016plus",
       "esintl",
       "non-standard"
     ]
@@ -490,7 +489,14 @@
     "family": "Chakra",
     "short": "IE 11",
     "release": "2013-10-17",
-    "obsolete": false
+    "obsolete": false,
+    "test_suites": [
+      "es5",
+      "es6",
+      "es2016plus",
+      "esintl",
+      "non-standard"
+    ]
   },
   "edge12": {
     "full": "Microsoft Edge 12",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -144,7 +144,6 @@
 <th class="platform typescript3 compiler obsolete" data-browser="typescript3"><a href="#typescript3" class="browser-name"><abbr title="TypeScript 3.0 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript3.1 compiler" data-browser="typescript3.1"><a href="#typescript3.1" class="browser-name"><abbr title="TypeScript 3.1 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
-<th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer 10">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer 11">IE 11</abbr></a></th>
 <th class="platform edge15 desktop obsolete" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge 15">Edge 15</abbr></a></th>
 <th class="platform edge16 desktop obsolete" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge 16">Edge 16</abbr></a></th>
@@ -209,7 +208,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="83">2016 features</td>
+      <tr class="category"><td colspan="82">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -232,7 +231,6 @@
 <td class="tally obsolete" data-browser="typescript3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="1">3/3</td>
@@ -317,7 +315,6 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -402,7 +399,6 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -492,7 +488,6 @@ return true;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -574,7 +569,6 @@ return true;
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">3/3</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="1">3/3</td>
@@ -663,7 +657,6 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -770,7 +763,6 @@ return 24;
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -860,7 +852,6 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -921,7 +912,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="83">2016 misc</td>
+<tr class="category"><td colspan="82">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -954,7 +945,6 @@ return true;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1052,7 +1042,6 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1142,7 +1131,6 @@ return true;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1228,7 +1216,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1315,7 +1302,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1407,7 +1393,6 @@ return passed;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1501,7 +1486,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1562,7 +1546,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="83">2017 features</td>
+<tr class="category"><td colspan="82">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1585,7 +1569,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">4/4</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">4/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="1">4/4</td>
@@ -1673,7 +1656,6 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1765,7 +1747,6 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1858,7 +1839,6 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -1946,7 +1926,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -2028,7 +2007,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">2/2</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="1">2/2</td>
@@ -2118,7 +2096,6 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -2208,7 +2185,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -2290,7 +2266,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">2/2</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="1">2/2</td>
@@ -2375,7 +2350,6 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -2460,7 +2434,6 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -2542,7 +2515,6 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="typescript3" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="1">15/15</td>
@@ -2638,7 +2610,6 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -2734,7 +2705,6 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -2820,7 +2790,6 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown obsolete" data-browser="typescript3">?</td>
 <td class="unknown" data-browser="typescript3.1">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -2906,7 +2875,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -2998,7 +2966,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3092,7 +3059,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3178,7 +3144,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="typescript3">?</td>
 <td class="unknown" data-browser="typescript3.1">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3269,7 +3234,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3355,7 +3319,6 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown obsolete" data-browser="typescript3">?</td>
 <td class="unknown" data-browser="typescript3.1">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3451,7 +3414,6 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3547,7 +3509,6 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3641,7 +3602,6 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3728,7 +3688,6 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3813,7 +3772,6 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3907,7 +3865,6 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -3989,7 +3946,6 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/17</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/17</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0" data-flagged-tally="1">0/17</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="1">17/17</td>
@@ -4074,7 +4030,6 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4159,7 +4114,6 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4244,7 +4198,6 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4329,7 +4282,6 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4414,7 +4366,6 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4499,7 +4450,6 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4584,7 +4534,6 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4669,7 +4618,6 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4754,7 +4702,6 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4839,7 +4786,6 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -4924,7 +4870,6 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5009,7 +4954,6 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5094,7 +5038,6 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5179,7 +5122,6 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5264,7 +5206,6 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5349,7 +5290,6 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5434,7 +5374,6 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5495,7 +5434,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
 </tr>
-<tr class="category"><td colspan="83">2017 misc</td>
+<tr class="category"><td colspan="82">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[22]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -5526,7 +5465,6 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5614,7 +5552,6 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -5702,7 +5639,6 @@ return (function(){
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5763,7 +5699,7 @@ return (function(){
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="83">2017 annex b</td>
+<tr class="category"><td colspan="82">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -5786,7 +5722,6 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
@@ -5876,7 +5811,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -5967,7 +5901,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6058,7 +5991,6 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6148,7 +6080,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6239,7 +6170,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6330,7 +6260,6 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6422,7 +6351,6 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6514,7 +6442,6 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6607,7 +6534,6 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6697,7 +6623,6 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6786,7 +6711,6 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -6878,7 +6802,6 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -6970,7 +6893,6 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -7063,7 +6985,6 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -7153,7 +7074,6 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -7242,7 +7162,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -7324,7 +7243,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="1">4/4</td>
@@ -7413,7 +7331,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -7502,7 +7419,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -7596,7 +7512,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -7690,7 +7605,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
@@ -7776,8 +7690,7 @@ return i === 0;
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes</td>
-<td class="yes" data-browser="ie11">Yes</td>
+<td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -7837,7 +7750,7 @@ return i === 0;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="83">2018 features</td>
+<tr class="category"><td colspan="82">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -7860,7 +7773,6 @@ return i === 0;
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">2/2</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/2</td>
@@ -7946,7 +7858,6 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -8033,7 +7944,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -8115,7 +8025,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">3/3</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/3</td>
@@ -8226,7 +8135,6 @@ function check() {
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -8329,7 +8237,6 @@ function check() {
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -8434,7 +8341,6 @@ function check() {
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -8520,7 +8426,6 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="unknown obsolete" data-browser="typescript3">?</td>
 <td class="unknown" data-browser="typescript3.1">?</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -8612,7 +8517,6 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -8698,7 +8602,6 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -8784,7 +8687,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -8866,7 +8768,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">2/2</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/2</td>
@@ -8958,7 +8859,6 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -9060,7 +8960,6 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -9121,7 +9020,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="ios11_3">No</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="83">2018 misc</td>
+<tr class="category"><td colspan="82">2018 misc</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -9154,7 +9053,6 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -9215,7 +9113,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="83">2019 misc</td>
+<tr class="category"><td colspan="82">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://tc39.github.io/proposal-optional-catch-binding/">optional catch binding</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
@@ -9238,7 +9136,6 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">3/3</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/3</td>
@@ -9329,7 +9226,6 @@ return false;
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -9421,7 +9317,6 @@ return false;
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
@@ -9518,7 +9413,6 @@ return it.next().value;
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -149,7 +149,6 @@
 <th class="platform typescript2_9 compiler obsolete" data-browser="typescript2_9"><a href="#typescript2_9" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript3 compiler obsolete" data-browser="typescript3"><a href="#typescript3" class="browser-name"><abbr title="TypeScript 3.0 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript3.1 compiler" data-browser="typescript3.1"><a href="#typescript3.1" class="browser-name"><abbr title="TypeScript 3.1 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
-<th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer 11">IE 11</abbr></a></th>
 <th class="platform edge15 desktop obsolete" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge 15">Edge 15</abbr></a></th>
 <th class="platform edge16 desktop obsolete" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge 16">Edge 16</abbr></a></th>
 <th class="platform edge17 desktop" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge 17">Edge 17</abbr></a></th>
@@ -213,7 +212,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="81">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="80">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/tc39/proposal-string-left-right-trim">string trimming</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -235,7 +234,6 @@
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">4/4</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">4/4</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge17" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -318,7 +316,6 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -401,7 +398,6 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -484,7 +480,6 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -567,7 +562,6 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -647,7 +641,6 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/2</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/2</td>
@@ -732,7 +725,6 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -821,7 +813,6 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -914,7 +905,6 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -994,7 +984,6 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/3</td>
@@ -1080,7 +1069,6 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="typescript2_9">Yes</td>
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -1172,7 +1160,6 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -1261,7 +1248,6 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -1341,7 +1327,6 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/2</td>
@@ -1427,7 +1412,6 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="typescript2_9">Yes</td>
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -1516,7 +1500,6 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -1596,7 +1579,6 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/7</td>
-<td class="tally" data-browser="ie11" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="edge17" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -1681,7 +1663,6 @@ return fn + &apos;&apos; === str;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -1765,7 +1746,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -1849,7 +1829,6 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -1933,7 +1912,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2017,7 +1995,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2101,7 +2078,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -2185,7 +2161,6 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -2265,7 +2240,6 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/2</td>
@@ -2348,7 +2322,6 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -2433,7 +2406,6 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -2516,7 +2488,6 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -2596,7 +2567,6 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/8</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/8</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/8</td>
@@ -2679,7 +2649,6 @@ return (1n + 2n) === 3n;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -2762,7 +2731,6 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -2845,7 +2813,6 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -2928,7 +2895,6 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3014,7 +2980,6 @@ return view[0] === -0x8000000000000000n;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3100,7 +3065,6 @@ return view[0] === 0n;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3183,7 +3147,6 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3266,7 +3229,6 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3350,7 +3312,6 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3410,7 +3371,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="81">Draft (stage 2)</td>
+<tr class="category"><td colspan="80">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -3441,7 +3402,6 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3521,7 +3481,6 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">1/1</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">1/1</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/1</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/1</td>
@@ -3612,7 +3571,6 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="yes obsolete" data-browser="typescript2_9">Yes</td>
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3698,7 +3656,6 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3785,7 +3742,6 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -3865,7 +3821,6 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/4</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/4</td>
@@ -3954,7 +3909,6 @@ try {
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4047,7 +4001,6 @@ try {
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4135,7 +4088,6 @@ try {
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4223,7 +4175,6 @@ try {
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4307,7 +4258,6 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes obsolete" data-browser="typescript2_9">Yes</td>
 <td class="yes obsolete" data-browser="typescript3">Yes</td>
 <td class="yes" data-browser="typescript3.1">Yes</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4387,7 +4337,6 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/4</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/4</td>
@@ -4473,7 +4422,6 @@ return set.size === 2
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4560,7 +4508,6 @@ return set.size === 3
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4646,7 +4593,6 @@ return set.size === 2
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4732,7 +4678,6 @@ return set.size === 2
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4792,7 +4737,7 @@ return set.size === 2
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="81">Proposal (stage 1)</td>
+<tr class="category"><td colspan="80">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -4820,7 +4765,6 @@ return do {
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -4900,7 +4844,6 @@ return do {
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">7/7</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">7/7</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/7</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/7</td>
@@ -4983,7 +4926,6 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5066,7 +5008,6 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5149,7 +5090,6 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5242,7 +5182,6 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5326,7 +5265,6 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5409,7 +5347,6 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5492,7 +5429,6 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5576,7 +5512,6 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5662,7 +5597,6 @@ return Math.signbit(-0) === false
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5742,7 +5676,6 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">7/7</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">7/7</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/7</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/7</td>
@@ -5827,7 +5760,6 @@ return Math.clamp(2, 4, 6) === 4
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5910,7 +5842,6 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -5994,7 +5925,6 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6077,7 +6007,6 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6160,7 +6089,6 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6244,7 +6172,6 @@ return Math.radians(90) === Math.PI / 2
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6327,7 +6254,6 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6407,7 +6333,6 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">7/7</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">7/7</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/7</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/7</td>
@@ -6490,7 +6415,6 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6573,7 +6497,6 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6658,7 +6581,6 @@ return score === 1;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6748,7 +6670,6 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6838,7 +6759,6 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -6928,7 +6848,6 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7018,7 +6937,6 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7098,7 +7016,6 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="1">8/8</td>
 <td class="tally" data-browser="typescript3.1" data-tally="1">8/8</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/8</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/8</td>
@@ -7184,7 +7101,6 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7272,7 +7188,6 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7358,7 +7273,6 @@ return C.has(A) + C.has(B);
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7444,7 +7358,6 @@ return C.has(3) + C.has(4);
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7530,7 +7443,6 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7618,7 +7530,6 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7704,7 +7615,6 @@ return C.has(A) + C.has(B);
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7790,7 +7700,6 @@ return C.has(A) + C.has(B);
 <td class="yes obsolete" data-browser="typescript2_9">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="typescript3.1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7885,7 +7794,6 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -7972,7 +7880,6 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8052,7 +7959,6 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/3</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/3</td>
@@ -8137,7 +8043,6 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8222,7 +8127,6 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8307,7 +8211,6 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8394,7 +8297,6 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8474,7 +8376,6 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/12</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/12</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/12</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/12</td>
@@ -8561,7 +8462,6 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8648,7 +8548,6 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8735,7 +8634,6 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8822,7 +8720,6 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8909,7 +8806,6 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -8996,7 +8892,6 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9083,7 +8978,6 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9173,7 +9067,6 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9261,7 +9154,6 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9348,7 +9240,6 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9435,7 +9326,6 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9522,7 +9412,6 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9602,7 +9491,6 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/8</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/8</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/8</td>
@@ -9685,7 +9573,6 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9768,7 +9655,6 @@ return Object.isFrozen([# 42 #]);
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9851,7 +9737,6 @@ return Object.isSealed({| foo: 42 |});
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -9934,7 +9819,6 @@ return Object.isSealed([| 42 |]);
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10025,7 +9909,6 @@ try {
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10117,7 +10000,6 @@ try {
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10208,7 +10090,6 @@ try {
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10300,7 +10181,6 @@ try {
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10383,7 +10263,6 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10471,7 +10350,6 @@ return results.length === 3
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10551,7 +10429,6 @@ return results.length === 3
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/2</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/2</td>
@@ -10634,7 +10511,6 @@ return [1, 2, 3].lastItem === 3;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10717,7 +10593,6 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10797,7 +10672,6 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally obsolete" data-browser="typescript2_9" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="typescript3" data-tally="0">0/15</td>
 <td class="tally" data-browser="typescript3.1" data-tally="0">0/15</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge15" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="edge16" data-tally="0">0/15</td>
 <td class="tally" data-browser="edge17" data-tally="0">0/15</td>
@@ -10885,7 +10759,6 @@ return map.size === 2
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -10971,7 +10844,6 @@ return map.size === 2
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11057,7 +10929,6 @@ return map.size === 2
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11144,7 +11015,6 @@ return map.size === 3
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11231,7 +11101,6 @@ return map.size === 3
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11318,7 +11187,6 @@ return map.size === 3
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11405,7 +11273,6 @@ return set.size === 3
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11492,7 +11359,6 @@ return set.deleteAll(2, 3) === true
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11575,7 +11441,6 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11661,7 +11526,6 @@ return set.size === 2
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11744,7 +11608,6 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11827,7 +11690,6 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11914,7 +11776,6 @@ return set.size === 3
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -11997,7 +11858,6 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -12080,7 +11940,6 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="typescript2_9">No</td>
 <td class="no obsolete" data-browser="typescript3">No</td>
 <td class="no" data-browser="typescript3.1">No</td>
-<td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge16">No</td>
 <td class="no" data-browser="edge17">No</td>
@@ -12140,7 +11999,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="81">Strawman (stage 0)</td>
+<tr class="category"><td colspan="80">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12162,7 +12021,6 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="tally obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12247,7 +12105,6 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12331,7 +12188,6 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12414,7 +12270,6 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12494,7 +12349,6 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -12578,7 +12432,6 @@ return f();
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12661,7 +12514,6 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12749,7 +12601,6 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12843,7 +12694,6 @@ return target === C.prototype
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12933,7 +12783,6 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13013,7 +12862,6 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13098,7 +12946,6 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13183,7 +13030,6 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13263,7 +13109,6 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -13346,7 +13191,6 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13429,7 +13273,6 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13512,7 +13355,6 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13595,7 +13437,6 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13678,7 +13519,6 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13761,7 +13601,6 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13844,7 +13683,6 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13924,7 +13762,6 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14013,7 +13850,6 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14109,7 +13945,6 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14189,7 +14024,6 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14274,7 +14108,6 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14360,7 +14193,6 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3.1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14420,7 +14252,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="ios11_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="81">Pre-strawman</td>
+<tr class="category"><td colspan="80">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -14442,7 +14274,6 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -14525,7 +14356,6 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14608,7 +14438,6 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14691,7 +14520,6 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14774,7 +14602,6 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14857,7 +14684,6 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14940,7 +14766,6 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15023,7 +14848,6 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15106,7 +14930,6 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15189,7 +15012,6 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="typescript3.1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
Closes #1205.

Note: we can't hide IE 11 from "es2016plus" tab yet (until it's not marked as obsolete) because in that case it will also disappear from list of obsolete browsers