### PR TITLE
Updating non-standard results for Firefox 58 Nightly

### DIFF
--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -856,6 +856,7 @@ exports.tests = [
   res: {
     ie7: false,
     firefox2: true,
+    firefox58: false,
     safari3_1: false,
     chrome7: false,
     opera7_5: false,

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -899,6 +899,7 @@ exports.tests = [
   res: {
     ie7: false,
     firefox2: true,
+    firefox58: false,
     safari3_1: false,
     chrome7: false,
     opera10_10: false,
@@ -918,6 +919,7 @@ exports.tests = [
   res: {
     ie7: false,
     firefox2: true,
+    firefox58: false,
     safari3_1: false,
     chrome7: false,
     opera7_5: false,

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -2547,7 +2547,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes" data-browser="firefox56">Yes</td>
 <td class="yes unstable" data-browser="firefox57">Yes</td>
-<td class="yes unstable" data-browser="firefox58">Yes</td>
+<td class="no unstable" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -2675,7 +2675,7 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes" data-browser="firefox56">Yes</td>
 <td class="yes unstable" data-browser="firefox57">Yes</td>
-<td class="yes unstable" data-browser="firefox58">Yes</td>
+<td class="no unstable" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>
@@ -2733,7 +2733,7 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes" data-browser="firefox56">Yes</td>
 <td class="yes unstable" data-browser="firefox57">Yes</td>
-<td class="yes unstable" data-browser="firefox58">Yes</td>
+<td class="no unstable" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>


### PR DESCRIPTION
Firefox 58 Nightly does not support Object.prototype.watch/unwatch anymore