### PR TITLE
Updating Firefox and Safari support for 'Array.prototype.{flat, flatMap}'

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2704,17 +2704,17 @@ exports.tests = [
         firefox2: false,
         firefox58: false,
         firefox59: {
-          val: 'false',
+          val: false,
           note_id: 'ffox-flatten',
-          note_html: 'Older Firefox Nightly builds support only the obsolete draft name <code>Array.prototype.flatten()</code>.'
+          note_html: 'Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.'
         },
-        firefox62: firefox.nightly,
+        firefox62: true,
         chrome69: true,
         opera10_50: false,
-        safaritp: {
-          val: 'false',
+        safari12: {
+          val: false,
           note_id: 'safari-flatten',
-          note_html: 'Safari TP supports only the obsolete draft name <code>Array.prototype.flatten()</code>.'
+          note_html: 'Older Safari and Webkit builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.'
         },
         duktape2_2: false,
       }
@@ -2734,6 +2734,7 @@ exports.tests = [
         firefox2: false,
         firefox58: false,
         firefox59: firefox.nightly,
+        firefox62: true,
         chrome69: true,
         opera10_50: false,
         safari12: true,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2149,7 +2149,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="firefox59" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox60" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox61" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="firefox62" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="firefox62" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome59" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome60" data-tally="0">0/2</td>
@@ -2227,7 +2227,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no" data-browser="firefox59">No<a href="#ffox-flatten-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[10]</sup></a></td>
 <td class="no unstable" data-browser="firefox61">No<a href="#ffox-flatten-note"><sup>[10]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
@@ -2245,7 +2245,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="safari10_1">No</td>
 <td class="no" data-browser="safari11">No</td>
 <td class="no" data-browser="safari11_1">No</td>
-<td class="no unstable" data-browser="safari12">No</td>
+<td class="no unstable" data-browser="safari12">No<a href="#safari-flatten-note"><sup>[11]</sup></a></td>
 <td class="no unstable" data-browser="safaritp">No<a href="#safari-flatten-note"><sup>[11]</sup></a></td>
 <td class="no unstable" data-browser="webkit">No<a href="#safari-flatten-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
@@ -2307,7 +2307,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
@@ -19060,7 +19060,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="babel-core-js-note">  <sup>[3]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[4]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="firefox-nightly-note">  <sup>[5]</sup> The feature is available only in Firefox Nightly builds.</p><p id="ffox-global-property-note">  <sup>[6]</sup> The feature was disabled due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1325907">some</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1326032">compatibility</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1328218">issues</a>.</p><p id="wk-global-property-note">  <sup>[7]</sup> The feature was disabled due to <a href="https://bugs.webkit.org/show_bug.cgi?id=165171">compatibility issues</a>.</p><p id="chrome-harmony-note">  <sup>[8]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="flatten-compat-issue-note">  <sup>[9]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[10]</sup> Older Firefox Nightly builds support only the obsolete draft name <code>Array.prototype.flatten()</code>.</p><p id="safari-flatten-note">  <sup>[11]</sup> Safari TP supports only the obsolete draft name <code>Array.prototype.flatten()</code>.</p><p id="babel-decorators-legacy-note">  <sup>[12]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="edge-experimental-flag-note">  <sup>[13]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="chrome-simd-note">  <sup>[14]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-simd&quot;</code> flag</p><p id="ffox-pipeline-note">  <sup>[15]</sup> Requires the <code>--enable-pipeline-operator</code> compile option.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="babel-core-js-note">  <sup>[3]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[4]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="firefox-nightly-note">  <sup>[5]</sup> The feature is available only in Firefox Nightly builds.</p><p id="ffox-global-property-note">  <sup>[6]</sup> The feature was disabled due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1325907">some</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1326032">compatibility</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1328218">issues</a>.</p><p id="wk-global-property-note">  <sup>[7]</sup> The feature was disabled due to <a href="https://bugs.webkit.org/show_bug.cgi?id=165171">compatibility issues</a>.</p><p id="chrome-harmony-note">  <sup>[8]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="flatten-compat-issue-note">  <sup>[9]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[10]</sup> Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p><p id="safari-flatten-note">  <sup>[11]</sup> Older Safari and Webkit builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p><p id="babel-decorators-legacy-note">  <sup>[12]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="edge-experimental-flag-note">  <sup>[13]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="chrome-simd-note">  <sup>[14]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-simd&quot;</code> flag</p><p id="ffox-pipeline-note">  <sup>[15]</sup> Requires the <code>--enable-pipeline-operator</code> compile option.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>


### PR DESCRIPTION
Updating Firefox results according to https://bugzilla.mozilla.org/show_bug.cgi?id=1435813
The Safari results were left of on the Safari 12 beta patch #1307.