### PR TITLE
`position: sticky;` is supported correctly in Firefox since version 32

### DIFF
--- a/master.js
+++ b/master.js
@@ -45,17 +45,16 @@ $(function() {
   var table = $('#table-wrapper');
   var currentBrowserSelector = ":nth-of-type(2)";
   var thead = $('thead');
-  
-  if (thead.css('position') === "-webkit-sticky") {
-    // Remove floatThead when native position:sticky is usable.
-    // Currently, only Safari (which floatThead incidentally does not support),
-    // and its -webkit-sticky prefix, works correctly with <thead>.
-    $.fn.floatThead = function() { return this };
-  }
 
   // position: sticky is implemented in chrome but buggy. currently makes the background transparent sometimes
   if (thead.css('position') === "sticky" && window.chrome) {
     thead.css('position', 'static');
+  }
+
+  if (thead.css('position') === "sticky" ||
+    thead.css('position') === "-webkit-sticky") {
+    // Remove floatThead when native position:sticky is usable.
+    $.fn.floatThead = function() { return this };
   }
 
   var initFloatingHeaders = function() {


### PR DESCRIPTION
See the MDN article [on the CSS `position` property](https://developer.mozilla.org/docs/Web/CSS/position#Browser_compatibility) for details.

Fixes #1139