### PR TITLE
remove invocations of .call and .apply with a host object

### DIFF
--- a/master.js
+++ b/master.js
@@ -27,11 +27,15 @@ document.write('<style>td:nth-of-type(2) { outline: #aaf solid 3px; }</style>');
 function makeAsyncPassedFn(className, textContent) {
   return function(rowNum) {
     return function() {
-      var elem = $("#table-wrapper tbody tr:not(.category)").eq(+rowNum).children(".current")[0];
-      elem.className = className;
-      elem.textContent = textContent;
+      var elem = $("#table-wrapper tbody tr:not(.category)")
+        .eq(+rowNum)
+        .children(".current")
+        .first()
+        .prop("className", className)
+        .text(textContent);
+
       if (window.__updateHeaderTotal) {
-        $(elem).parent().prevAll('.supertest').first().each(window.__updateSupertest);
+        elem.parent().prevAll('.supertest').first().each(window.__updateSupertest);
         $('th.current').each(window.__updateHeaderTotal);
       }
     };

--- a/master.js
+++ b/master.js
@@ -466,7 +466,7 @@ $(function() {
     if (!ordering[sortAttr]) {
       // Sort the platforms
 
-      var cells = [].slice.call($('th.platform')).sort(function(a, b) {
+      var cells = $('th.platform').toArray().sort(function(a, b) {
         return sortSpec.order * (parseFloat(b.getAttribute(sortAttr)) - parseFloat(a.getAttribute(sortAttr)));
       });
       ordering[sortAttr] = $.map(cells, platformOf);
@@ -482,7 +482,7 @@ $(function() {
     // Now sort the columns using the comparison function
     table.detach().find('tr').each(function(i, row) {
 
-      var cells = [].slice.call(row.cells, 3).sort(comparator);
+      var cells = $(row.cells).slice(3).toArray().sort(comparator);
 
       for (var j = 0, jlen = cells.length; j < jlen; j++) {
         row.appendChild(cells[j]);


### PR DESCRIPTION
Old IE would not accept host objects in the 'thisArg' position
of Function.prototype.call and ...apply. This commit uses toArray
instead.

One call passed a jQuery object, which should work, but it too
was updated for the sake of consistency.