### PR TITLE
remove all uses of document.write

### DIFF
--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -145,7 +145,11 @@
 				var thisScript = document.currentScript || document.scripts[document.scripts.length-1];
 				var pre = thisScript.parentNode;
 
-				pre.textContent = pre.innerText = "" + __createIterableObject;
+                if ("textContent" in pre) {
+                  pre.textContent = "" + __createIterableObject;
+                } else {
+                  pre.innerText = "" + __createIterableObject;
+                }
 			</script>
 		</pre>
       </div>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -140,7 +140,14 @@
     <div id="footnotes">
       <div id="create-iterable-object">
         <code>__createIterableObject()</code>, used in the numerous "generic iterables" tests, is defined as:
-        <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
+		<pre>
+			<script>
+				var thisScript = document.currentScript || document.scripts[document.scripts.length-1];
+				var pre = thisScript.parentNode;
+
+				pre.textContent = pre.innerText = "" + __createIterableObject;
+			</script>
+		</pre>
       </div>
       <!-- FOOTNOTES -->
     </div>

--- a/master.css
+++ b/master.css
@@ -172,6 +172,10 @@ table.one-selected td.selected {
   border-right: solid 5px #eee;
 }
 
+td:nth-of-type(2).current {
+    outline: #aaf solid 3px;
+}
+
 /* yes/no grid text colors */
 .yes a,
 .tally a,
@@ -204,6 +208,7 @@ td.hover {
     filter:opacity(0.75) brightness(1.1);
     -webkit-filter:opacity(0.75) brightness(1.1);
 }
+
 tr:hover td.obsolete,
 td.hover.obsolete,
 tr:hover td.unstable,

--- a/master.js
+++ b/master.js
@@ -29,8 +29,6 @@ window.test = function(expression) {
   var td = thisScript.parentNode;
   var tr = td.parentNode;
 
-  //document.write('<td class="' + result.toLowerCase() + ' current">' + result + '</td><td></td>');
-
   // Insert the two new TD elements after the one that contains the SCRIPT
   td = tr.insertBefore(document.createElement("td"), td.nextSibling);
   td.className = result.toLowerCase() + " current";
@@ -38,9 +36,6 @@ window.test = function(expression) {
 
   tr.insertBefore(document.createElement("td"), td.nextSibling);
 };
-
-// Moved to 'master.css'
-//document.write('<style>td:nth-of-type(2) { outline: #aaf solid 3px; }</style>');
 
 // For async tests, this returned function is used to set results
 // instead of returning true/false.

--- a/master.js
+++ b/master.js
@@ -5,6 +5,11 @@ var _gaq = [
 ];
 // jshint ignore:end
 
+
+if (!document.scripts) { // Create "live list" for all scripts if it doesn't exist
+  document.scripts = document.getElementsByTagName("script");
+}
+
 (function() {
   var ga = document.createElement('script');
   ga.type = 'text/javascript';
@@ -17,10 +22,25 @@ var _gaq = [
 
 window.test = function(expression) {
   var result = (typeof expression === "string" ? expression : !!expression ? 'Yes' : 'No');
-  document.write('<td class="' + result.toLowerCase() + ' current">' + result + '</td><td></td>');
+
+  // Last SCRIPT in the document is the one currently executing
+  var thisScript = document.currentScript || document.scripts[document.scripts.length-1];
+
+  var td = thisScript.parentNode;
+  var tr = td.parentNode;
+
+  //document.write('<td class="' + result.toLowerCase() + ' current">' + result + '</td><td></td>');
+
+  // Insert the two new TD elements after the one that contains the SCRIPT
+  td = tr.insertBefore(document.createElement("td"), td.nextSibling);
+  td.className = result.toLowerCase() + " current";
+  td.textContent = td.innerText = result;
+
+  tr.insertBefore(document.createElement("td"), td.nextSibling);
 };
 
-document.write('<style>td:nth-of-type(2) { outline: #aaf solid 3px; }</style>');
+// Moved to 'master.css'
+//document.write('<style>td:nth-of-type(2) { outline: #aaf solid 3px; }</style>');
 
 // For async tests, this returned function is used to set results
 // instead of returning true/false.

--- a/master.js
+++ b/master.js
@@ -32,7 +32,12 @@ window.test = function(expression) {
   // Insert the two new TD elements after the one that contains the SCRIPT
   td = tr.insertBefore(document.createElement("td"), td.nextSibling);
   td.className = result.toLowerCase() + " current";
-  td.textContent = td.innerText = result;
+
+  if ("textContent" in td) {
+    td.textContent = result;
+  } else {
+    td.innerText = result;
+  }
 
   tr.insertBefore(document.createElement("td"), td.nextSibling);
 };


### PR DESCRIPTION
This commit updates the scripts that used 'document.write' to
instead use DOM creation methods.

The call that wrote a single CSS rules was removed with the rule
being added to 'master.css'.

The 'document.write' calls were always in the currently executing
script, so the 'document.currentScript' or the last script in
'document.scripts' (or its polyfill, which was added) was used to
obtain the proper element to target with the new nodes.

The original structure of the HTML was kept.

Resolves #1289