### PR TITLE
use scheme-less url when fetching jquery

### DIFF
--- a/es5/index.html
+++ b/es5/index.html
@@ -7,7 +7,7 @@
     <title>ECMAScript 5 compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/es5/skeleton.html
+++ b/es5/skeleton.html
@@ -7,7 +7,7 @@
     <title>ECMAScript 5 compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};


### PR DESCRIPTION
IE6 seems to have trouble loading jquery from the CDN with 'https'
when the page is 'http'. This changes the 'src' to a scheme-less
url so that it properly loads.