### PR TITLE
Updating esnext results for Chrome 66

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2087,7 +2087,7 @@ exports.tests = [
       res: {
         ie11: false,
         firefox2: false,
-        chrome67: chrome.harmony,
+        chrome66: chrome.harmony,
         opera10_50: false,
         duktape2_0: false,
       }
@@ -2106,7 +2106,7 @@ exports.tests = [
       res: {
         ie11: false,
         firefox2: false,
-        chrome67: chrome.harmony,
+        chrome66: chrome.harmony,
         opera10_50: false,
         duktape2_0: false,
       }

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -932,7 +932,7 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="chrome63" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome64" data-tally="0">0/3</td>
 <td class="tally" data-browser="chrome65" data-tally="0" data-flagged-tally="0.3333333333333333">0/3</td>
-<td class="tally" data-browser="chrome66" data-tally="0" data-flagged-tally="0.3333333333333333">0/3</td>
+<td class="tally" data-browser="chrome66" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally unstable" data-browser="chrome67" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally unstable" data-browser="chrome68" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally obsolete" data-browser="safari9" data-tally="0">0/3</td>
@@ -1094,7 +1094,7 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
 <td class="no" data-browser="chrome65">No</td>
-<td class="no" data-browser="chrome66">No</td>
+<td class="no flagged" data-browser="chrome66">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no flagged unstable" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
@@ -1175,7 +1175,7 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
 <td class="no" data-browser="chrome65">No</td>
-<td class="no" data-browser="chrome66">No</td>
+<td class="no flagged" data-browser="chrome66">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no flagged unstable" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>


### PR DESCRIPTION
I have found some more tests that pass on Chrome 66 with the --js-flags="--harmony" flag.
This is a followup to #1275 .