### PR TITLE
Fix closure compiler command line options

### DIFF
--- a/build.js
+++ b/build.js
@@ -270,7 +270,7 @@ process.nextTick(function () {
         try {
           output = "" + child_process.execSync('./node_modules/.bin/google-closure-compiler-js ' +
             fpath +
-            ' --language_in=ECMASCRIPT6 --language_out=ECMASCRIPT5 --rewrite_polyfills'
+            ' --languageIn=ECMASCRIPT6 --languageOut=ECMASCRIPT5 --rewritePolyfills --warningLevel=QUIET'
           );
         } catch(e) {
           throw new Error('\n' + e.stdout.toString().split(fpath).join(''));


### PR DESCRIPTION
Flags should be camel case according to https://github.com/google/closure-compiler-js/blob/master/README.md#flags

Otherwise, you get this error when running `build.js`

```
{ Error: java.lang.RuntimeException: Unhandled flag: language_in
    at iJ.HG [as Vf] (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/jscomp.js:7699:22264)
    at iJ.KG [as Xf] (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/jscomp.js:7699:22465)
    at iJ.FG (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/jscomp.js:2219:48)
    at iJ.NG (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/jscomp.js:595:19)
    at new iJ (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/jscomp.js:596:19)
    at y8c (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/jscomp.js:7326:77)
    at zJ (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/jscomp.js:1759:29)
    at CJ (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/jscomp.js:3066:44)
    at /Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/jscomp.js:3241:46
    at module.exports (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/compile.js:31:15)
    at ready (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/cmd.js:107:18)
    at Promise.all.then.arr (/Users/yang.su/code/compat-table/node_modules/google-closure-compiler-js/cmd.js:58:45)
    at <anonymous>
  '__java$exception':
   { g: null,
     f: 'Unhandled flag: language_in',
     backingJsObject: [Circular] } }
```