### PR TITLE
Non-standard comprehensions (ES draft style) dropped from Firefox 59

### DIFF
--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -442,6 +442,7 @@ exports.tests = [
   res: {
     firefox2: false,
     firefox30: true,
+    firefox58: false,
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -716,6 +716,7 @@ exports.tests = [
   res: {
     firefox2: false,
     firefox30: true,
+    firefox58: false,
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -442,7 +442,7 @@ exports.tests = [
   res: {
     firefox2: false,
     firefox30: true,
-    firefox58: false,
+    firefox59: false,
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,
@@ -717,7 +717,7 @@ exports.tests = [
   res: {
     firefox2: false,
     firefox30: true,
-    firefox58: false,
+    firefox59: false,
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -1367,7 +1367,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes" data-browser="firefox56">Yes</td>
 <td class="yes unstable" data-browser="firefox57">Yes</td>
-<td class="yes unstable" data-browser="firefox58">Yes</td>
+<td class="no unstable" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -1367,7 +1367,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes" data-browser="firefox56">Yes</td>
 <td class="yes unstable" data-browser="firefox57">Yes</td>
-<td class="no unstable" data-browser="firefox58">No</td>
+<td class="yes unstable" data-browser="firefox58">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>
@@ -2034,7 +2034,7 @@ return passed;
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes" data-browser="firefox56">Yes</td>
 <td class="yes unstable" data-browser="firefox57">Yes</td>
-<td class="no unstable" data-browser="firefox58">No</td>
+<td class="yes unstable" data-browser="firefox58">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -2034,7 +2034,7 @@ return passed;
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes" data-browser="firefox56">Yes</td>
 <td class="yes unstable" data-browser="firefox57">Yes</td>
-<td class="yes unstable" data-browser="firefox58">Yes</td>
+<td class="no unstable" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>


### PR DESCRIPTION
Non-standard array and generator comprehensions (JS 1.8) dropped from Firefox 58
See https://bugzilla.mozilla.org/show_bug.cgi?id=1414340
This was actually tested with yesterday's nightly build.