### PR TITLE
Update to jQuery 1.12

### DIFF
--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -7,7 +7,7 @@
     <title>ECMAScript 2016+ compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/es2016plus/skeleton.html
+++ b/es2016plus/skeleton.html
@@ -7,7 +7,7 @@
     <title>ECMAScript 2016+ compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/es5/index.html
+++ b/es5/index.html
@@ -7,7 +7,7 @@
     <title>ECMAScript 5 compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/es5/skeleton.html
+++ b/es5/skeleton.html
@@ -7,7 +7,7 @@
     <title>ECMAScript 5 compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -7,7 +7,7 @@
     <title>ECMAScript 6 compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -7,7 +7,7 @@
     <title>ECMAScript Internationalisation compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/esintl/skeleton.html
+++ b/esintl/skeleton.html
@@ -7,7 +7,7 @@
     <title>ECMAScript Internationalisation compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -7,7 +7,7 @@
     <title>ECMAScript Next compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/esnext/skeleton.html
+++ b/esnext/skeleton.html
@@ -7,7 +7,7 @@
     <title>ECMAScript Next compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -7,7 +7,7 @@
     <title>ECMAScript extensions compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};

--- a/non-standard/skeleton.html
+++ b/non-standard/skeleton.html
@@ -7,7 +7,7 @@
     <title>ECMAScript extensions compatibility table</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,600">
     <link rel="stylesheet" href="../master.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="../master.js"></script>
     <script>
       var __script_executed = {};


### PR DESCRIPTION
Updating the jQuery to version 1.12.4.  It is supposed to be fully compatible with the version 1.11.1, which is currently linked.
The change logs mention many IE corrections, but I didn't notice any improvement.  What I did notice was faster initial rendering on Firefox, specially on the ES6 tab.