### PR TITLE
Array.prototype.{flatten, flatMap} implemented on Firefox 59 Nightly

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2789,6 +2789,8 @@ exports.tests = [
         babel: babel.corejs,
         typescript1: typescript.corejs,
         firefox2: false,
+        firefox58: false,
+        firefox59: firefox.nightly,
         opera10_50: false,
         duktape2_2: false,
       }
@@ -2804,6 +2806,8 @@ exports.tests = [
         babel: babel.corejs,
         typescript1: typescript.corejs,
         firefox2: false,
+        firefox58: false,
+        firefox59: firefox.nightly,
         opera10_50: false,
         duktape2_2: false,
       }

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2433,7 +2433,7 @@ return [1, [2, 3], [4, [5, 6]]].flatten().join(&apos;&apos;) === &apos;12345,6&a
 <td class="no" data-browser="firefox56">No</td>
 <td class="no" data-browser="firefox57">No</td>
 <td class="no unstable" data-browser="firefox58">No</td>
-<td class="no unstable" data-browser="firefox59">No</td>
+<td class="no unstable" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>
@@ -2507,7 +2507,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no" data-browser="firefox56">No</td>
 <td class="no" data-browser="firefox57">No</td>
 <td class="no unstable" data-browser="firefox58">No</td>
-<td class="no unstable" data-browser="firefox59">No</td>
+<td class="no unstable" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>


### PR DESCRIPTION
Array.prototype.{flatten, flatMap} is now implemented on Firefox 59 Nightly