### PR TITLE
TypeScript 2.8 released

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -112,7 +112,7 @@
     "family": "TypeScript",
     "platformtype": "compiler",
     "release": "2017-02-22",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -177,6 +177,19 @@
     "family": "TypeScript",
     "platformtype": "compiler",
     "release": "2018-01-31",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "typescript2_8": {
+    "full": "TypeScript 2.8 + core-js 2.5",
+    "short": "Type-<br />Script +<br /><nobr>core-js</nobr>",
+    "family": "TypeScript",
+    "platformtype": "compiler",
+    "release": "2018-03-27",
     "obsolete": false,
     "test_suites": [
       "es6",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -125,12 +125,12 @@
 <th class="platform babel7 compiler unstable" data-browser="babel7"><a href="#babel7" class="browser-name"><abbr title="Babel 7 beta + core-js 2.5">Babel 7 +<br><nobr>core-js</nobr></abbr></a><a href="#babel-optional-note"><sup>[2]</sup></a></th>
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure</abbr></a></th>
 <th class="platform typescript1 compiler obsolete" data-browser="typescript1"><a href="#typescript1" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
-<th class="platform typescript2_2 compiler obsolete" data-browser="typescript2_2"><a href="#typescript2_2" class="browser-name"><abbr title="TypeScript 2.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_3 compiler obsolete" data-browser="typescript2_3"><a href="#typescript2_3" class="browser-name"><abbr title="TypeScript 2.3 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_4 compiler obsolete" data-browser="typescript2_4"><a href="#typescript2_4" class="browser-name"><abbr title="TypeScript 2.4 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_5 compiler obsolete" data-browser="typescript2_5"><a href="#typescript2_5" class="browser-name"><abbr title="TypeScript 2.5 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_6 compiler obsolete" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
-<th class="platform typescript2_7 compiler" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
+<th class="platform typescript2_7 compiler obsolete" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
+<th class="platform typescript2_8 compiler" data-browser="typescript2_8"><a href="#typescript2_8" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
@@ -204,12 +204,12 @@
 <td class="tally unstable" data-browser="babel7" data-tally="1">3/3</td>
 <td class="tally" data-browser="closure" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
@@ -280,12 +280,12 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -356,12 +356,12 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -437,12 +437,12 @@ return true;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -510,12 +510,12 @@ return true;
 <td class="tally unstable" data-browser="babel7" data-tally="1">3/3</td>
 <td class="tally" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
@@ -590,12 +590,12 @@ return [1, 2, 3].includes(1)
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -688,12 +688,12 @@ return 24;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -769,12 +769,12 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -854,12 +854,12 @@ return true;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -943,12 +943,12 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1024,12 +1024,12 @@ return true;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1101,12 +1101,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1179,12 +1179,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1262,12 +1262,12 @@ return passed;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1347,12 +1347,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1422,12 +1422,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally unstable" data-browser="babel7" data-tally="1">4/4</td>
 <td class="tally" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">4/4</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">4/4</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">4/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
@@ -1501,12 +1501,12 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1584,12 +1584,12 @@ return Array.isArray(e)
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1668,12 +1668,12 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1747,12 +1747,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1820,12 +1820,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally unstable" data-browser="babel7" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
@@ -1901,12 +1901,12 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1982,12 +1982,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2055,12 +2055,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally unstable" data-browser="babel7" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
@@ -2131,12 +2131,12 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2207,12 +2207,12 @@ return Math.min(1,2,3,) === 1;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2280,12 +2280,12 @@ return Math.min(1,2,3,) === 1;
 <td class="tally unstable" data-browser="babel7" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally" data-browser="closure" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
@@ -2367,12 +2367,12 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2454,12 +2454,12 @@ p.catch(function(result) {
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2531,12 +2531,12 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="no" data-browser="closure">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2608,12 +2608,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="no" data-browser="closure">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2691,12 +2691,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-async-await-note"><sup>[16]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2776,12 +2776,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2853,12 +2853,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2935,12 +2935,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3012,12 +3012,12 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="no" data-browser="closure">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3099,12 +3099,12 @@ p.then(function(result) {
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3186,12 +3186,12 @@ p.then(function(result) {
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3271,12 +3271,12 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-regenerator-note"><sup>[15]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3349,12 +3349,12 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="no" data-browser="closure">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3425,12 +3425,12 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="no" data-browser="closure">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3510,12 +3510,12 @@ p.then(function(result) {
 <td class="unknown unstable" data-browser="babel7">?</td>
 <td class="no" data-browser="closure">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3583,12 +3583,12 @@ p.then(function(result) {
 <td class="tally unstable" data-browser="babel7" data-tally="0">0/17</td>
 <td class="tally" data-browser="closure" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/17</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/17</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0">0/17</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
@@ -3659,12 +3659,12 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3735,12 +3735,12 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3811,12 +3811,12 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3887,12 +3887,12 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3963,12 +3963,12 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4039,12 +4039,12 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4115,12 +4115,12 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4191,12 +4191,12 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4267,12 +4267,12 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4343,12 +4343,12 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4419,12 +4419,12 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4495,12 +4495,12 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4571,12 +4571,12 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4647,12 +4647,12 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4723,12 +4723,12 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4799,12 +4799,12 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4875,12 +4875,12 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4958,12 +4958,12 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5037,12 +5037,12 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5116,12 +5116,12 @@ return (function(){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5191,12 +5191,12 @@ return (function(){
 <td class="tally unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
@@ -5272,12 +5272,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5354,12 +5354,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5436,12 +5436,12 @@ return true;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5517,12 +5517,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5599,12 +5599,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5681,12 +5681,12 @@ return true;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5764,12 +5764,12 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5847,12 +5847,12 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5931,12 +5931,12 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6012,12 +6012,12 @@ return true;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6092,12 +6092,12 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6175,12 +6175,12 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6258,12 +6258,12 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6342,12 +6342,12 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6423,12 +6423,12 @@ return true;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6503,12 +6503,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6576,12 +6576,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
@@ -6656,12 +6656,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6736,12 +6736,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6821,12 +6821,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6906,12 +6906,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6983,12 +6983,12 @@ return i === 0;
 <td class="no unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7058,12 +7058,12 @@ return i === 0;
 <td class="tally unstable" data-browser="babel7" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
@@ -7135,12 +7135,12 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7213,12 +7213,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7286,12 +7286,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally unstable" data-browser="babel7" data-tally="1">3/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
@@ -7388,12 +7388,12 @@ function check() {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7482,12 +7482,12 @@ function check() {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7578,12 +7578,12 @@ function check() {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7661,12 +7661,12 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7738,12 +7738,12 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
-<td class="unknown obsolete" data-browser="typescript2_2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_3">?</td>
 <td class="unknown obsolete" data-browser="typescript2_4">?</td>
 <td class="unknown obsolete" data-browser="typescript2_5">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
-<td class="unknown" data-browser="typescript2_7">?</td>
+<td class="unknown obsolete" data-browser="typescript2_7">?</td>
+<td class="unknown" data-browser="typescript2_8">?</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7821,12 +7821,12 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7898,12 +7898,12 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7975,12 +7975,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8048,12 +8048,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally unstable" data-browser="babel7" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
@@ -8131,12 +8131,12 @@ iterator.next().then(function(step){
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8224,12 +8224,12 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -131,12 +131,12 @@
 <th class="platform babel7 compiler unstable" data-browser="babel7"><a href="#babel7" class="browser-name"><abbr title="Babel 7 beta + core-js 2.5">Babel 7 +<br><nobr>core-js</nobr></abbr></a><a href="#babel-optional-note"><sup>[2]</sup></a></th>
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure</abbr></a></th>
 <th class="platform typescript1 compiler obsolete" data-browser="typescript1"><a href="#typescript1" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
-<th class="platform typescript2_2 compiler obsolete" data-browser="typescript2_2"><a href="#typescript2_2" class="browser-name"><abbr title="TypeScript 2.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_3 compiler obsolete" data-browser="typescript2_3"><a href="#typescript2_3" class="browser-name"><abbr title="TypeScript 2.3 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_4 compiler obsolete" data-browser="typescript2_4"><a href="#typescript2_4" class="browser-name"><abbr title="TypeScript 2.4 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_5 compiler obsolete" data-browser="typescript2_5"><a href="#typescript2_5" class="browser-name"><abbr title="TypeScript 2.5 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_6 compiler obsolete" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
-<th class="platform typescript2_7 compiler" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
+<th class="platform typescript2_7 compiler obsolete" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
+<th class="platform typescript2_8 compiler" data-browser="typescript2_8"><a href="#typescript2_8" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a></th>
 <th class="platform edge13 desktop obsolete" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a></th>
@@ -208,12 +208,12 @@
 <td class="tally unstable" data-browser="babel7" data-tally="1">4/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">4/4</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">4/4</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">4/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -282,12 +282,12 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -356,12 +356,12 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -430,12 +430,12 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -504,12 +504,12 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -575,12 +575,12 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally unstable" data-browser="babel7" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -651,12 +651,12 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -732,12 +732,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -816,12 +816,12 @@ return a === &apos;1a2b&apos;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -887,12 +887,12 @@ return a === &apos;1a2b&apos;
 <td class="tally unstable" data-browser="babel7" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
@@ -964,12 +964,12 @@ return new C().x === &apos;x&apos;;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1047,12 +1047,12 @@ return new C(42).x() === 42;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1127,12 +1127,12 @@ return new C().x() === 42;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1198,12 +1198,12 @@ return new C().x() === 42;
 <td class="tally unstable" data-browser="babel7" data-tally="0">0/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/7</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/7</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
@@ -1274,12 +1274,12 @@ return fn + &apos;&apos; === str;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1349,12 +1349,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1424,12 +1424,12 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes obsolete" data-browser="edge13">Yes</td>
@@ -1499,12 +1499,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1574,12 +1574,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1649,12 +1649,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1724,12 +1724,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1795,12 +1795,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally unstable" data-browser="babel7" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -1869,12 +1869,12 @@ return [1, [2, 3], [4, [5, 6]]].flatten().join(&apos;&apos;) === &apos;12345,6&a
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -1945,12 +1945,12 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2016,12 +2016,12 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="tally unstable" data-browser="babel7" data-tally="1">3/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
@@ -2096,12 +2096,12 @@ return false;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2177,12 +2177,12 @@ return false;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2263,12 +2263,12 @@ return it.next().value;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2338,12 +2338,12 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2420,12 +2420,12 @@ return result === &apos;tromple&apos;;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2491,12 +2491,12 @@ return result === &apos;tromple&apos;;
 <td class="tally unstable" data-browser="babel7" data-tally="0">0/1</td>
 <td class="tally" data-browser="closure" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">1/1</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">1/1</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/1</td>
@@ -2573,12 +2573,12 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no unstable" data-browser="babel7">No<a href="#babel-decorators-legacy-note"><sup>[12]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2651,12 +2651,12 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2722,12 +2722,12 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally unstable" data-browser="babel7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/2</td>
@@ -2799,12 +2799,12 @@ return C.x === &apos;x&apos;;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
-<td class="yes" data-browser="typescript2_7">Yes</td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes</td>
+<td class="yes" data-browser="typescript2_8">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2879,12 +2879,12 @@ return new C().x() === 42;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -2950,12 +2950,12 @@ return new C().x() === 42;
 <td class="tally unstable" data-browser="babel7" data-tally="1">4/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/4</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/4</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/4</td>
@@ -3030,12 +3030,12 @@ try {
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3114,12 +3114,12 @@ try {
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3193,12 +3193,12 @@ try {
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3272,12 +3272,12 @@ try {
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3346,12 +3346,12 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3425,12 +3425,12 @@ return do {
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3496,12 +3496,12 @@ return do {
 <td class="tally unstable" data-browser="babel7" data-tally="0">0/57</td>
 <td class="tally" data-browser="closure" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/57</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/57</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0">0/57</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.017543859649122806">0/57</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0" data-flagged-tally="0.543859649122807">0/57</td>
@@ -3578,12 +3578,12 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="edge12">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -3652,12 +3652,12 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -3726,12 +3726,12 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -3800,12 +3800,12 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -3874,12 +3874,12 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -3948,12 +3948,12 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4022,12 +4022,12 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4096,12 +4096,12 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4170,12 +4170,12 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4244,12 +4244,12 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4318,12 +4318,12 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4394,12 +4394,12 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -4470,12 +4470,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -4546,12 +4546,12 @@ return simdSmallIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4622,12 +4622,12 @@ return simdBoolIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4698,12 +4698,12 @@ return simdBoolTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4774,12 +4774,12 @@ return simdBoolTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -4850,12 +4850,12 @@ return simdAllTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -4926,12 +4926,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5002,12 +5002,12 @@ return simdAllTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5078,12 +5078,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5154,12 +5154,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5230,12 +5230,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5306,12 +5306,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5382,12 +5382,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5458,12 +5458,12 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5534,12 +5534,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5610,12 +5610,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5686,12 +5686,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5762,12 +5762,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5838,12 +5838,12 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -5914,12 +5914,12 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -5990,12 +5990,12 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6066,12 +6066,12 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6142,12 +6142,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6218,12 +6218,12 @@ return simdBoolTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6294,12 +6294,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6370,12 +6370,12 @@ return simdBoolIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6446,12 +6446,12 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6522,12 +6522,12 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6598,12 +6598,12 @@ return simdAllTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6674,12 +6674,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6750,12 +6750,12 @@ return simdIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6826,12 +6826,12 @@ return simdIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -6902,12 +6902,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -6978,12 +6978,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7054,12 +7054,12 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7130,12 +7130,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7206,12 +7206,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7282,12 +7282,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7358,12 +7358,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7434,12 +7434,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7510,12 +7510,12 @@ return simdSmallIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7586,12 +7586,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged obsolete" data-browser="edge13">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
@@ -7662,12 +7662,12 @@ return simdBoolIntTypes.every(function(type){
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7738,12 +7738,12 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7812,12 +7812,12 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7889,12 +7889,12 @@ return typeof Realm === &quot;function&quot;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -7960,12 +7960,12 @@ return typeof Realm === &quot;function&quot;
 <td class="tally unstable" data-browser="babel7" data-tally="1">7/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">7/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/7</td>
@@ -8034,12 +8034,12 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8108,12 +8108,12 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8182,12 +8182,12 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8266,12 +8266,12 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8341,12 +8341,12 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8415,12 +8415,12 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8489,12 +8489,12 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8564,12 +8564,12 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8641,12 +8641,12 @@ return Math.signbit(-0) === false
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8712,12 +8712,12 @@ return Math.signbit(-0) === false
 <td class="tally unstable" data-browser="babel7" data-tally="1">7/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">7/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/7</td>
@@ -8788,12 +8788,12 @@ return Math.clamp(2, 4, 6) === 4
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8862,12 +8862,12 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -8937,12 +8937,12 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9011,12 +9011,12 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9085,12 +9085,12 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9160,12 +9160,12 @@ return Math.radians(90) === Math.PI / 2
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9234,12 +9234,12 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9305,12 +9305,12 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally unstable" data-browser="babel7" data-tally="1">7/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">7/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/7</td>
@@ -9379,12 +9379,12 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9453,12 +9453,12 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9529,12 +9529,12 @@ return score === 1;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9610,12 +9610,12 @@ Promise.try(function() {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9691,12 +9691,12 @@ Promise.try(function() {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9772,12 +9772,12 @@ Promise.try(function() {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9853,12 +9853,12 @@ Promise.try(function() {
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -9924,12 +9924,12 @@ Promise.try(function() {
 <td class="tally unstable" data-browser="babel7" data-tally="1">8/8</td>
 <td class="tally" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">8/8</td>
-<td class="tally" data-browser="typescript2_7" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="1">8/8</td>
+<td class="tally" data-browser="typescript2_8" data-tally="1">8/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/8</td>
@@ -10001,12 +10001,12 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10080,12 +10080,12 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10157,12 +10157,12 @@ return C.has(A) + C.has(B);
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10234,12 +10234,12 @@ return C.has(3) + C.has(4);
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10311,12 +10311,12 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10390,12 +10390,12 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10467,12 +10467,12 @@ return C.has(A) + C.has(B);
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10544,12 +10544,12 @@ return C.has(A) + C.has(B);
 <td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10630,12 +10630,12 @@ return result === &apos;Hello, hello!&apos;;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10708,12 +10708,12 @@ return 123i === &apos;string123number123&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10779,12 +10779,12 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally unstable" data-browser="babel7" data-tally="1">3/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/3</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/3</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/3</td>
@@ -10855,12 +10855,12 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -10931,12 +10931,12 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11007,12 +11007,12 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11085,12 +11085,12 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="yes unstable" data-browser="babel7">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11156,12 +11156,12 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally unstable" data-browser="babel7" data-tally="0">0/12</td>
 <td class="tally" data-browser="closure" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/12</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/12</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/12</td>
@@ -11234,12 +11234,12 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11312,12 +11312,12 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11390,12 +11390,12 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11468,12 +11468,12 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11546,12 +11546,12 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11624,12 +11624,12 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11702,12 +11702,12 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11783,12 +11783,12 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11862,12 +11862,12 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -11940,12 +11940,12 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12018,12 +12018,12 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12096,12 +12096,12 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12167,12 +12167,12 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally unstable" data-browser="babel7" data-tally="0">0/8</td>
 <td class="tally" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="typescript2_2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_5" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/8</td>
-<td class="tally" data-browser="typescript2_7" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/8</td>
+<td class="tally" data-browser="typescript2_8" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge13" data-tally="0">0/8</td>
@@ -12241,12 +12241,12 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12315,12 +12315,12 @@ return Object.isFrozen([# 42 #]);
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12389,12 +12389,12 @@ return Object.isSealed({| foo: 42 |});
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12463,12 +12463,12 @@ return Object.isSealed([| 42 |]);
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12545,12 +12545,12 @@ try {
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12628,12 +12628,12 @@ try {
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12710,12 +12710,12 @@ try {
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12793,12 +12793,12 @@ try {
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12867,12 +12867,12 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -12946,12 +12946,12 @@ return results.length === 3
 <td class="no unstable" data-browser="babel7">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
-<td class="no obsolete" data-browser="typescript2_2">No</td>
 <td class="no obsolete" data-browser="typescript2_3">No</td>
 <td class="no obsolete" data-browser="typescript2_4">No</td>
 <td class="no obsolete" data-browser="typescript2_5">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
-<td class="no" data-browser="typescript2_7">No</td>
+<td class="no obsolete" data-browser="typescript2_7">No</td>
+<td class="no" data-browser="typescript2_8">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no obsolete" data-browser="edge13">No</td>
@@ -13019,12 +13019,12 @@ return results.length === 3
 <td class="tally unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13095,12 +13095,12 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13170,12 +13170,12 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13244,12 +13244,12 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13315,12 +13315,12 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -13390,12 +13390,12 @@ return f();
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13464,12 +13464,12 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13543,12 +13543,12 @@ return Array.isArray(arr)
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13628,12 +13628,12 @@ return target === C.prototype
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13709,12 +13709,12 @@ return (@inverse function(it){
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13780,12 +13780,12 @@ return (@inverse function(it){
 <td class="tally unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13856,12 +13856,12 @@ return Reflect.isCallable(function(){})
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13932,12 +13932,12 @@ return Reflect.isConstructor(function(){})
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14003,12 +14003,12 @@ return Reflect.isConstructor(function(){})
 <td class="tally unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -14077,12 +14077,12 @@ return typeof Zone == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14151,12 +14151,12 @@ return &apos;current&apos; in Zone;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14225,12 +14225,12 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14299,12 +14299,12 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14373,12 +14373,12 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14447,12 +14447,12 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14521,12 +14521,12 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14598,12 +14598,12 @@ passed = true;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14669,12 +14669,12 @@ passed = true;
 <td class="tally unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14749,12 +14749,12 @@ return (function f(n){
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14836,12 +14836,12 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14907,12 +14907,12 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14983,12 +14983,12 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15060,12 +15060,12 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15133,12 +15133,12 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -15207,12 +15207,12 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15281,12 +15281,12 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15355,12 +15355,12 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15429,12 +15429,12 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15503,12 +15503,12 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15577,12 +15577,12 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15651,12 +15651,12 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15725,12 +15725,12 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15799,12 +15799,12 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
TypeScript 2.8 was released yesterday.  I didn't actually run any test, as there are no changes on the JS side according to the [release notes](https://blogs.msdn.microsoft.com/typescript/2018/03/27/announcing-typescript-2-8/).  All the breaking changes mentioned there refer to specific TypeScript stuff, they shouldn't break any pure JS code.