### PR TITLE
Make the test for Misc > Proxy get > RegExp#flags less fragile.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -9649,9 +9649,9 @@ exports.tests = [
         var get = [];
         var p = new Proxy({}, { get: function(o, k) { get.push(k); return o[k]; }});
         Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);
-        return get.indexOf('global') !== -1 &&
-               get.indexOf('ignoreCase') !== -1 &&
-               get.indexOf('multiline') !== -1;
+        return get.indexOf('global') === 0 &&
+               get.indexOf('ignoreCase') === 1 &&
+               get.indexOf('multiline') === 2;
       */},
       res: {
         firefox2: false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -9646,12 +9646,22 @@ exports.tests = [
       name: 'RegExp.prototype.flags',
       exec: function() {/*
         // RegExp.prototype.flags -> Get -> [[Get]]
-        var get = [];
-        var p = new Proxy({}, { get: function(o, k) { get.push(k); return o[k]; }});
+        var expected = [];
+        // Sorted alphabetically by shortname – "gumsuy".
+        if ('global' in RegExp.prototype) expected.push('global');
+        if ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');
+        if ('multiline' in RegExp.prototype) expected.push('multiline');
+        if ('dotAll' in RegExp.prototype) expected.push('dotAll');
+        if ('unicode' in RegExp.prototype) expected.push('unicode');
+        if ('sticky' in RegExp.prototype) expected.push('sticky');
+        var actual = [];
+        var p = new Proxy({}, { get: function(o, k) { actual.push(k); return o[k]; }});
         Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);
-        return get.indexOf('global') === 0 &&
-               get.indexOf('ignoreCase') === 1 &&
-               get.indexOf('multiline') === 2;
+        if (expected.length !== actual.length) return false;
+        for (var i = 0; i < expected.length; i++) {
+          if (expected[i] !== actual[i]) return false;
+        }
+        return true;
       */},
       res: {
         firefox2: false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -9649,7 +9649,9 @@ exports.tests = [
         var get = [];
         var p = new Proxy({}, { get: function(o, k) { get.push(k); return o[k]; }});
         Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);
-        return get + '' === "global,ignoreCase,multiline,unicode,sticky";
+        return get.indexOf('global') !== -1 &&
+               get.indexOf('ignoreCase') !== -1 &&
+               get.indexOf('multiline') !== -1;
       */},
       res: {
         firefox2: false,


### PR DESCRIPTION
Rather than comparing an array by converting it to a string, tests the array for inclusion of well-known elements.

This allows correct detection of the feature on recent versions of Node (resolves #1208) and Chrome.