### PR TITLE
Firefox 58 release leftovers

### DIFF
--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -460,6 +460,7 @@ exports.tests = [
     ie7: false,
     firefox2: false,
     firefox3: true,
+    firefox59: false,
     safari3_1: false,
     chrome7: false,
     opera7_5: false,

--- a/environments.json
+++ b/environments.json
@@ -777,7 +777,7 @@
     "short": "FF 50",
     "release": "2016-11-15",
     "retire": "2017-01-24",
-    "obsolete": true
+    "obsolete": "very"
   },
   "firefox51": {
     "full": "Firefox 51",
@@ -792,7 +792,7 @@
     "family": "SpiderMonkey",
     "short": "FF 52 ESR",
     "release": "2017-03-07",
-    "retire": "2018-06-26",
+    "retire": "2018-08-28",
     "obsolete": false
   },
   "firefox53": {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -139,7 +139,6 @@
 <th class="platform edge16 desktop" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16</abbr></a></th>
 <th class="platform edge17 desktop unstable" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge">Edge 17 Preview</abbr></a></th>
 <th class="platform firefox45 desktop obsolete" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox 45 ESR">FF 45 ESR</abbr></a></th>
-<th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox 50">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox 51">FF 51</abbr></a></th>
 <th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox 52 ESR">FF 52 ESR</abbr></a></th>
 <th class="platform firefox53 desktop obsolete" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox 53">FF 53</abbr></a></th>
@@ -218,7 +217,6 @@
 <td class="tally" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox52" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">3/3</td>
@@ -294,7 +292,6 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -370,7 +367,6 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -451,7 +447,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -524,7 +519,6 @@ return true;
 <td class="tally" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox52" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">3/3</td>
@@ -604,7 +598,6 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -702,7 +695,6 @@ return 24;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -783,7 +775,6 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -868,7 +859,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -957,7 +947,6 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1038,7 +1027,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1115,7 +1103,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1193,7 +1180,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1276,7 +1262,6 @@ return passed;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1361,7 +1346,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1436,7 +1420,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox52" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">4/4</td>
@@ -1515,7 +1498,6 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1598,7 +1580,6 @@ return Array.isArray(e)
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1682,7 +1663,6 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1761,7 +1741,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1834,7 +1813,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox52" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">2/2</td>
@@ -1915,7 +1893,6 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1996,7 +1973,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2069,7 +2045,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox52" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">2/2</td>
@@ -2145,7 +2120,6 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2221,7 +2195,6 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2294,7 +2267,6 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="edge16" data-tally="1">15/15</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/15</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/15</td>
 <td class="tally" data-browser="firefox52" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">15/15</td>
@@ -2381,7 +2353,6 @@ p.then(function(result) {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2468,7 +2439,6 @@ p.catch(function(result) {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2545,7 +2515,6 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2622,7 +2591,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2705,7 +2673,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2790,7 +2757,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2867,7 +2833,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2949,7 +2914,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3026,7 +2990,6 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3113,7 +3076,6 @@ p.then(function(result) {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3200,7 +3162,6 @@ p.then(function(result) {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3285,7 +3246,6 @@ p.then(function(result) {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3364,7 +3324,6 @@ return passed;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3440,7 +3399,6 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3525,7 +3483,6 @@ p.then(function(result) {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3598,7 +3555,6 @@ p.then(function(result) {
 <td class="tally" data-browser="edge16" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/17</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0" data-flagged-tally="1">0/17</td>
@@ -3674,7 +3630,6 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -3750,7 +3705,6 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -3826,7 +3780,6 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -3902,7 +3855,6 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -3978,7 +3930,6 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4054,7 +4005,6 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4130,7 +4080,6 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4206,7 +4155,6 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4282,7 +4230,6 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4358,7 +4305,6 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4434,7 +4380,6 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4510,7 +4455,6 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4586,7 +4530,6 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4662,7 +4605,6 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4738,7 +4680,6 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4814,7 +4755,6 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4890,7 +4830,6 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox53">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
@@ -4973,7 +4912,6 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5052,7 +4990,6 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -5131,7 +5068,6 @@ return (function(){
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5206,7 +5142,6 @@ return (function(){
 <td class="tally" data-browser="edge16" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">16/16</td>
 <td class="tally" data-browser="firefox52" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">16/16</td>
@@ -5287,7 +5222,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5369,7 +5303,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5451,7 +5384,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5532,7 +5464,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5614,7 +5545,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5696,7 +5626,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5779,7 +5708,6 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5862,7 +5790,6 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5946,7 +5873,6 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6027,7 +5953,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6107,7 +6032,6 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6190,7 +6114,6 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6273,7 +6196,6 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6357,7 +6279,6 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6438,7 +6359,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6518,7 +6438,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6591,7 +6510,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox52" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">4/4</td>
@@ -6671,7 +6589,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6751,7 +6668,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6836,7 +6752,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6921,7 +6836,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6998,7 +6912,6 @@ return i === 0;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -7083,7 +6996,6 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -7160,7 +7072,6 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -136,7 +136,6 @@
 <th class="platform edge16 desktop" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16</abbr></a></th>
 <th class="platform edge17 desktop unstable" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge">Edge 17 Preview</abbr></a></th>
 <th class="platform firefox45 desktop obsolete" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox 45 ESR">FF 45 ESR</abbr></a></th>
-<th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox 50">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox 51">FF 51</abbr></a></th>
 <th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox 52 ESR">FF 52 ESR</abbr></a></th>
 <th class="platform firefox53 desktop obsolete" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox 53">FF 53</abbr></a></th>
@@ -215,7 +214,6 @@
 <td class="tally" data-browser="edge16" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox52" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">5/5</td>
@@ -293,7 +291,6 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -373,7 +370,6 @@ return value === 1;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -451,7 +447,6 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -529,7 +524,6 @@ return [1,].length === 1;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -607,7 +601,6 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -684,7 +677,6 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="edge16" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">13/13</td>
 <td class="tally" data-browser="firefox52" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">13/13</td>
@@ -764,7 +756,6 @@ return typeof Object.create == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -844,7 +835,6 @@ return typeof Object.defineProperty == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -924,7 +914,6 @@ return typeof Object.defineProperties == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1004,7 +993,6 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1084,7 +1072,6 @@ return typeof Object.keys == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1164,7 +1151,6 @@ return typeof Object.seal == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1244,7 +1230,6 @@ return typeof Object.freeze == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1324,7 +1309,6 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1404,7 +1388,6 @@ return typeof Object.isSealed == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1484,7 +1467,6 @@ return typeof Object.isFrozen == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1564,7 +1546,6 @@ return typeof Object.isExtensible == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1644,7 +1625,6 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1724,7 +1704,6 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1799,7 +1778,6 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally" data-browser="edge16" data-tally="1">12/12</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">12/12</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">12/12</td>
 <td class="tally" data-browser="firefox52" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">12/12</td>
@@ -1879,7 +1857,6 @@ return typeof Array.isArray == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1959,7 +1936,6 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2039,7 +2015,6 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2119,7 +2094,6 @@ return typeof Array.prototype.every == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2199,7 +2173,6 @@ return typeof Array.prototype.some == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2279,7 +2252,6 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2359,7 +2331,6 @@ return typeof Array.prototype.map == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2439,7 +2410,6 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2519,7 +2489,6 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2599,7 +2568,6 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2719,7 +2687,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2809,7 +2776,6 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2884,7 +2850,6 @@ try {
 <td class="tally" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox52" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">2/2</td>
@@ -2964,7 +2929,6 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3044,7 +3008,6 @@ return typeof String.prototype.trim == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3119,7 +3082,6 @@ return typeof String.prototype.trim == 'function';
 <td class="tally" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox52" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">3/3</td>
@@ -3199,7 +3161,6 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3279,7 +3240,6 @@ return typeof Date.now == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3367,7 +3327,6 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3447,7 +3406,6 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3527,7 +3485,6 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3604,7 +3561,6 @@ return typeof JSON == 'object';
 <td class="tally" data-browser="edge16" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox52" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">3/3</td>
@@ -3685,7 +3641,6 @@ return result;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3766,7 +3721,6 @@ return result;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3847,7 +3801,6 @@ return result;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3922,7 +3875,6 @@ return result;
 <td class="tally" data-browser="edge16" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">8/8</td>
 <td class="tally" data-browser="firefox52" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">8/8</td>
@@ -4002,7 +3954,6 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4082,7 +4033,6 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4160,7 +4110,6 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4238,7 +4187,6 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4317,7 +4265,6 @@ return _\u200c\u200d;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4397,7 +4344,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4483,7 +4429,6 @@ return result;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4567,7 +4512,6 @@ catch(e) {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4642,7 +4586,6 @@ catch(e) {
 <td class="tally" data-browser="edge16" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">19/19</td>
 <td class="tally" data-browser="firefox52" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">19/19</td>
@@ -4725,7 +4668,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4804,7 +4746,6 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="yes" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
 <td class="yes unstable" data-browser="edge17">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4885,7 +4826,6 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -4980,7 +4920,6 @@ return test(String, &apos;&apos;)
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5061,7 +5000,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5140,7 +5078,6 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5223,7 +5160,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5306,7 +5242,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5391,7 +5326,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5473,7 +5407,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5553,7 +5486,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5634,7 +5566,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5719,7 +5650,6 @@ return (function(x){
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5798,7 +5728,6 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5877,7 +5806,6 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -5956,7 +5884,6 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6035,7 +5962,6 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6114,7 +6040,6 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -6193,7 +6118,6 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -140,7 +140,6 @@
 <th class="platform edge16 desktop" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16</abbr></a></th>
 <th class="platform edge17 desktop unstable" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge">Edge 17 Preview</abbr></a></th>
 <th class="platform firefox45 desktop obsolete" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox 45 ESR">FF 45 ESR</abbr></a></th>
-<th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox 50">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox 51">FF 51</abbr></a></th>
 <th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox 52 ESR">FF 52 ESR</abbr></a></th>
 <th class="platform firefox53 desktop obsolete" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox 53">FF 53</abbr></a></th>
@@ -209,7 +208,6 @@
 <td class="tally" data-browser="edge16" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox52" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">2/2</td>
@@ -277,7 +275,6 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -345,7 +342,6 @@ return Intl.constructor === Object;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -410,7 +406,6 @@ return Intl.constructor === Object;
 <td class="tally" data-browser="edge16" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox52" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">4/4</td>
@@ -478,7 +473,6 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -546,7 +540,6 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -614,7 +607,6 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -710,7 +702,6 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -775,7 +766,6 @@ try {
 <td class="tally" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">1/1</td>
@@ -843,7 +833,6 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -908,7 +897,6 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">1/1</td>
@@ -976,7 +964,6 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1041,7 +1028,6 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally" data-browser="edge16" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox52" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">5/5</td>
@@ -1109,7 +1095,6 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1177,7 +1162,6 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1245,7 +1229,6 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1313,7 +1296,6 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1409,7 +1391,6 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1474,7 +1455,6 @@ try {
 <td class="tally" data-browser="edge16" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally" data-browser="firefox52" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">6/6</td>
@@ -1542,7 +1522,6 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1610,7 +1589,6 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1678,7 +1656,6 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1774,7 +1751,6 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox50">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox51">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox53">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
@@ -1843,7 +1819,6 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1919,7 +1894,6 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1984,7 +1958,6 @@ try {
 <td class="tally" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">1/1</td>
@@ -2052,7 +2025,6 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2117,7 +2089,6 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">1/1</td>
@@ -2185,7 +2156,6 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2250,7 +2220,6 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">1/1</td>
@@ -2318,7 +2287,6 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2383,7 +2351,6 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">1/1</td>
@@ -2451,7 +2418,6 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2516,7 +2482,6 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">1/1</td>
@@ -2584,7 +2549,6 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2649,7 +2613,6 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">1/1</td>
@@ -2717,7 +2680,6 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2782,7 +2744,6 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally" data-browser="edge16" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">1/1</td>
@@ -2850,7 +2811,6 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -143,7 +143,6 @@
 <th class="platform edge16 desktop" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16</abbr></a></th>
 <th class="platform edge17 desktop unstable" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge">Edge 17 Preview</abbr></a></th>
 <th class="platform firefox45 desktop obsolete" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox 45 ESR">FF 45 ESR</abbr></a></th>
-<th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox 50">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox 51">FF 51</abbr></a></th>
 <th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox 52 ESR">FF 52 ESR</abbr></a></th>
 <th class="platform firefox53 desktop obsolete" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox 53">FF 53</abbr></a></th>
@@ -220,7 +219,6 @@
 <td class="tally" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/2</td>
@@ -295,7 +293,6 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -371,7 +368,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -442,7 +438,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/2</td>
@@ -518,7 +513,6 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
@@ -599,7 +593,6 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
@@ -670,7 +663,6 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/2</td>
@@ -751,7 +743,6 @@ iterator.next().then(function(step){
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -842,7 +833,6 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -923,7 +913,6 @@ return result.groups.year === &apos;2016&apos;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -998,7 +987,6 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1073,7 +1061,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1144,7 +1131,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="edge16" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/3</td>
@@ -1221,7 +1207,6 @@ return new C().x === &apos;x&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1304,7 +1289,6 @@ return new C(42).x() === 42;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1384,7 +1368,6 @@ return new C().x() === 42;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1455,7 +1438,6 @@ return new C().x() === 42;
 <td class="tally" data-browser="edge16" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td class="tally" data-browser="firefox52" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
@@ -1531,7 +1513,6 @@ return fn + &apos;&apos; === str;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1606,7 +1587,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1681,7 +1661,6 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1756,7 +1735,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1831,7 +1809,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1906,7 +1883,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1981,7 +1957,6 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2052,7 +2027,6 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="edge16" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/3</td>
@@ -2152,7 +2126,6 @@ function check() {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2244,7 +2217,6 @@ function check() {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2338,7 +2310,6 @@ function check() {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2409,7 +2380,6 @@ function check() {
 <td class="tally" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/2</td>
@@ -2483,7 +2453,6 @@ return [1, [2, 3], [4, [5, 6]]].flatten().join(&apos;&apos;) === &apos;12345,6&a
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2559,7 +2528,6 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2630,7 +2598,6 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="tally" data-browser="edge16" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/3</td>
@@ -2710,7 +2677,6 @@ return false;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2791,7 +2757,6 @@ return false;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2877,7 +2842,6 @@ return it.next().value;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2952,7 +2916,6 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -3034,7 +2997,6 @@ return result === &apos;tromple&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -3105,7 +3067,6 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="edge16" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/1</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/1</td>
@@ -3187,7 +3148,6 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -3258,7 +3218,6 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally" data-browser="edge16" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="firefox52" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -3332,7 +3291,6 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3406,7 +3364,6 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3480,7 +3437,6 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -3554,7 +3510,6 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -3638,7 +3593,6 @@ return a === &apos;1a2b&apos;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -3709,7 +3663,6 @@ return a === &apos;1a2b&apos;
 <td class="tally" data-browser="edge16" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/2</td>
@@ -3786,7 +3739,6 @@ return C.x === &apos;x&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -3866,7 +3818,6 @@ return new C().x() === 42;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -3937,7 +3888,6 @@ return new C().x() === 42;
 <td class="tally" data-browser="edge16" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/4</td>
@@ -4017,7 +3967,6 @@ try {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -4101,7 +4050,6 @@ try {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -4180,7 +4128,6 @@ try {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -4259,7 +4206,6 @@ try {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -4338,7 +4284,6 @@ return do {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -4409,7 +4354,6 @@ return do {
 <td class="tally" data-browser="edge16" data-tally="0" data-flagged-tally="0.9649122807017544">0/57</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0" data-flagged-tally="0.9649122807017544">0/57</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/57</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/57</td>
@@ -4491,7 +4435,6 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -4565,7 +4508,6 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -4639,7 +4581,6 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -4713,7 +4654,6 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -4787,7 +4727,6 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -4861,7 +4800,6 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -4935,7 +4873,6 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5009,7 +4946,6 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5083,7 +5019,6 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5157,7 +5092,6 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5231,7 +5165,6 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5307,7 +5240,6 @@ return simdFloatTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5383,7 +5315,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5459,7 +5390,6 @@ return simdSmallIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5535,7 +5465,6 @@ return simdBoolIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5611,7 +5540,6 @@ return simdBoolTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5687,7 +5615,6 @@ return simdBoolTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5763,7 +5690,6 @@ return simdAllTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5839,7 +5765,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5915,7 +5840,6 @@ return simdAllTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -5991,7 +5915,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6067,7 +5990,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6143,7 +6065,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6219,7 +6140,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6295,7 +6215,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6371,7 +6290,6 @@ return simdFloatTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6447,7 +6365,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6523,7 +6440,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6599,7 +6515,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6675,7 +6590,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6751,7 +6665,6 @@ return simdFloatTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6827,7 +6740,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6903,7 +6815,6 @@ return simdFloatTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -6979,7 +6890,6 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7055,7 +6965,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7131,7 +7040,6 @@ return simdBoolTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7207,7 +7115,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7283,7 +7190,6 @@ return simdBoolIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7359,7 +7265,6 @@ return simdFloatTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7435,7 +7340,6 @@ return simdFloatTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7511,7 +7415,6 @@ return simdAllTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7587,7 +7490,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7663,7 +7565,6 @@ return simdIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7739,7 +7640,6 @@ return simdIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7815,7 +7715,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7891,7 +7790,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -7967,7 +7865,6 @@ return simdFloatTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8043,7 +7940,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8119,7 +8015,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8195,7 +8090,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8271,7 +8165,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8347,7 +8240,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8423,7 +8315,6 @@ return simdSmallIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8499,7 +8390,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8575,7 +8465,6 @@ return simdBoolIntTypes.every(function(type){
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8651,7 +8540,6 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8725,7 +8613,6 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no flagged" data-browser="edge16">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged unstable" data-browser="edge17">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox51">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="firefox52">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox53">No<a href="#firefox-nightly-note"><sup>[9]</sup></a></td>
@@ -8802,7 +8689,6 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -8873,7 +8759,6 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="edge16" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/7</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/7</td>
@@ -8947,7 +8832,6 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9021,7 +8905,6 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9095,7 +8978,6 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9179,7 +9061,6 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9254,7 +9135,6 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9328,7 +9208,6 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9402,7 +9281,6 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9480,7 +9358,6 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9555,7 +9432,6 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9632,7 +9508,6 @@ return Math.signbit(-0) === false
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9703,7 +9578,6 @@ return Math.signbit(-0) === false
 <td class="tally" data-browser="edge16" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/7</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/7</td>
@@ -9779,7 +9653,6 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9853,7 +9726,6 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -9928,7 +9800,6 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10002,7 +9873,6 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10076,7 +9946,6 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10151,7 +10020,6 @@ return Math.radians(90) === Math.PI / 2
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10225,7 +10093,6 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10296,7 +10163,6 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally" data-browser="edge16" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/7</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/7</td>
@@ -10370,7 +10236,6 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10444,7 +10309,6 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10520,7 +10384,6 @@ return score === 1;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10601,7 +10464,6 @@ Promise.try(function() {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10682,7 +10544,6 @@ Promise.try(function() {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10763,7 +10624,6 @@ Promise.try(function() {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10844,7 +10704,6 @@ Promise.try(function() {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -10915,7 +10774,6 @@ Promise.try(function() {
 <td class="tally" data-browser="edge16" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/8</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/8</td>
@@ -10992,7 +10850,6 @@ return C.get(A) + C.get(B) === 3;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11071,7 +10928,6 @@ return C.get(A) + C.get(B) === 5;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11148,7 +11004,6 @@ return C.has(A) + C.has(B);
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11225,7 +11080,6 @@ return C.has(3) + C.has(4);
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11302,7 +11156,6 @@ return C.get(A) + C.get(B) === 3;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11381,7 +11234,6 @@ return C.get(A) + C.get(B) === 5;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11458,7 +11310,6 @@ return C.has(A) + C.has(B);
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11535,7 +11386,6 @@ return C.has(A) + C.has(B);
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11621,7 +11471,6 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11699,7 +11548,6 @@ return 123i === &apos;string123number123&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11770,7 +11618,6 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally" data-browser="edge16" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/3</td>
@@ -11846,7 +11693,6 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11922,7 +11768,6 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -11998,7 +11843,6 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12076,7 +11920,6 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12147,7 +11990,6 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally" data-browser="edge16" data-tally="0">0/12</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/12</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/12</td>
@@ -12225,7 +12067,6 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12303,7 +12144,6 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12381,7 +12221,6 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12459,7 +12298,6 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12537,7 +12375,6 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12615,7 +12452,6 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12693,7 +12529,6 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12774,7 +12609,6 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12853,7 +12687,6 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -12931,7 +12764,6 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13009,7 +12841,6 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13087,7 +12918,6 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13161,7 +12991,6 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13232,7 +13061,6 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="tally" data-browser="edge16" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="0">0/8</td>
 <td class="tally" data-browser="firefox52" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="0">0/8</td>
@@ -13306,7 +13134,6 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13380,7 +13207,6 @@ return Object.isFrozen([# 42 #]);
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13454,7 +13280,6 @@ return Object.isSealed({| foo: 42 |});
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13528,7 +13353,6 @@ return Object.isSealed([| 42 |]);
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13610,7 +13434,6 @@ try {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13693,7 +13516,6 @@ try {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13775,7 +13597,6 @@ try {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13858,7 +13679,6 @@ try {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -13932,7 +13752,6 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -14011,7 +13830,6 @@ return results.length === 3
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -14084,7 +13902,6 @@ return results.length === 3
 <td class="tally not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14160,7 +13977,6 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14235,7 +14051,6 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14309,7 +14124,6 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14380,7 +14194,6 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -14455,7 +14268,6 @@ return f();
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14529,7 +14341,6 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14608,7 +14419,6 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14693,7 +14503,6 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14774,7 +14583,6 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14845,7 +14653,6 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14921,7 +14728,6 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14997,7 +14803,6 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15068,7 +14873,6 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -15142,7 +14946,6 @@ return typeof Zone == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15216,7 +15019,6 @@ return &apos;current&apos; in Zone;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15290,7 +15092,6 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15364,7 +15165,6 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15438,7 +15238,6 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15512,7 +15311,6 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15586,7 +15384,6 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15663,7 +15460,6 @@ passed = true;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15734,7 +15530,6 @@ passed = true;
 <td class="tally not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -15814,7 +15609,6 @@ return (function f(n){
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15901,7 +15695,6 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15972,7 +15765,6 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -16048,7 +15840,6 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16125,7 +15916,6 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16198,7 +15988,6 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -16272,7 +16061,6 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16346,7 +16134,6 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16420,7 +16207,6 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16494,7 +16280,6 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16568,7 +16353,6 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16642,7 +16426,6 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16716,7 +16499,6 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16790,7 +16572,6 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16864,7 +16645,6 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge16" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge17" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="firefox50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox52" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox53" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -129,7 +129,6 @@
 <th class="platform edge16 desktop" data-browser="edge16"><a href="#edge16" class="browser-name"><abbr title="Microsoft Edge">Edge 16</abbr></a></th>
 <th class="platform edge17 desktop unstable" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge">Edge 17 Preview</abbr></a></th>
 <th class="platform firefox45 desktop obsolete" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox 45 ESR">FF 45 ESR</abbr></a></th>
-<th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox 50">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox 51">FF 51</abbr></a></th>
 <th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox 52 ESR">FF 52 ESR</abbr></a></th>
 <th class="platform firefox53 desktop obsolete" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox 53">FF 53</abbr></a></th>
@@ -193,7 +192,6 @@
 <td class="tally" data-browser="edge16" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="edge17" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox45" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox51" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox52" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox53" data-tally="1">4/4</td>
@@ -256,7 +254,6 @@ return typeof uneval == &apos;function&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -327,7 +324,6 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -390,7 +386,6 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -542,7 +537,6 @@ return true;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -606,7 +600,6 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -673,7 +666,6 @@ return 'caller' in function(){};
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -742,7 +734,6 @@ return (function () {}).arity === 0 &&
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -813,7 +804,6 @@ return f(1, 'boo');
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -878,7 +868,6 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -944,7 +933,6 @@ return new C instanceof C;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1011,7 +999,6 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1076,7 +1063,6 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1151,7 +1137,6 @@ return executed;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1216,7 +1201,6 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1281,7 +1265,6 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1348,7 +1331,6 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1411,7 +1393,6 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1474,7 +1455,6 @@ return (function(x)x)(1) === 1;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1483,8 +1463,8 @@ return (function(x)x)(1) === 1;
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes" data-browser="firefox57">Yes</td>
 <td class="yes" data-browser="firefox58">Yes</td>
-<td class="yes unstable" data-browser="firefox59">Yes</td>
-<td class="yes unstable" data-browser="firefox60">Yes</td>
+<td class="no unstable" data-browser="firefox59">No</td>
+<td class="no unstable" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome54">No</td>
 <td class="no obsolete" data-browser="chrome55">No</td>
@@ -1537,7 +1517,6 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1604,7 +1583,6 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1668,7 +1646,6 @@ return arr[1] === arr;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -1765,7 +1742,6 @@ catch(e) {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1868,7 +1844,6 @@ catch(e) {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -1970,7 +1945,6 @@ global.test((function () {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2035,7 +2009,6 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2105,7 +2078,6 @@ return passed;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2186,7 +2158,6 @@ try {
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2255,7 +2226,6 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2326,7 +2296,6 @@ return true;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2389,7 +2358,6 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2453,7 +2421,6 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2516,7 +2483,6 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2577,7 +2543,6 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2640,7 +2605,6 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2711,7 +2675,6 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2774,7 +2737,6 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2835,7 +2797,6 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -2896,7 +2857,6 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -2959,7 +2919,6 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>
@@ -3034,7 +2993,6 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3099,7 +3057,6 @@ return 'lineNumber' in new Error();
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3164,7 +3121,6 @@ return 'columnNumber' in new Error();
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3229,7 +3185,6 @@ return 'fileName' in new Error();
 <td class="no" data-browser="edge16">No</td>
 <td class="no unstable" data-browser="edge17">No</td>
 <td class="yes obsolete" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
 <td class="yes obsolete" data-browser="firefox51">Yes</td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox53">Yes</td>
@@ -3294,7 +3249,6 @@ return 'description' in new Error();
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes unstable" data-browser="edge17">Yes</td>
 <td class="no obsolete" data-browser="firefox45">No</td>
-<td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no obsolete" data-browser="firefox51">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox53">No</td>


### PR DESCRIPTION
Firefox 58 was released today, updating accordingly.  This released was postponed for one week, so all the following releases will be postponed to, updating dated accordingly.  Also, the next ESR was postponed from FF59 to FF60, updating 52ESR retirement accordingly.
Finally, I ran all the tests and found only one wrong value for Firefox 59 on the non-standard tab.