### PR TITLE
Non-standard Generators (JS 1.8) dropped from Firefox 58

### DIFF
--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -639,6 +639,7 @@ exports.tests = [
     ie7: false,
     firefox2: false,
     firefox3: true,
+    firefox58: false,
     safari3_1: false,
     chrome7: false,
     opera7_5: false,

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -252,6 +252,7 @@ exports.tests = [
     ie7: false,
     firefox2: false,
     firefox5: true,
+    firefox58: false,
     safari3_1: false,
     chrome7: false,
     opera7_5: false,

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -1905,7 +1905,7 @@ global.test((function () {
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes" data-browser="firefox56">Yes</td>
 <td class="yes unstable" data-browser="firefox57">Yes</td>
-<td class="yes unstable" data-browser="firefox58">Yes</td>
+<td class="no unstable" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -858,7 +858,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes" data-browser="firefox56">Yes</td>
 <td class="yes unstable" data-browser="firefox57">Yes</td>
-<td class="yes unstable" data-browser="firefox58">Yes</td>
+<td class="no unstable" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1083482
This was actually tested with yesterday's nightly build.