### PR TITLE
TypeScript 2.7 released

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -3115,6 +3115,8 @@ exports.tests = [
   */},
   res : {
     babel: true,
+    typescript1: false,
+    typescript2_7: true,
     firefox2: false,
     opera10_50: false,
   }

--- a/environments.json
+++ b/environments.json
@@ -149,6 +149,19 @@
     "family": "TypeScript",
     "platformtype": "compiler",
     "release": "2017-10-31",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "typescript2_7": {
+    "full": "TypeScript 2.7 + core-js 2.5",
+    "short": "Type-<br />Script +<br /><nobr>core-js</nobr>",
+    "family": "TypeScript",
+    "platformtype": "compiler",
+    "release": "2018-01-31",
     "obsolete": false,
     "test_suites": [
       "es6",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -128,7 +128,8 @@
 <th class="platform typescript2_3 compiler obsolete" data-browser="typescript2_3"><a href="#typescript2_3" class="browser-name"><abbr title="TypeScript 2.3 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_4 compiler obsolete" data-browser="typescript2_4"><a href="#typescript2_4" class="browser-name"><abbr title="TypeScript 2.4 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_5 compiler obsolete" data-browser="typescript2_5"><a href="#typescript2_5" class="browser-name"><abbr title="TypeScript 2.5 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
-<th class="platform typescript2_6 compiler" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
+<th class="platform typescript2_6 compiler obsolete" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
+<th class="platform typescript2_7 compiler" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
@@ -194,7 +195,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="72">2016 features</td>
+      <tr class="category"><td colspan="73">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -205,7 +206,8 @@
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
@@ -279,7 +281,8 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -353,7 +356,8 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -432,7 +436,8 @@ return true;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -503,7 +508,8 @@ return true;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
@@ -581,7 +587,8 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -677,7 +684,8 @@ return 24;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -756,7 +764,8 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -818,7 +827,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">2016 misc</td>
+<tr class="category"><td colspan="73">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[9]</sup></a></span><script data-source="
 function * generator() {
@@ -839,7 +848,8 @@ return true;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -926,7 +936,8 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1005,7 +1016,8 @@ return true;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1080,7 +1092,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1156,7 +1169,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1237,7 +1251,8 @@ return passed;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1320,7 +1335,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1382,7 +1398,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">2017 features</td>
+<tr class="category"><td colspan="73">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1393,7 +1409,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">4/4</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">4/4</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">4/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
@@ -1470,7 +1487,8 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1551,7 +1569,8 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1633,7 +1652,8 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1710,7 +1730,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1781,7 +1802,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
@@ -1860,7 +1882,8 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1939,7 +1962,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2010,7 +2034,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
@@ -2084,7 +2109,8 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2158,7 +2184,8 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2229,7 +2256,8 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
@@ -2314,7 +2342,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2399,7 +2428,8 @@ p.catch(function(result) {
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2474,7 +2504,8 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2549,7 +2580,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2630,7 +2662,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2713,7 +2746,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2788,7 +2822,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2868,7 +2903,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2943,7 +2979,8 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3028,7 +3065,8 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3113,7 +3151,8 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3196,7 +3235,8 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3272,7 +3312,8 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3346,7 +3387,8 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3429,7 +3471,8 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3500,7 +3543,8 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/17</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/17</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0">0/17</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
@@ -3574,7 +3618,8 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3648,7 +3693,8 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3722,7 +3768,8 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3796,7 +3843,8 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3870,7 +3918,8 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3944,7 +3993,8 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4018,7 +4068,8 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4092,7 +4143,8 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4166,7 +4218,8 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4240,7 +4293,8 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4314,7 +4368,8 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4388,7 +4443,8 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4462,7 +4518,8 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4536,7 +4593,8 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4610,7 +4668,8 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4684,7 +4743,8 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4758,7 +4818,8 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4820,7 +4881,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">2017 misc</td>
+<tr class="category"><td colspan="73">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[23]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -4839,7 +4900,8 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4916,7 +4978,8 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4993,7 +5056,8 @@ return (function(){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5055,7 +5119,7 @@ return (function(){
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">2017 annex b</td>
+<tr class="category"><td colspan="73">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -5066,7 +5130,8 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
@@ -5145,7 +5210,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5225,7 +5291,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5305,7 +5372,8 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5384,7 +5452,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5464,7 +5533,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5544,7 +5614,8 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5625,7 +5696,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5706,7 +5778,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5788,7 +5861,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5867,7 +5941,8 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5945,7 +6020,8 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6026,7 +6102,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6107,7 +6184,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6189,7 +6267,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6268,7 +6347,8 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6346,7 +6426,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6417,7 +6498,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
@@ -6495,7 +6577,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6573,7 +6656,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6656,7 +6740,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6739,7 +6824,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6814,7 +6900,8 @@ return i === 0;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6876,7 +6963,7 @@ return i === 0;
 <td class="yes" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">2018 features</td>
+<tr class="category"><td colspan="73">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -6887,7 +6974,8 @@ return i === 0;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
@@ -6962,7 +7050,8 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7038,7 +7127,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7109,7 +7199,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
@@ -7209,7 +7300,8 @@ function check() {
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7301,7 +7393,8 @@ function check() {
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7395,7 +7488,8 @@ function check() {
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7476,7 +7570,8 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7551,7 +7646,8 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
-<td class="unknown" data-browser="typescript2_6">?</td>
+<td class="unknown obsolete" data-browser="typescript2_6">?</td>
+<td class="unknown" data-browser="typescript2_7">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7632,7 +7728,8 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7707,7 +7804,8 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7782,7 +7880,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7853,7 +7952,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
@@ -7934,7 +8034,8 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8025,7 +8126,8 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -134,7 +134,8 @@
 <th class="platform typescript2_3 compiler obsolete" data-browser="typescript2_3"><a href="#typescript2_3" class="browser-name"><abbr title="TypeScript 2.3 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_4 compiler obsolete" data-browser="typescript2_4"><a href="#typescript2_4" class="browser-name"><abbr title="TypeScript 2.4 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_5 compiler obsolete" data-browser="typescript2_5"><a href="#typescript2_5" class="browser-name"><abbr title="TypeScript 2.5 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
-<th class="platform typescript2_6 compiler" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
+<th class="platform typescript2_6 compiler obsolete" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
+<th class="platform typescript2_7 compiler" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -198,7 +199,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="70">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="71">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-string-left-right-trim">string trimming</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -209,7 +210,8 @@
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">4/4</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">4/4</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">4/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -281,7 +283,8 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -353,7 +356,8 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -425,7 +429,8 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -497,7 +502,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -566,7 +572,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -640,7 +647,8 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -719,7 +727,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -801,7 +810,8 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -870,7 +880,8 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
@@ -945,7 +956,8 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1026,7 +1038,8 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1104,7 +1117,8 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1173,7 +1187,8 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/7</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/7</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
@@ -1247,7 +1262,8 @@ return fn + &apos;&apos; === str;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1320,7 +1336,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1393,7 +1410,8 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1466,7 +1484,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1539,7 +1558,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1612,7 +1632,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1685,7 +1706,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1754,7 +1776,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -1826,7 +1849,8 @@ return [1, [2, 3], [4, [5, 6]]].flatten().join(&apos;&apos;) === &apos;12345,6&a
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1900,7 +1924,8 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1969,7 +1994,8 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/3</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/3</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
@@ -2047,7 +2073,8 @@ return false;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2126,7 +2153,8 @@ return false;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2210,7 +2238,8 @@ return it.next().value;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2283,7 +2312,8 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2343,7 +2373,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="70">Draft (stage 2)</td>
+<tr class="category"><td colspan="71">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -2363,7 +2393,8 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2432,7 +2463,8 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">1/1</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">1/1</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/1</td>
@@ -2512,7 +2544,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2581,7 +2614,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -2656,7 +2690,8 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
-<td class="yes" data-browser="typescript2_6">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes</td>
+<td class="yes" data-browser="typescript2_7">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2734,7 +2769,8 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2803,7 +2839,8 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/4</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/4</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/4</td>
@@ -2881,7 +2918,8 @@ try {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2963,7 +3001,8 @@ try {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3040,7 +3079,8 @@ try {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3117,7 +3157,8 @@ try {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3189,7 +3230,8 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3249,7 +3291,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="70">Proposal (stage 1)</td>
+<tr class="category"><td colspan="71">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -3266,7 +3308,8 @@ return do {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3335,7 +3378,8 @@ return do {
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/57</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/57</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0">0/57</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.017543859649122806">0/57</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.543859649122807">0/57</td>
@@ -3415,7 +3459,8 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -3487,7 +3532,8 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -3559,7 +3605,8 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -3631,7 +3678,8 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3703,7 +3751,8 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -3775,7 +3824,8 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3847,7 +3897,8 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3919,7 +3970,8 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3991,7 +4043,8 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4063,7 +4116,8 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4135,7 +4189,8 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4209,7 +4264,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -4283,7 +4339,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -4357,7 +4414,8 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4431,7 +4489,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4505,7 +4564,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4579,7 +4639,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4653,7 +4714,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -4727,7 +4789,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -4801,7 +4864,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -4875,7 +4939,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -4949,7 +5014,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5023,7 +5089,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5097,7 +5164,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5171,7 +5239,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5245,7 +5314,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5319,7 +5389,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5393,7 +5464,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5467,7 +5539,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5541,7 +5614,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5615,7 +5689,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5689,7 +5764,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5763,7 +5839,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5837,7 +5914,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5911,7 +5989,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5985,7 +6064,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6059,7 +6139,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6133,7 +6214,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6207,7 +6289,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6281,7 +6364,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6355,7 +6439,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6429,7 +6514,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6503,7 +6589,8 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6577,7 +6664,8 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6651,7 +6739,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6725,7 +6814,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6799,7 +6889,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6873,7 +6964,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6947,7 +7039,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7021,7 +7114,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7095,7 +7189,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7169,7 +7264,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7243,7 +7339,8 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7317,7 +7414,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7391,7 +7489,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7465,7 +7564,8 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7537,7 +7637,8 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7612,7 +7713,8 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7681,7 +7783,8 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">7/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/7</td>
@@ -7753,7 +7856,8 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7825,7 +7929,8 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7897,7 +8002,8 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7979,7 +8085,8 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8052,7 +8159,8 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8124,7 +8232,8 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8196,7 +8305,8 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8272,7 +8382,8 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8345,7 +8456,8 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8420,7 +8532,8 @@ return Math.signbit(-0) === false
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8489,7 +8602,8 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">7/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/7</td>
@@ -8563,7 +8677,8 @@ return Math.clamp(2, 4, 6) === 4
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8635,7 +8750,8 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8708,7 +8824,8 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8780,7 +8897,8 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8852,7 +8970,8 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8925,7 +9044,8 @@ return Math.radians(90) === Math.PI / 2
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8997,7 +9117,8 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9066,7 +9187,8 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">7/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/7</td>
@@ -9138,7 +9260,8 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9210,7 +9333,8 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9284,7 +9408,8 @@ return score === 1;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9363,7 +9488,8 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9442,7 +9568,8 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9521,7 +9648,8 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9600,7 +9728,8 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9669,7 +9798,8 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">8/8</td>
-<td class="tally" data-browser="typescript2_6" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="1">8/8</td>
+<td class="tally" data-browser="typescript2_7" data-tally="1">8/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/8</td>
@@ -9744,7 +9874,8 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9821,7 +9952,8 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9896,7 +10028,8 @@ return C.has(A) + C.has(B);
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9971,7 +10104,8 @@ return C.has(3) + C.has(4);
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10046,7 +10180,8 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10123,7 +10258,8 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10198,7 +10334,8 @@ return C.has(A) + C.has(B);
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10273,7 +10410,8 @@ return C.has(A) + C.has(B);
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10357,7 +10495,8 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10433,7 +10572,8 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10502,7 +10642,8 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/3</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/3</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
@@ -10576,7 +10717,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10650,7 +10792,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10724,7 +10867,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10800,7 +10944,8 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10869,7 +11014,8 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/12</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/12</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/12</td>
@@ -10945,7 +11091,8 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11021,7 +11168,8 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11097,7 +11245,8 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11173,7 +11322,8 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11249,7 +11399,8 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11325,7 +11476,8 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11401,7 +11553,8 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11480,7 +11633,8 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11557,7 +11711,8 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11633,7 +11788,8 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11709,7 +11865,8 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11785,7 +11942,8 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11854,7 +12012,8 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/8</td>
-<td class="tally" data-browser="typescript2_6" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/8</td>
+<td class="tally" data-browser="typescript2_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/8</td>
@@ -11926,7 +12085,8 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11998,7 +12158,8 @@ return Object.isFrozen([# 42 #]);
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12070,7 +12231,8 @@ return Object.isSealed({| foo: 42 |});
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12142,7 +12304,8 @@ return Object.isSealed([| 42 |]);
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12222,7 +12385,8 @@ try {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12303,7 +12467,8 @@ try {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12383,7 +12548,8 @@ try {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12464,7 +12630,8 @@ try {
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12536,7 +12703,8 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12613,7 +12781,8 @@ return results.length === 3
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
-<td class="no" data-browser="typescript2_6">No</td>
+<td class="no obsolete" data-browser="typescript2_6">No</td>
+<td class="no" data-browser="typescript2_7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12673,7 +12842,7 @@ return results.length === 3
 <td class="no" data-browser="ios10_3">No</td>
 <td class="no" data-browser="ios11">No</td>
 </tr>
-<tr class="category"><td colspan="70">Strawman (stage 0)</td>
+<tr class="category"><td colspan="71">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12684,7 +12853,8 @@ return results.length === 3
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12758,7 +12928,8 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12831,7 +13002,8 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12903,7 +13075,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12972,7 +13145,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -13045,7 +13219,8 @@ return f();
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13117,7 +13292,8 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13194,7 +13370,8 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13277,7 +13454,8 @@ return target === C.prototype
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13356,7 +13534,8 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13425,7 +13604,8 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13499,7 +13679,8 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13573,7 +13754,8 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13642,7 +13824,8 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -13714,7 +13897,8 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13786,7 +13970,8 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13858,7 +14043,8 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13930,7 +14116,8 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14002,7 +14189,8 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14074,7 +14262,8 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14146,7 +14335,8 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14221,7 +14411,8 @@ passed = true;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14290,7 +14481,8 @@ passed = true;
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14368,7 +14560,8 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14453,7 +14646,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14522,7 +14716,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14596,7 +14791,8 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14671,7 +14867,8 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14731,7 +14928,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="ios10_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="70">Pre-strawman</td>
+<tr class="category"><td colspan="71">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -14742,7 +14939,8 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -14814,7 +15012,8 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14886,7 +15085,8 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14958,7 +15158,8 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15030,7 +15231,8 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15102,7 +15304,8 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15174,7 +15377,8 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15246,7 +15450,8 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15318,7 +15523,8 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15390,7 +15596,8 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
TypeScript 2.7 was released yesterday.  It now supports the Numeric Separators proposal, as stated in the
[release notes](https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/).