### PR TITLE
Add results for GraalVM JavaScript

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -39,6 +39,7 @@ exports.tests = [
           chrome52: true,
           safari10_1: true,
           duktape2_0: true,
+          graalvm: true,
         }
       },
       {
@@ -62,6 +63,7 @@ exports.tests = [
           chrome52: true,
           safari10_1: true,
           duktape2_0: true,
+          graalvm: true,
         }
       },
       {
@@ -86,6 +88,7 @@ exports.tests = [
           chrome52: true,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
     ],
@@ -123,6 +126,7 @@ exports.tests = [
           edge14: true,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -154,6 +158,7 @@ exports.tests = [
           edge14: true,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -185,6 +190,7 @@ exports.tests = [
           opera10_50: false,
           safari10: true,
           duktape2_0: false,
+          graalvm: true,
         },
       },
       {
@@ -206,6 +212,7 @@ exports.tests = [
           chrome54: true,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         },
       },
     ],
@@ -240,6 +247,7 @@ exports.tests = [
           firefox43: true,
           opera10_50: false,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -282,6 +290,7 @@ exports.tests = [
           firefox43: true,
           opera10_50: false,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -306,6 +315,7 @@ exports.tests = [
           opera10_50: false,
           safari10: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
     ],
@@ -344,6 +354,7 @@ exports.tests = [
           node8: true,
           safari10: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -374,6 +385,7 @@ exports.tests = [
           node8: true,
           safari10: true,
           duktape2_0: false,
+          graalvm: true,
         }
       }
     ]
@@ -405,6 +417,7 @@ exports.tests = [
           node8: true,
           safari10: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -427,6 +440,7 @@ exports.tests = [
           node8: true,
           safari10: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
     ],
@@ -471,6 +485,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -504,6 +519,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -528,6 +544,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -551,6 +568,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         },
       },
       {
@@ -581,6 +599,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: false,
         }
       },
       {
@@ -612,6 +631,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: false,
         }
       },
       {
@@ -635,6 +655,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -663,6 +684,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -686,6 +708,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -719,6 +742,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -752,6 +776,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -783,6 +808,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -808,6 +834,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         },
       },
       {
@@ -830,6 +857,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         },
       },
       {
@@ -862,6 +890,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
+          graalvm: true,
         },
       },
     ]
@@ -913,6 +942,7 @@ exports.tests = [
           },
           safaritp: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -937,6 +967,7 @@ exports.tests = [
           safari11: { val: false, note_id: 'sf-shared-memory-spectre' },
           safaritp: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -964,6 +995,7 @@ exports.tests = [
           safari11: { val: false, note_id: 'sf-shared-memory-spectre' },
           safaritp: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -990,6 +1022,7 @@ exports.tests = [
           safari11: { val: false, note_id: 'sf-shared-memory-spectre' },
           safaritp: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1016,6 +1049,7 @@ exports.tests = [
           safari11: { val: false, note_id: 'sf-shared-memory-spectre' },
           safaritp: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1043,6 +1077,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1070,6 +1105,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1097,6 +1133,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1124,6 +1161,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1151,6 +1189,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1178,6 +1217,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1205,6 +1245,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1232,6 +1273,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1259,6 +1301,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1286,6 +1329,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1313,6 +1357,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -1340,6 +1385,7 @@ exports.tests = [
           safari10_1: true,
           safari11_1: { val: false, note_id: 'sf-shared-memory-spectre' },
           duktape2_0: false,
+          graalvm: true,
         }
       }
     ]
@@ -1375,6 +1421,7 @@ exports.tests = [
       chrome50: true,
       safari10: true,
       duktape2_0: false,
+          graalvm: true,
     }
   },
   {
@@ -1417,6 +1464,7 @@ exports.tests = [
       node4: true,
       safari10: true,
       duktape2_0: false,
+          graalvm: true,
     }
   },
   {
@@ -1447,6 +1495,7 @@ exports.tests = [
       chrome47: true,
       safari10: true,
       duktape2_0: false,
+          graalvm: true,
     }
   },
   {
@@ -1478,6 +1527,7 @@ exports.tests = [
       safari10_1: true,
       typescript1: true,
       duktape2_0: false,
+          graalvm: true,
     }
   },
   {
@@ -1509,6 +1559,7 @@ exports.tests = [
       chrome49: true,
       safari10_1: true,
       duktape2_0: false,
+          graalvm: true,
     }
   },
   {
@@ -1544,6 +1595,7 @@ exports.tests = [
       chrome50: true,
       safari10: true,
       duktape2_0: true,
+      graalvm: true,
     },
   },
   {
@@ -1572,6 +1624,7 @@ exports.tests = [
       edge14: true,
       safari10: true,
       duktape2_0: false,
+      graalvm: true,
     },
   },
   {
@@ -1606,6 +1659,7 @@ exports.tests = [
         ios5_1: true,
         duktape2_0: false,
         duktape2_2: true,
+        graalvm: true,
       }
     },
       {
@@ -1634,6 +1688,7 @@ exports.tests = [
           android4_0: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         }
       },
       {
@@ -1662,6 +1717,7 @@ exports.tests = [
           safari9: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1691,6 +1747,7 @@ exports.tests = [
           ios5_1: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1719,6 +1776,7 @@ exports.tests = [
           android4_0: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1747,6 +1805,7 @@ exports.tests = [
           safari9: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1777,6 +1836,7 @@ exports.tests = [
           ios5_1: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1807,6 +1867,7 @@ exports.tests = [
           ios5_1: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1837,6 +1898,7 @@ exports.tests = [
           android4_0: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1863,6 +1925,7 @@ exports.tests = [
           safari9: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1889,6 +1952,7 @@ exports.tests = [
           ios5_1: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1919,6 +1983,7 @@ exports.tests = [
           ios5_1: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1949,6 +2014,7 @@ exports.tests = [
           ios5_1: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -1979,6 +2045,7 @@ exports.tests = [
           android4_0: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -2005,6 +2072,7 @@ exports.tests = [
           safari9: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       },
       {
@@ -2031,6 +2099,7 @@ exports.tests = [
           ios5_1: true,
           duktape2_0: false,
           duktape2_2: true,
+          graalvm: true,
         },
       }
     ]
@@ -2058,6 +2127,7 @@ exports.tests = [
         chrome52: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
       {
@@ -2078,6 +2148,7 @@ exports.tests = [
           chrome52: true,
           safari10: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -2104,6 +2175,7 @@ exports.tests = [
           node8: true,
           safari10: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -2130,6 +2202,7 @@ exports.tests = [
           node8: true,
           safari10: true,
           duktape2_0: false,
+          graalvm: true,
         }
       }
     ]
@@ -2166,6 +2239,7 @@ exports.tests = [
       safari10: true,
       safari10_1: true,
       duktape2_0: true,
+      graalvm: true,
     },
   },
   {
@@ -2188,6 +2262,7 @@ exports.tests = [
       safari10: true,
       safari10_1: true,
       duktape2_0: false,
+      graalvm: true,
     },
   },
   {
@@ -2220,6 +2295,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+	  graalvm: true,
     },
   },
   {
@@ -2244,6 +2320,7 @@ exports.tests = [
       node8: true,
       safari10_1: true,
       duktape2_0: false,
+	  graalvm: true,
     },
   },
   {
@@ -2274,6 +2351,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -2299,6 +2377,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
     ],
@@ -2356,6 +2435,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_2: false,
+          graalvm: true,
         }
       },
       {
@@ -2396,6 +2476,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_2: false,
+          graalvm: true,
         }
       },
       {
@@ -2438,6 +2519,7 @@ exports.tests = [
           chrome63: true,
           webkit: true,
           duktape2_2: false,
+          graalvm: true,
         }
       }
     ]
@@ -2466,6 +2548,7 @@ exports.tests = [
       chrome62: true,
       safari11: true,
       duktape2_0: false,
+      graalvm: true,
     }
   },
   {
@@ -2505,6 +2588,7 @@ exports.tests = [
       duktape2_2: false,
       android1_5: null,
       ios4: null,
+      graalvm: true,
     },
   },
   {
@@ -2532,6 +2616,7 @@ exports.tests = [
       safari11_1: true,
       safaritp: true,
       duktape2_0: false,
+	  graalvm: true,
     }
   },
   {
@@ -2550,6 +2635,7 @@ exports.tests = [
       chrome50: chrome.harmony,
       chrome62: true,
       duktape2_0: false,
+	  graalvm: true,
     }
   },
   {
@@ -2571,6 +2657,7 @@ exports.tests = [
       safari11_1: true,
       safaritp: true,
       duktape2_0: false,
+	  graalvm: true,
     }
   },
   {
@@ -2604,6 +2691,7 @@ exports.tests = [
           safari12: true,
           webkit: true,
           duktape2_0: false,
+          graalvm: true,
         }
       },
       {
@@ -2641,6 +2729,7 @@ exports.tests = [
           safari12: true,
           webkit: true,
           duktape2_0: false,
+          graalvm: true,
         }
       }
     ]
@@ -2676,6 +2765,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_2: false,
+          graalvm: false,
         },
       },
       {
@@ -2704,6 +2794,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_2: false,
+          graalvm: false,
         },
       },
       {
@@ -2737,6 +2828,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_2: false,
+          graalvm: false,
         }
       }
     ]

--- a/data-es5.js
+++ b/data-es5.js
@@ -30,6 +30,7 @@ exports.tests = [
       duktape2_0: true,
       nashorn1_8: true,
       nashorn9: true,
+      graalvm: true,
     }
   },
   {
@@ -54,6 +55,7 @@ exports.tests = [
       duktape2_0: true,
       nashorn1_8: true,
       nashorn9: true,
+      graalvm: true,
     },
   },
   {
@@ -78,6 +80,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -102,6 +105,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -130,6 +134,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   }],
   separator: 'after'
@@ -160,6 +165,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -197,6 +203,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -222,6 +229,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -249,6 +257,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -277,6 +286,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -302,6 +312,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -327,6 +338,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -352,6 +364,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -377,6 +390,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -402,6 +416,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -427,6 +442,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -460,6 +476,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -487,6 +504,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
     separator: 'after'
   }],
@@ -519,6 +537,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -544,6 +563,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -569,6 +589,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -594,6 +615,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -619,6 +641,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -644,6 +667,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -669,6 +693,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -694,6 +719,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -719,6 +745,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -744,6 +771,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   }, {
     name: 'Array.prototype.sort: compareFn must be function or undefined',
@@ -794,6 +822,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -826,6 +855,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   }],
 },
@@ -855,6 +885,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -882,6 +913,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
     separator: 'after'
   }
@@ -913,6 +945,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -937,6 +970,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -973,6 +1007,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   }]
 },
@@ -1003,6 +1038,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+      graalvm: true,
   },
 },
 {
@@ -1035,6 +1071,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+      graalvm: true,
   },
   separator: 'after'
 },
@@ -1070,6 +1107,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -1100,6 +1138,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -1130,6 +1169,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   }]
 },
@@ -1165,6 +1205,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1192,6 +1233,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -1219,6 +1261,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1247,6 +1290,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1278,6 +1322,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -1305,6 +1350,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -1340,6 +1386,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   },
   {
@@ -1370,6 +1417,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   }]
 },
@@ -1404,6 +1452,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1432,6 +1481,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1458,6 +1508,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1496,6 +1547,7 @@ exports.tests = [
       ios7: true,
       android4_1: true,
       duktape2_0: true,
+      graalvm: true,
     },
   },
   {
@@ -1523,6 +1575,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1548,6 +1601,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1577,6 +1631,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1603,6 +1658,7 @@ exports.tests = [
       ios7: true,
       android4_1: true,
       duktape2_0: true,
+      graalvm: true,
     },
   },
   {
@@ -1634,6 +1690,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1662,6 +1719,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1688,6 +1746,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1715,6 +1774,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1746,6 +1806,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1771,6 +1832,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1796,6 +1858,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1821,6 +1884,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1846,6 +1910,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1871,6 +1936,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   },
   {
@@ -1901,6 +1967,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }
   }]
 }

--- a/data-es6.js
+++ b/data-es6.js
@@ -43,6 +43,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         duktape2_0: true,
+        graalvm: false,
       },
     },
     {
@@ -73,7 +74,8 @@ exports.tests = [
         chrome61: false,
         safari10: true,
         xs6: true,
-        duktape2_0: true,
+        duktape2_0: false,
+        graalvm: false,
       },
     }
   ]
@@ -112,6 +114,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -142,6 +145,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -172,6 +176,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -198,6 +203,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -224,6 +230,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -250,6 +257,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -276,6 +284,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -301,6 +310,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -325,6 +335,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -345,6 +356,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -383,6 +395,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -419,6 +432,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -440,6 +454,7 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         duktape2_2: false,
+        graalvm: true,
       },
     },
   ],
@@ -481,6 +496,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -512,6 +528,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -546,6 +563,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -579,6 +597,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -610,6 +629,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -639,6 +659,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -668,6 +689,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -696,6 +718,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -730,6 +753,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -762,6 +786,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -797,6 +822,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -831,6 +857,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -863,6 +890,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -893,6 +921,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -923,6 +952,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -952,6 +982,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ]
@@ -995,6 +1026,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1026,6 +1058,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1060,6 +1093,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1091,6 +1125,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1119,6 +1154,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1155,6 +1191,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1186,6 +1223,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1218,6 +1256,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1253,6 +1292,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1285,6 +1325,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1314,6 +1355,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1351,6 +1393,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -1388,6 +1431,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1416,6 +1460,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1444,6 +1489,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -1476,6 +1522,7 @@ exports.tests = [
         node6_5: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1508,6 +1555,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1535,6 +1583,7 @@ exports.tests = [
         node6_5: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1561,6 +1610,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ]
@@ -1599,6 +1649,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1624,6 +1675,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1656,6 +1708,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1687,6 +1740,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1710,6 +1764,7 @@ exports.tests = [
         ejs: { val: false, note_id: 'ejs-no-function-ctor' },
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -1746,6 +1801,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1771,6 +1827,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1799,6 +1856,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1820,6 +1878,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1843,6 +1902,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1865,6 +1925,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1887,6 +1948,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1908,6 +1970,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1933,6 +1996,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1956,6 +2020,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1986,6 +2051,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2011,6 +2077,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2037,6 +2104,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2062,6 +2130,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2089,6 +2158,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ]
@@ -2126,6 +2196,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2157,6 +2228,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2184,6 +2256,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2211,6 +2284,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2242,6 +2316,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2273,6 +2348,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2304,6 +2380,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2335,6 +2412,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2370,6 +2448,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2401,6 +2480,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2432,6 +2512,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2465,6 +2546,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2496,6 +2578,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2529,6 +2612,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2559,6 +2643,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2589,6 +2674,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2615,6 +2701,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: false,
       },
     },
     {
@@ -2641,6 +2728,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2670,6 +2758,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2697,6 +2786,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2738,6 +2828,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2770,6 +2861,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2799,6 +2891,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2830,6 +2923,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -2873,6 +2967,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2906,6 +3001,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2940,6 +3036,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -2973,6 +3070,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3008,6 +3106,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3035,6 +3134,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3072,6 +3172,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3109,6 +3210,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -3144,6 +3246,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -3173,6 +3276,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3201,6 +3305,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3227,6 +3332,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -3253,6 +3359,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -3281,6 +3388,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       }
     }
   ]
@@ -3322,6 +3430,7 @@ exports.tests = [
         safari10: true,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3349,6 +3458,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3377,6 +3487,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
   ],
@@ -3413,6 +3524,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3438,6 +3550,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3462,6 +3575,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3484,6 +3598,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3505,6 +3620,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -3543,6 +3659,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3574,6 +3691,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3602,6 +3720,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3629,6 +3748,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -3658,6 +3778,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3688,6 +3809,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3718,6 +3840,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3744,6 +3867,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3772,6 +3896,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -3815,6 +3940,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3849,6 +3975,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3885,6 +4012,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3911,6 +4039,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3943,6 +4072,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -3974,6 +4104,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4008,6 +4139,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4040,6 +4172,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4075,6 +4208,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4107,6 +4241,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4138,6 +4273,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4171,6 +4307,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4204,6 +4341,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4237,6 +4375,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4269,6 +4408,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4304,6 +4444,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4339,6 +4480,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4374,6 +4516,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4408,6 +4551,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4446,6 +4590,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4481,6 +4626,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4516,6 +4662,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4551,6 +4698,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4586,6 +4734,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4620,6 +4769,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4655,6 +4805,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4684,6 +4835,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -4725,6 +4877,7 @@ exports.tests = [
         jxa: true,
         duktape1_0: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -4756,6 +4909,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4787,6 +4941,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4820,6 +4975,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -4850,6 +5006,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -4886,6 +5043,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -4914,6 +5072,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -4937,6 +5096,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -4960,6 +5120,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
   ],
@@ -4995,6 +5156,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -5018,6 +5180,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -5056,6 +5219,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5083,6 +5247,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5115,6 +5280,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -5149,6 +5315,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -5175,6 +5342,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -5196,6 +5364,7 @@ exports.tests = [
         node6_5: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -5217,6 +5386,7 @@ exports.tests = [
         node6_5: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -5237,6 +5407,7 @@ exports.tests = [
         node6_5: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -5277,6 +5448,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5308,6 +5480,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5336,6 +5509,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5367,6 +5541,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5398,6 +5573,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5429,6 +5605,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5460,6 +5637,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5491,6 +5669,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5523,6 +5702,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5554,6 +5734,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5585,6 +5766,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5616,6 +5798,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5647,6 +5830,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5678,6 +5862,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5709,6 +5894,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5740,6 +5926,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5771,6 +5958,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5793,6 +5981,7 @@ exports.tests = [
         chrome51: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -5840,6 +6029,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -5875,6 +6065,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -5916,6 +6107,7 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         duktape2_1: true,
+		graalvm: true,
       },
     },
   ].concat([ //@@ jph
@@ -5935,6 +6127,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.of',
@@ -5953,6 +6146,7 @@ exports.tests = [
       ejs: true,
       jxa: true,
       duktape2_0: false,
+        graalvm: true,
     }},
     {
       name: '.prototype.subarray',
@@ -5975,6 +6169,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }},
     {
       name: '.prototype.join',
@@ -5993,6 +6188,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+	  graalvm: true,
     }},
     {
       name: '.prototype.indexOf',
@@ -6011,6 +6207,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+	  graalvm: true,
     }},
     {
       name: '.prototype.lastIndexOf',
@@ -6029,6 +6226,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+	  graalvm: true,
     }},
     {
       name: '.prototype.slice',
@@ -6046,6 +6244,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+	  graalvm: true,
     }},
     {
       name: '.prototype.every',
@@ -6064,6 +6263,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+	  graalvm: true,
     }},
     {
       name: '.prototype.filter',
@@ -6081,6 +6281,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.forEach',
@@ -6099,6 +6300,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.map',
@@ -6116,6 +6318,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.reduce',
@@ -6134,6 +6337,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.reduceRight',
@@ -6152,6 +6356,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.reverse',
@@ -6170,6 +6375,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.some',
@@ -6188,6 +6394,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.sort',
@@ -6205,6 +6412,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.copyWithin',
@@ -6223,6 +6431,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.find',
@@ -6241,6 +6450,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.findIndex',
@@ -6259,6 +6469,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.fill',
@@ -6277,6 +6488,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.keys',
@@ -6295,6 +6507,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.values',
@@ -6313,6 +6526,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype.entries',
@@ -6330,6 +6544,7 @@ exports.tests = [
       xs6: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     {
       name: '.prototype[Symbol.iterator]',
@@ -6350,6 +6565,7 @@ exports.tests = [
       duktape2_0: false,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     }},
     {
       name: '[Symbol.species]',
@@ -6368,6 +6584,7 @@ exports.tests = [
       safari10: true,
       jxa: true,
       duktape2_0: false,
+      graalvm: true,
     }},
     ].map(function(m) {
       var eqFn = ' === "function"';
@@ -6426,6 +6643,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6457,6 +6675,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6487,6 +6706,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6515,6 +6735,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6548,6 +6769,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -6574,6 +6796,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -6602,6 +6825,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6633,6 +6857,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6666,6 +6891,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6694,6 +6920,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6722,6 +6949,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6750,6 +6978,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6778,6 +7007,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6806,6 +7036,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6834,6 +7065,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6861,6 +7093,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6895,6 +7128,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6929,6 +7163,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -6951,6 +7186,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+		graalvm: true,
       },
     },
   ],
@@ -6993,6 +7229,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7023,6 +7260,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7053,6 +7291,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7081,6 +7320,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7114,6 +7354,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -7143,6 +7384,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -7170,6 +7412,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7202,6 +7445,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7237,6 +7481,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7265,6 +7510,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7293,6 +7539,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7321,6 +7568,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7348,6 +7596,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7376,6 +7625,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7404,6 +7654,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7432,6 +7683,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7466,6 +7718,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7500,6 +7753,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7522,6 +7776,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+		graalvm: true,
       },
     },
   ],
@@ -7562,6 +7817,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7591,6 +7847,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7620,6 +7877,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7647,6 +7905,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7679,6 +7938,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+		graalvm: true,
       },
     },
     {
@@ -7707,6 +7967,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7733,6 +7994,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -7761,6 +8023,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7788,6 +8051,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7822,6 +8086,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7848,6 +8113,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7880,6 +8146,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -7921,6 +8188,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7948,6 +8216,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -7977,6 +8246,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -8004,6 +8274,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -8036,6 +8307,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+		graalvm: true,
       },
     },
     {
@@ -8062,6 +8334,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8089,6 +8362,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -8115,6 +8389,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -8146,6 +8421,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -8171,6 +8447,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -8203,6 +8480,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -8240,6 +8518,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8259,6 +8538,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8284,6 +8564,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8313,6 +8594,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8358,6 +8640,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8385,6 +8668,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8411,6 +8695,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+		graalvm: true,
       },
     },
     {
@@ -8456,6 +8741,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8482,6 +8768,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8507,6 +8794,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8549,6 +8837,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8575,6 +8864,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8608,6 +8898,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -8645,6 +8936,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8712,6 +9004,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8743,6 +9036,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8789,6 +9083,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8815,6 +9110,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8846,6 +9142,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8877,6 +9174,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8910,6 +9208,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8938,6 +9237,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -8977,6 +9277,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9006,6 +9307,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9037,6 +9339,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9072,6 +9375,7 @@ exports.tests = [
         safari10: true,
         duktape1_0: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -9121,6 +9425,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9150,6 +9455,7 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         duktape2_2: true,
+		graalvm: true,
       },
     },
     {
@@ -9181,6 +9487,7 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         duktape2_2: true,
+		graalvm: true,
       },
     },
     {
@@ -9208,6 +9515,7 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         duktape2_2: true,
+		graalvm: true,
       },
     },
     {
@@ -9249,6 +9557,7 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         duktape2_2: true,
+		graalvm: true,
       },
     },
     {
@@ -9275,6 +9584,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9293,6 +9603,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9313,6 +9624,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -9343,6 +9655,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9364,6 +9677,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -9386,6 +9700,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9410,6 +9725,7 @@ exports.tests = [
         safari10: true,
         edge14: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9431,6 +9747,7 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         duktape2_2: true,
+        graalvm: true,
       },
     },
     {
@@ -9453,6 +9770,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9485,6 +9803,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9514,6 +9833,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9534,6 +9854,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9554,6 +9875,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9574,6 +9896,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9595,6 +9918,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -9617,6 +9941,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9640,6 +9965,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9674,6 +10000,7 @@ exports.tests = [
         edge14: edge.experimental,
         safari10: true,
         duktape2_0: false,
+        graalvm: false,
       },
     },
     {
@@ -9694,6 +10021,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9715,6 +10043,7 @@ exports.tests = [
         echojs: null,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -9737,6 +10066,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9759,6 +10089,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9782,6 +10113,7 @@ exports.tests = [
         chrome56: true,
         node8: true,
         duktape2_0: false,
+        graalvm: true,
         safaritp: true,
         webkit: true,
       },
@@ -9807,6 +10139,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9828,6 +10161,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9857,6 +10191,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9890,6 +10225,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9911,6 +10247,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -9931,6 +10268,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9952,6 +10290,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -9975,6 +10314,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -9996,6 +10336,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10017,6 +10358,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10038,6 +10380,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10060,6 +10403,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10083,6 +10427,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10105,6 +10450,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10128,6 +10474,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10149,6 +10496,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -10178,7 +10526,8 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         safari10: true,
-        duktape2_0: true
+        duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10200,6 +10549,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10221,6 +10571,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10241,6 +10592,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10261,6 +10613,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10281,6 +10634,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10301,6 +10655,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10321,6 +10676,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10343,6 +10699,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10365,6 +10722,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10387,6 +10745,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
   ],
@@ -10416,6 +10775,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10436,6 +10796,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -10465,6 +10826,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10488,6 +10850,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10510,6 +10873,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10532,6 +10896,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10554,6 +10919,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10576,6 +10942,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
   ],
@@ -10607,6 +10974,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10628,6 +10996,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10650,6 +11019,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10671,6 +11041,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -10701,6 +11072,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10722,6 +11094,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10743,6 +11116,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
   ],
@@ -10777,6 +11151,7 @@ exports.tests = [
         chrome49: true,
         duktape1_0: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10802,6 +11177,7 @@ exports.tests = [
         safari10: true,
         duktape1_0: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10825,6 +11201,7 @@ exports.tests = [
         chrome49: true,
         duktape1_0: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10849,6 +11226,7 @@ exports.tests = [
         chrome49: true,
         duktape1_0: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10874,6 +11252,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10898,6 +11277,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10920,6 +11300,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10944,6 +11325,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10967,6 +11349,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -10991,6 +11374,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -11018,6 +11402,7 @@ exports.tests = [
         chrome49: true,
         duktape1_0: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -11049,6 +11434,7 @@ exports.tests = [
         chrome49: true,
         duktape1_0: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -11071,6 +11457,7 @@ exports.tests = [
         xs6: true,
         chrome49: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -11095,6 +11482,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -11117,6 +11505,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11140,6 +11529,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11161,6 +11551,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11184,6 +11575,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11204,6 +11596,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11242,6 +11635,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -11283,6 +11677,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -11317,6 +11712,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11344,6 +11740,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11371,6 +11768,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11396,6 +11794,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11421,6 +11820,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11447,6 +11847,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11473,6 +11874,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11499,6 +11901,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11525,6 +11928,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11557,6 +11961,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11587,6 +11992,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11615,6 +12021,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11656,6 +12063,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11682,6 +12090,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11710,6 +12119,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11739,6 +12149,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11764,6 +12175,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11791,6 +12203,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11820,6 +12233,7 @@ exports.tests = [
         edge14: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11849,6 +12263,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11877,6 +12292,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11909,6 +12325,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -11946,6 +12363,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -11974,6 +12392,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -12002,6 +12421,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12028,6 +12448,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12054,6 +12475,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12081,6 +12503,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12108,6 +12531,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12134,6 +12558,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12160,6 +12585,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12187,6 +12613,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12215,6 +12642,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12248,6 +12676,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12281,6 +12710,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12312,6 +12742,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12338,6 +12769,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12369,6 +12801,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12399,6 +12832,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12441,6 +12875,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12467,6 +12902,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12500,6 +12936,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12530,6 +12967,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12555,6 +12993,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12583,6 +13022,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12612,6 +13052,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -12649,6 +13090,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12677,6 +13119,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -12705,6 +13148,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12731,6 +13175,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12758,6 +13203,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12785,6 +13231,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12812,6 +13259,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12837,6 +13285,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12865,6 +13314,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12898,6 +13348,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12928,6 +13379,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12957,6 +13409,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -12992,6 +13445,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13019,6 +13473,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13048,6 +13503,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13077,6 +13533,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13101,6 +13558,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },{
       name: 'in parameters, function \'length\' property',
@@ -13126,6 +13584,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13155,6 +13614,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13182,6 +13642,7 @@ exports.tests = [
         node6_5: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13210,6 +13671,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13236,6 +13698,7 @@ exports.tests = [
         node6_5: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13259,6 +13722,7 @@ exports.tests = [
         node6: true,
         node6_5: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13285,6 +13749,7 @@ exports.tests = [
         safari9: false,
         safari10: true,
         duktape2_2: false,
+        graalvm: true,
       },
     },
   ],
@@ -13339,6 +13804,7 @@ exports.tests = [
         node0_12: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13367,6 +13833,7 @@ exports.tests = [
         safari10: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13396,6 +13863,7 @@ exports.tests = [
         node0_12: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13433,6 +13901,7 @@ exports.tests = [
         node0_12: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13468,6 +13937,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13506,6 +13976,7 @@ exports.tests = [
         node0_12: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13541,6 +14012,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -13562,6 +14034,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -13596,6 +14069,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13625,6 +14099,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13659,6 +14134,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -13686,6 +14162,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -13719,6 +14196,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13742,6 +14220,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13768,6 +14247,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13791,6 +14271,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13814,6 +14295,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13837,6 +14319,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13860,6 +14343,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13883,6 +14367,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13906,6 +14391,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -13930,6 +14416,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
   ],
@@ -13966,6 +14453,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -13992,6 +14480,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -14018,6 +14507,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -14043,6 +14533,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -14072,6 +14563,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -14096,6 +14588,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -14136,6 +14629,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -14166,6 +14660,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -14189,6 +14684,7 @@ exports.tests = [
         ejs: { val: false, note_id: 'ejs-no-function-ctor' },
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -14210,6 +14706,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -14232,6 +14729,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14257,6 +14755,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14279,6 +14778,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14303,6 +14803,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -14326,6 +14827,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -14353,6 +14855,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14380,6 +14883,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14401,6 +14905,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14426,6 +14931,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14451,6 +14957,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14474,6 +14981,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14497,6 +15005,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14518,6 +15027,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
   ],
@@ -14550,6 +15060,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14577,6 +15088,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
   ],
@@ -14612,6 +15124,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -14634,6 +15147,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14662,6 +15176,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -14691,6 +15206,7 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         duktape2_1: true,
+		graalvm: true,
       },
     },
     {
@@ -14723,6 +15239,7 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         duktape2_1: true,
+		graalvm: true,
       },
     },
     {
@@ -14752,6 +15269,7 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         duktape2_1: true,
+		graalvm: true,
       },
     },
     {
@@ -14784,6 +15302,7 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         duktape2_1: true,
+		graalvm: true,
       },
     },
     {
@@ -14818,6 +15337,7 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         duktape2_1: true,
+		graalvm: true,
       },
     },
     {
@@ -14844,6 +15364,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -14877,6 +15398,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -14918,6 +15440,7 @@ exports.tests = [
         xs6: false,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14949,6 +15472,7 @@ exports.tests = [
         xs6: false,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -14979,6 +15503,7 @@ exports.tests = [
         xs6: false,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -15011,6 +15536,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       }
     },
     {
@@ -15031,6 +15557,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       }
     },
   ]
@@ -15066,6 +15593,7 @@ exports.tests = [
         ejs: true,
         duktape2_0: false,
         duktape2_2: true,
+		graalvm: true,
       }
     },
     {
@@ -15093,6 +15621,7 @@ exports.tests = [
         ejs: true,
         safari10: true,
         duktape2_0: false,
+		graalvm: true,
       }
     },
   ]
@@ -15132,6 +15661,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15157,6 +15687,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15192,6 +15723,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15227,6 +15759,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15256,6 +15789,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15290,6 +15824,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15309,6 +15844,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -15338,6 +15874,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15368,6 +15905,7 @@ exports.tests = [
         duktape2_1: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15402,6 +15940,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15444,6 +15983,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -15469,6 +16009,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -15511,6 +16052,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -15534,6 +16076,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -15562,6 +16105,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -15587,6 +16131,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -15609,6 +16154,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -15633,6 +16179,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15657,6 +16204,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15681,6 +16229,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15705,6 +16254,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15729,6 +16279,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15755,6 +16306,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15780,6 +16332,7 @@ exports.tests = [
         ejs: null,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15805,6 +16358,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15830,6 +16384,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15855,6 +16410,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15880,6 +16436,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15904,6 +16461,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15929,6 +16487,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15954,6 +16513,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -15979,6 +16539,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -16008,6 +16569,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16033,6 +16595,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16075,6 +16638,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16118,6 +16682,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16142,6 +16707,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16171,6 +16737,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -16203,6 +16770,7 @@ exports.tests = [
         edge14: edge.experimental,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -16224,6 +16792,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16245,6 +16814,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16266,6 +16836,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16287,6 +16858,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16309,6 +16881,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ]
@@ -16345,6 +16918,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -16371,6 +16945,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
   ]
@@ -16404,6 +16979,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -16428,6 +17004,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -16451,6 +17028,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -16476,6 +17054,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -16500,6 +17079,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -16526,6 +17106,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -16549,6 +17130,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+		graalvm: true,
       },
     },
     {
@@ -16575,6 +17157,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -16608,6 +17191,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -16633,6 +17217,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -16658,6 +17243,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -16682,6 +17268,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -16707,6 +17294,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -16733,6 +17321,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -16759,6 +17348,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -16784,6 +17374,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -16811,6 +17402,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16839,6 +17431,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16861,6 +17454,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -16893,6 +17487,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16920,6 +17515,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16947,6 +17543,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -16974,6 +17571,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17002,6 +17600,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -17059,6 +17658,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -17087,6 +17687,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -17122,6 +17723,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -17154,6 +17756,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -17183,6 +17786,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -17218,6 +17822,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17244,6 +17849,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17270,6 +17876,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17297,6 +17904,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17319,6 +17927,7 @@ exports.tests = [
         safari9: true,
         typescript1: typescript.corejs,
         duktape2_2: false,
+        graalvm: true,
       },
     },
     {
@@ -17341,6 +17950,7 @@ exports.tests = [
         safari9: true,
         typescript1: typescript.corejs,
         duktape2_2: false,
+        graalvm: true,
       },
     },
     {
@@ -17366,6 +17976,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17392,6 +18003,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17418,6 +18030,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -17448,6 +18061,7 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         duktape2_2: true,
+        graalvm: true,
       },
       'imul': {
         ejs: true,
@@ -17474,6 +18088,7 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         duktape2_2: true,
+        graalvm: true,
       },
       'sign': {
         ejs: true,
@@ -17495,6 +18110,7 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         duktape2_2: true,
+        graalvm: true,
       },
       'log10': {
         ejs: true,
@@ -17515,6 +18131,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
       'log2': {
         ejs: true,
@@ -17535,6 +18152,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
       'log1p': {
         ejs: true,
@@ -17555,6 +18173,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
       'expm1': {
         ejs: true,
@@ -17574,6 +18193,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
       'cosh': {
         ejs: true,
@@ -17594,6 +18214,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
       'sinh': {
         ejs: true,
@@ -17614,6 +18235,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
       'tanh': {
         ejs: true,
@@ -17634,6 +18256,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
       'acosh': {
         ejs: true,
@@ -17654,6 +18277,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
       'asinh': {
         ejs: true,
@@ -17673,6 +18297,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
       'atanh': {
         ejs: true,
@@ -17693,6 +18318,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
       'trunc': {
         ejs: true,
@@ -17713,6 +18339,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
       'fround': {
         ejs: true,
@@ -17732,6 +18359,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
       'cbrt': {
         ejs: true,
@@ -17752,6 +18380,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     };
     var eqFn = ' === "function"';
@@ -17790,6 +18419,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       }
     });
   }()),
@@ -17819,6 +18449,7 @@ exports.tests = [
     xs6: true,
     safari10: true,
     duktape2_0: false,
+	graalvm: true,
   }
 },
 {
@@ -17850,6 +18481,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17874,6 +18506,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17898,6 +18531,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -17918,6 +18552,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -17939,6 +18574,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -17960,6 +18596,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -17981,6 +18618,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -18003,6 +18641,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -18025,6 +18664,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -18048,6 +18688,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -18071,6 +18712,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
   ],
@@ -18102,6 +18744,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18127,6 +18770,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18150,6 +18794,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18173,6 +18818,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -18202,6 +18848,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18224,6 +18871,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18247,6 +18895,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18268,6 +18917,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18289,6 +18939,7 @@ exports.tests = [
         xs6: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18309,6 +18960,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -18359,6 +19011,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18382,6 +19035,7 @@ exports.tests = [
         xs6: true,
         ejs: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18416,6 +19070,7 @@ exports.tests = [
         node5: "strict",
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18450,6 +19105,7 @@ exports.tests = [
         node5: "strict",
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -18482,6 +19138,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18506,6 +19163,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18532,6 +19190,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18556,6 +19215,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18582,6 +19242,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -18609,6 +19270,7 @@ exports.tests = [
         ejs: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -18676,6 +19338,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -18714,6 +19377,7 @@ exports.tests = [
         chrome49: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -18756,6 +19420,7 @@ exports.tests = [
         chrome49: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -18799,6 +19464,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -18835,6 +19501,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -18876,6 +19543,7 @@ exports.tests = [
         ejs: true,
         chrome49: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -18913,6 +19581,7 @@ exports.tests = [
         chrome49: true,
         duktape2_0: false,
         duktape2_2: true,
+        graalvm: true,
       }
     },
   ],
@@ -18961,6 +19630,7 @@ exports.tests = [
         duktape2_2: false,
         android1_5: null,
         ios4: null,
+        graalvm: true,
       },
     },
     {
@@ -18998,6 +19668,7 @@ exports.tests = [
         duktape2_2: false,
         android1_5: null,
         ios4: null,
+        graalvm: true,
       },
     },
     {
@@ -19039,6 +19710,7 @@ exports.tests = [
         ios4: null,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -19069,6 +19741,7 @@ exports.tests = [
         duktape2_0: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -19096,6 +19769,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -19125,6 +19799,7 @@ exports.tests = [
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -19148,6 +19823,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -19176,6 +19852,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
     {
@@ -19196,6 +19873,7 @@ exports.tests = [
         chrome49: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -19216,6 +19894,7 @@ exports.tests = [
         jxa: true,
         safari10: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
     {
@@ -19246,6 +19925,7 @@ exports.tests = [
         chrome50: true,
         safari10: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -19272,6 +19952,7 @@ exports.tests = [
         safari10: true,
         jxa: true,
         duktape2_0: true,
+        graalvm: true,
       },
     },
   ],
@@ -19304,6 +19985,7 @@ exports.tests = [
     xs6: false,
     duktape2_0: false,
     duktape2_1: true,
+    graalvm: false,
   }
 },
 ];

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -28,6 +28,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -46,6 +47,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -71,6 +73,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -90,6 +93,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -109,6 +113,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -176,6 +181,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -201,6 +207,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -226,6 +233,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -251,6 +259,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -269,6 +278,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -288,6 +298,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -307,6 +318,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -374,6 +386,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ],
@@ -399,6 +412,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -418,6 +432,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -437,6 +452,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -504,6 +520,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -530,6 +547,7 @@ exports.tests = [
         android4_0: null,
         ios7: false,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -556,6 +574,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
+        graalvm: false,
       }
     }
   ],
@@ -585,6 +604,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -614,6 +634,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -643,6 +664,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -672,6 +694,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -701,6 +724,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -730,6 +754,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],
@@ -759,6 +784,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       },
     },
   ],

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -35,6 +35,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -49,6 +50,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       },
     },
   ],
@@ -70,6 +72,7 @@ exports.tests = [
     firefox2: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -92,6 +95,7 @@ exports.tests = [
     firefox2: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -121,6 +125,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
   ],
@@ -141,6 +146,7 @@ exports.tests = [
     firefox52: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -159,6 +165,7 @@ exports.tests = [
     firefox2: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -201,6 +208,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -237,6 +245,7 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
+        graalvm: true,
       }
     },
     {
@@ -257,6 +266,7 @@ exports.tests = [
         opera10_50: false,
         safari12: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -277,6 +287,7 @@ exports.tests = [
         opera10_50: false,
         safari12: true,
         duktape2_0: false,
+        graalvm: true,
       }
     }
   ]
@@ -327,6 +338,7 @@ exports.tests = [
       node8_7: true,
       duktape2_0: false,
       duktape2_1: true,
+      graalvm: true,
     }
   }, {
     name: '"global" global property has correct property descriptor',
@@ -374,6 +386,7 @@ exports.tests = [
       node8_7: false,
       duktape2_0: false,
       duktape2_1: true,
+      graalvm: true,
     }
   }]
 },
@@ -395,6 +408,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -409,6 +423,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -423,6 +438,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -447,6 +463,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -462,6 +479,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -476,6 +494,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -490,6 +509,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     }
   ]
@@ -520,6 +540,7 @@ exports.tests = [
     chrome69: chrome.harmony,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -539,6 +560,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -551,6 +573,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -568,6 +591,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     }
   ]
@@ -597,6 +621,7 @@ exports.tests = [
     firefox2: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -619,6 +644,7 @@ exports.tests = [
     firefox2: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -639,6 +665,7 @@ exports.tests = [
     opera10_50: false,
     chrome65: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -659,6 +686,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -673,6 +701,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     }
   ]
@@ -695,6 +724,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -709,6 +739,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -723,6 +754,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -737,6 +769,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -751,6 +784,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -765,6 +799,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -779,6 +814,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -793,6 +829,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -807,6 +844,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     }
   ]
@@ -827,6 +865,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -839,6 +878,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -851,6 +891,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -863,6 +904,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -875,6 +917,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -887,6 +930,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -899,6 +943,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     }
   ]
@@ -917,6 +962,7 @@ exports.tests = [
     firefox2: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -942,6 +988,7 @@ exports.tests = [
         chrome65: chrome.harmony,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -964,6 +1011,7 @@ exports.tests = [
         chrome66: chrome.harmony,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -983,6 +1031,7 @@ exports.tests = [
         chrome66: chrome.harmony,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     }
   ]
@@ -1008,6 +1057,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     },
     {
@@ -1025,6 +1075,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       }
     }
   ]
@@ -1047,6 +1098,7 @@ exports.tests = [
     firefox2: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: false,
   }
 },
 {
@@ -1071,6 +1123,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       },
     },
     {
@@ -1096,6 +1149,7 @@ exports.tests = [
         firefox2: false,
         opera10_50: false,
         duktape2_0: false,
+        graalvm: false,
       },
     }
   ]
@@ -1121,6 +1175,7 @@ exports.tests = [
       chrome59: chrome.harmony,
       chrome66: true,
       duktape2_0: false,
+      graalvm: true,
     },
   }, {
     name: 'arrows',
@@ -1141,6 +1196,7 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   }, {
     name: '[native code]',
@@ -1160,6 +1216,7 @@ exports.tests = [
       duktape2_0: true,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   }, {
     name: 'class expression with implicit constructor',
@@ -1177,6 +1234,7 @@ exports.tests = [
       ie11: false,
       edge14: true,
       duktape2_0: false,
+      graalvm: true,
     },
   }, {
     name: 'class expression with explicit constructor',
@@ -1194,6 +1252,7 @@ exports.tests = [
       ie11: false,
       edge14: true,
       duktape2_0: false,
+      graalvm: true,
     },
   }, {
     name: 'unicode escape sequences in identifiers',
@@ -1209,6 +1268,7 @@ exports.tests = [
       chrome59: chrome.harmony,
       chrome66: true,
       duktape2_0: false,
+      graalvm: true,
     },
   }, {
     name: 'methods and computed property names',
@@ -1226,6 +1286,7 @@ exports.tests = [
       duktape2_0: false,
       nashorn9: true,
       nashorn10: true,
+      graalvm: true,
     },
   }]
 },
@@ -1247,6 +1308,7 @@ exports.tests = [
     firefox52: false,
     opera10_50: false,
     duktape2_2: false,
+    graalvm: false,
   }
 },
 {
@@ -1268,6 +1330,7 @@ exports.tests = [
       firefox52: false,
       opera10_50: false,
       duktape2_2: false,
+      graalvm: false,
     },
   }, {
     name: 'Math.DEG_PER_RAD',
@@ -1281,6 +1344,7 @@ exports.tests = [
       firefox52: false,
       opera10_50: false,
       duktape2_2: false,
+      graalvm: false,
     },
   }, {
     name: 'Math.degrees',
@@ -1294,6 +1358,7 @@ exports.tests = [
       firefox52: false,
       opera10_50: false,
       duktape2_2: false,
+      graalvm: false,
     },
   }, {
     name: 'Math.fscale',
@@ -1307,6 +1372,7 @@ exports.tests = [
       firefox52: false,
       opera10_50: false,
       duktape2_2: false,
+      graalvm: false,
     },
   }, {
     name: 'Math.RAD_PER_DEG',
@@ -1320,6 +1386,7 @@ exports.tests = [
       firefox52: false,
       opera10_50: false,
       duktape2_2: false,
+      graalvm: false,
     },
   }, {
     name: 'Math.radians',
@@ -1334,6 +1401,7 @@ exports.tests = [
       firefox52: false,
       opera10_50: false,
       duktape2_2: false,
+      graalvm: false,
     },
   }, {
     name: 'Math.scale',
@@ -1347,6 +1415,7 @@ exports.tests = [
       firefox52: false,
       opera10_50: false,
       duktape2_2: false,
+      graalvm: false,
     },
   }]
 },
@@ -1369,6 +1438,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1384,6 +1454,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1401,6 +1472,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1423,6 +1495,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1445,6 +1518,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1467,6 +1541,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1489,6 +1564,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     }
   ]
@@ -1528,6 +1604,7 @@ exports.tests = [
         safari12: true,
         safaritp: true,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1550,6 +1627,7 @@ exports.tests = [
         opera10_50: false,
         safari12: true,
         duktape2_2: false,
+        graalvm: false,
       }
     }
   ]
@@ -1575,6 +1653,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1594,6 +1673,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1611,6 +1691,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1628,6 +1709,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1645,6 +1727,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1664,6 +1747,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1681,6 +1765,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
     {
@@ -1698,6 +1783,7 @@ exports.tests = [
         firefox52: false,
         opera10_50: false,
         duktape2_2: false,
+        graalvm: false,
       }
     },
   ]
@@ -1734,6 +1820,7 @@ exports.tests = [
       note_html: 'Requires the <code>--enable-pipeline-operator</code> compile option.'
     },
     opera10_50: false,
+    graalvm: false,
   }
 },
 {
@@ -1752,6 +1839,7 @@ exports.tests = [
     ie11: false,
     firefox52: false,
     opera10_50: false,
+    graalvm: false,
   }
 },
 {
@@ -1776,6 +1864,7 @@ exports.tests = [
         ie11: false,
         firefox52: false,
         opera10_50: false,
+        graalvm: false,
       }
     },
     {
@@ -1798,6 +1887,7 @@ exports.tests = [
         ie11: false,
         firefox52: false,
         opera10_50: false,
+        graalvm: false,
       }
     },
     {
@@ -1815,6 +1905,7 @@ exports.tests = [
         ie11: false,
         firefox52: false,
         opera10_50: false,
+        graalvm: false,
       }
     },
     {
@@ -1832,6 +1923,7 @@ exports.tests = [
         ie11: false,
         firefox52: false,
         opera10_50: false,
+        graalvm: false,
       }
     },
   ]
@@ -1852,6 +1944,7 @@ exports.tests = [
       res : {
         babel7: true,
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -1864,6 +1957,7 @@ exports.tests = [
       res : {
         babel7: true,
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -1876,6 +1970,7 @@ exports.tests = [
       res : {
         babel7: true,
         ie11: false,
+        graalvm: false,
       }
     },
   ]
@@ -1895,6 +1990,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -1907,6 +2003,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
   ]
@@ -1926,6 +2023,7 @@ exports.tests = [
   res : {
     babel7: true,
     ie11: false,
+    graalvm: false,
   }
 },
 {
@@ -1945,6 +2043,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -1958,6 +2057,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -1971,6 +2071,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -1984,6 +2085,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -1997,6 +2099,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -2010,6 +2113,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -2023,6 +2127,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -2039,6 +2144,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -2053,6 +2159,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -2066,6 +2173,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -2079,6 +2187,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
     {
@@ -2092,6 +2201,7 @@ exports.tests = [
       */},
       res : {
         ie11: false,
+        graalvm: false,
       }
     },
   ]
@@ -2113,6 +2223,7 @@ exports.tests = [
     firefox2: false,
     chrome67: chrome.harmony,
     opera10_50: false,
+    graalvm: false,
   }
 },
 {
@@ -2129,6 +2240,7 @@ exports.tests = [
     chrome67: false,
     safari11:false,
     safaritp:true,
+    graalvm: false,
   }
 },
 {
@@ -2144,6 +2256,7 @@ exports.tests = [
       */},
       res : {
           ie11: false,
+          graalvm: false,
       }
     },
     {
@@ -2153,6 +2266,7 @@ exports.tests = [
       */},
       res : {
           ie11: false,
+          graalvm: false,
       }
     },
     {
@@ -2162,6 +2276,7 @@ exports.tests = [
       */},
       res : {
           ie11: false,
+          graalvm: false,
       }
     },
     {
@@ -2171,6 +2286,7 @@ exports.tests = [
       */},
       res : {
           ie11: false,
+          graalvm: false,
       }
     },
     {
@@ -2188,6 +2304,7 @@ exports.tests = [
       */},
       res : {
           ie11: false,
+          graalvm: false,
       }
     },
     {
@@ -2206,6 +2323,7 @@ exports.tests = [
       */},
       res : {
           ie11: false,
+          graalvm: false,
       }
     },
     {
@@ -2223,6 +2341,7 @@ exports.tests = [
       */},
       res : {
           ie11: false,
+          graalvm: false,
       }
     },
     {
@@ -2241,6 +2360,7 @@ exports.tests = [
       */},
       res : {
           ie11: false,
+          graalvm: false,
       }
     },
   ]
@@ -2258,6 +2378,7 @@ exports.tests = [
       */},
       res: {
         chrome67: true,
+        graalvm: true,
       },
     },
     {
@@ -2267,6 +2388,7 @@ exports.tests = [
       */},
       res: {
         chrome67: true,
+        graalvm: true,
       },
     },
     {
@@ -2276,6 +2398,7 @@ exports.tests = [
       */},
       res: {
         chrome67: true,
+        graalvm: true,
       },
     },
     {
@@ -2285,6 +2408,7 @@ exports.tests = [
       */},
       res: {
         chrome67: true,
+        graalvm: true,
       },
     },
     {
@@ -2297,6 +2421,7 @@ exports.tests = [
       */},
       res: {
         chrome67: true,
+        graalvm: false,
       },
     },
     {
@@ -2309,6 +2434,7 @@ exports.tests = [
       */},
       res: {
         chrome67: true,
+        graalvm: false,
       },
     },
     {
@@ -2318,6 +2444,7 @@ exports.tests = [
       */},
       res: {
         chrome67: true,
+        graalvm: false,
       },
     },
     {
@@ -2327,6 +2454,7 @@ exports.tests = [
       */},
       res: {
         chrome67: true,
+        graalvm: false,
       },
     },
   ],
@@ -2341,6 +2469,7 @@ exports.tests = [
   */},
   res: {
       ie11: false,
+      graalvm: false,
   }
 },
 {
@@ -2357,7 +2486,8 @@ exports.tests = [
       && results[2] === 98;
   */},
   res: {
-      ie11: false,
+    ie11: false,
+    graalvm: false,
   }
 },
 {
@@ -2370,6 +2500,7 @@ exports.tests = [
     return object.foo === 42 && object.bar === 23;
   */},
   res: {
+      graalvm: false,
   }
 },
 {
@@ -2384,6 +2515,7 @@ exports.tests = [
         return [1, 2, 3].lastItem === 3;
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2392,6 +2524,7 @@ exports.tests = [
         return [1, 2, 3].lastIndex === 2;
       */},
       res: {
+        graalvm: false,
       }
     },
   ]
@@ -2412,6 +2545,7 @@ exports.tests = [
       */},
       res: {
         firefox2: false,
+        graalvm: false,
       }
     },
     {
@@ -2425,6 +2559,7 @@ exports.tests = [
       */},
       res: {
         firefox2: false,
+        graalvm: false,
       }
     },
     {
@@ -2437,6 +2572,7 @@ exports.tests = [
       */},
       res: {
         firefox2: false,
+        graalvm: false,
       }
     },
     {
@@ -2449,6 +2585,7 @@ exports.tests = [
       */},
       res: {
         firefox2: false,
+        graalvm: false,
       }
     },
   ]
@@ -2470,6 +2607,7 @@ exports.tests = [
           && map.get(1)[1] === 3;
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2481,6 +2619,7 @@ exports.tests = [
           && map.get(102).id === 102;
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2492,6 +2631,7 @@ exports.tests = [
           && map.get(3) === 6;
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2504,6 +2644,7 @@ exports.tests = [
           && map.get(9) === 6;
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2516,6 +2657,7 @@ exports.tests = [
           && map.get(3) === 36;
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2528,6 +2670,7 @@ exports.tests = [
           && map.get(3) === 6;
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2540,6 +2683,7 @@ exports.tests = [
           && set.has(3);
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2552,6 +2696,7 @@ exports.tests = [
           && set.has(4);
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2560,6 +2705,7 @@ exports.tests = [
         return new Set([1, 2, 3]).every(it => typeof it === 'number');
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2571,6 +2717,7 @@ exports.tests = [
           && set.has(3);
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2579,6 +2726,7 @@ exports.tests = [
         return new Set([1, 2, 3]).find(it => !(it % 2)) === 2;
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2587,6 +2735,7 @@ exports.tests = [
         return new Set([1, 2, 3]).join('|') === '1|2|3';
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2599,6 +2748,7 @@ exports.tests = [
           && set.has(9);
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2607,6 +2757,7 @@ exports.tests = [
         return new Set([1, 2, 3]).reduce((memo, it) => memo + it) === 6;
       */},
       res: {
+        graalvm: false,
       }
     },
     {
@@ -2615,6 +2766,7 @@ exports.tests = [
         return new Set([1, 2, 3]).some(it => it % 2);
       */},
       res: {
+        graalvm: false,
       }
     },
   ]

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -1209,6 +1209,7 @@ exports.tests = [
         opera10_50: false,
         rhino1_7: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -1233,6 +1234,7 @@ exports.tests = [
         besen: true,
         rhino1_7: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1246,6 +1248,7 @@ exports.tests = [
         opera10_50: false,
         rhino1_7: null,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1347,6 +1350,7 @@ exports.tests = [
         besen: null,
         rhino1_7: null,
         duktape2_0: false,
+        graalvm: true,
       },
     },
   ]
@@ -1367,6 +1371,7 @@ exports.tests = [
     opera10_50: false,
     rhino1_7: null,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 },
@@ -1390,6 +1395,7 @@ exports.tests = [
     phantom: true,
     android4_0: true,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1414,6 +1420,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1439,6 +1446,7 @@ exports.tests = [
     phantom: true,
     android4_0: true,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1464,6 +1472,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 },
@@ -1483,6 +1492,7 @@ exports.tests = [
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: true,
   },
 },
 {
@@ -1507,6 +1517,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1530,6 +1541,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1561,6 +1573,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -1581,6 +1594,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1601,6 +1615,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 },
@@ -1628,6 +1643,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1647,6 +1663,7 @@ exports.tests = [
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1673,6 +1690,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -1696,6 +1714,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1726,6 +1745,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -1750,6 +1770,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 },
@@ -1789,6 +1810,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1830,6 +1852,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1881,6 +1904,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   },
 },
 {
@@ -1906,6 +1930,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1931,6 +1956,7 @@ exports.tests = [
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 },
@@ -1960,6 +1986,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -1987,6 +2014,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -2015,6 +2043,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -2035,6 +2064,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -2057,6 +2087,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 },
@@ -2078,6 +2109,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -2094,6 +2126,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 },
@@ -2116,6 +2149,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   },
 },
 {
@@ -2141,6 +2175,7 @@ exports.tests = [
     ejs: true,
     android4_0: true,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 },
@@ -2163,6 +2198,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -2184,6 +2220,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   }
 },
 {
@@ -2204,6 +2241,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   },
 },
 {
@@ -2223,6 +2261,7 @@ exports.tests = [
     node0_10: true,
     android5_0: true,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 },
@@ -2256,6 +2295,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -2281,6 +2321,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -2307,6 +2348,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -2332,6 +2374,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
+    graalvm: true,
   }
 },
 {
@@ -2353,6 +2396,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
+    graalvm: true,
   },
   separator: 'after'
 }

--- a/environments.json
+++ b/environments.json
@@ -2406,10 +2406,12 @@
     ]
   },
   "graalvm": {
-    "full": "GraalVM JavaScript",
-    "family": "GraalVM",
-    "short": "GraalVM",
+    "full": "GraalVM JavaScript 1.0.0 RC3",
+    "family": "GraalVM 1.0",
+    "short": "GraalVM 1.0",
     "platformtype": "engine",
+    "note_id": "graalvm-node-mode",
+    "note_html": "Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.",
     "release": "2018-07-01",
     "unstable": false,
     "test_suites": [

--- a/environments.json
+++ b/environments.json
@@ -2405,6 +2405,21 @@
       "es6"
     ]
   },
+  "graalvm": {
+    "full": "GraalVM JavaScript",
+    "family": "GraalVM",
+    "short": "GraalVM",
+    "platformtype": "engine",
+    "release": "2018-07-01",
+    "unstable": false,
+    "test_suites": [
+      "es5",
+      "es6",
+      "es2016plus",
+      "esnext",
+      "esintl"
+    ]
+  },
   "android1_5": {
     "full": "Android Browser 1.5 (Cupcake)",
     "family": "Android Browser",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -188,6 +188,7 @@
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
+<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC3">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios9 mobile obsolete" data-browser="ios9"><a href="#ios9" class="browser-name"><abbr title="iOS Safari">iOS 9</abbr></a></th>
@@ -200,7 +201,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="78">2016 features</td>
+      <tr class="category"><td colspan="79">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -271,6 +272,7 @@
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="graalvm" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/3</td>
@@ -341,7 +343,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node7">Yes</td>
 <td class="yes obsolete" data-browser="node7_6">Yes</td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
@@ -351,6 +353,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -421,7 +424,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node7">Yes</td>
 <td class="yes obsolete" data-browser="node7_6">Yes</td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
@@ -431,6 +434,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -506,7 +510,7 @@ return true;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node7">Yes</td>
 <td class="yes obsolete" data-browser="node7_6">Yes</td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
@@ -516,6 +520,7 @@ return true;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -593,6 +598,7 @@ return true;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally" data-browser="graalvm" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -610,20 +616,20 @@ return [1, 2, 3].includes(1)
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].includes(1)\n&& ![1, 2, 3].includes(4)\n&& ![1, 2, 3].includes(1, 1)\n&& [NaN].includes(NaN)\n&& Array(1).includes();\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].includes(1)\n&& ![1, 2, 3].includes(4)\n&& ![1, 2, 3].includes(1, 1)\n&& [NaN].includes(NaN)\n&& Array(1).includes();\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20180319">Yes</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -677,6 +683,7 @@ return [1, 2, 3].includes(1)
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -712,20 +719,20 @@ return 24;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");try{return Function("asyncTestPassed","\nvar passed = 0;\nreturn [].includes.call({\nget \"0\"() {\npassed = NaN;\nreturn 'foo';\n},\nget \"11\"() {\npassed += 1;\nreturn 0;\n},\nget \"19\"() {\npassed += 1;\nreturn 'foo';\n},\nget \"21\"() {\npassed = NaN;\nreturn 'foo';\n},\nget length() {\npassed += 1;\nreturn 24;\n}\n}, 'foo', 6) === true && passed === 3;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("6");return Function("asyncTestPassed","'use strict';"+"\nvar passed = 0;\nreturn [].includes.call({\nget \"0\"() {\npassed = NaN;\nreturn 'foo';\n},\nget \"11\"() {\npassed += 1;\nreturn 0;\n},\nget \"19\"() {\npassed += 1;\nreturn 'foo';\n},\nget \"21\"() {\npassed = NaN;\nreturn 'foo';\n},\nget length() {\npassed += 1;\nreturn 24;\n}\n}, 'foo', 6) === true && passed === 3;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -779,6 +786,7 @@ return 24;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -797,20 +805,20 @@ return new TypedArray([1, 2, 3]).includes(1)
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\nreturn [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,\nInt32Array, Uint32Array, Float32Array, Float64Array].every(function(TypedArray){\nreturn new TypedArray([1, 2, 3]).includes(1)\n&& !new TypedArray([1, 2, 3]).includes(4)\n&& !new TypedArray([1, 2, 3]).includes(1, 1);\n});\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\nreturn [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,\nInt32Array, Uint32Array, Float32Array, Float64Array].every(function(TypedArray){\nreturn new TypedArray([1, 2, 3]).includes(1)\n&& !new TypedArray([1, 2, 3]).includes(4)\n&& !new TypedArray([1, 2, 3]).includes(1, 1);\n});\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -864,6 +872,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -872,9 +881,9 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="78">2016 misc</td>
+<tr class="category"><td colspan="79">2016 misc</td>
 </tr>
-<tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[6]</sup></a></span><script data-source="
+<tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
 yield 3;
 }
@@ -953,6 +962,7 @@ return true;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -961,7 +971,7 @@ return true;
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr significance="0.125"><td id="test-generator_throw()_caught_by_inner_generator"><span><a class="anchor" href="#test-generator_throw()_caught_by_inner_generator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-generatorfunction-objects">generator throw() caught by inner generator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#IteratorResult_object_returned_instead_of_throwing" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#gen-throw-note"><sup>[7]</sup></a></span><script data-source="
+<tr significance="0.125"><td id="test-generator_throw()_caught_by_inner_generator"><span><a class="anchor" href="#test-generator_throw()_caught_by_inner_generator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-generatorfunction-objects">generator throw() caught by inner generator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#IteratorResult_object_returned_instead_of_throwing" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#gen-throw-note"><sup>[8]</sup></a></span><script data-source="
 function * generator() {
 yield * (function * () {
 try {
@@ -1046,6 +1056,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1054,7 +1065,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr significance="0.125"><td id="test-strict_fn_w/_non-strict_non-simple_params_is_error"><span><a class="anchor" href="#test-strict_fn_w/_non-strict_non-simple_params_is_error">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-functiondeclarationinstantiation">strict fn w/ non-strict non-simple params is error</a><a href="#strict-fn-non-strict-params-note"><sup>[8]</sup></a></span><script data-source="
+<tr significance="0.125"><td id="test-strict_fn_w/_non-strict_non-simple_params_is_error"><span><a class="anchor" href="#test-strict_fn_w/_non-strict_non-simple_params_is_error">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-functiondeclarationinstantiation">strict fn w/ non-strict non-simple params is error</a><a href="#strict-fn-non-strict-params-note"><sup>[9]</sup></a></span><script data-source="
 function foo(...a){}
 try {
 Function(&quot;function bar(...a){&apos;use strict&apos;;}&quot;)();
@@ -1131,6 +1142,7 @@ return true;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1139,7 +1151,7 @@ return true;
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr significance="0.125"><td id="test-nested_rest_destructuring,_declarations"><span><a class="anchor" href="#test-nested_rest_destructuring,_declarations">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-destructuring-assignment">nested rest destructuring, declarations</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Nested_object_and_array_destructuring" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#nested-rest-destruct-decl-note"><sup>[9]</sup></a></span><script data-source="
+<tr significance="0.125"><td id="test-nested_rest_destructuring,_declarations"><span><a class="anchor" href="#test-nested_rest_destructuring,_declarations">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-destructuring-assignment">nested rest destructuring, declarations</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Nested_object_and_array_destructuring" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#nested-rest-destruct-decl-note"><sup>[10]</sup></a></span><script data-source="
 var [x, ...[y, ...z]] = [1,2,3,4];
 return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -1212,6 +1224,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1220,7 +1233,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr significance="0.125"><td id="test-nested_rest_destructuring,_parameters"><span><a class="anchor" href="#test-nested_rest_destructuring,_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-destructuring-assignment">nested rest destructuring, parameters</a><a href="#nested-rest-destruct-params-note"><sup>[10]</sup></a></span><script data-source="
+<tr significance="0.125"><td id="test-nested_rest_destructuring,_parameters"><span><a class="anchor" href="#test-nested_rest_destructuring,_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-destructuring-assignment">nested rest destructuring, parameters</a><a href="#nested-rest-destruct-params-note"><sup>[11]</sup></a></span><script data-source="
 return function([x, ...[y, ...z]]) {
 return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos;;
 }([1,2,3,4]);
@@ -1294,6 +1307,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1302,7 +1316,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr significance="0.125"><td id="test-Proxy,_enumerate_handler_removed"><span><a class="anchor" href="#test-Proxy,_enumerate_handler_removed">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-proxy-objects">Proxy, &quot;enumerate&quot; handler removed</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/enumerate" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-enumerate-removed-note"><sup>[11]</sup></a></span><script data-source="
+<tr significance="0.125"><td id="test-Proxy,_enumerate_handler_removed"><span><a class="anchor" href="#test-Proxy,_enumerate_handler_removed">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-proxy-objects">Proxy, &quot;enumerate&quot; handler removed</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/enumerate" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-enumerate-removed-note"><sup>[12]</sup></a></span><script data-source="
 var passed = true;
 var proxy = new Proxy({}, {
 enumerate: function() {
@@ -1381,6 +1395,7 @@ return passed;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1470,6 +1485,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1478,7 +1494,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="78">2017 features</td>
+<tr class="category"><td colspan="79">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1549,6 +1565,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally" data-browser="graalvm" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/4</td>
@@ -1565,20 +1582,20 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar v = Object.values(obj);\nreturn Array.isArray(v) && String(v) === \"foo,bar,baz\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar v = Object.values(obj);\nreturn Array.isArray(v) && String(v) === \"foo,bar,baz\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20180319">Yes</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1622,7 +1639,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node7">Yes</td>
 <td class="yes obsolete" data-browser="node7_6">Yes</td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
@@ -1632,6 +1649,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1652,20 +1670,20 @@ return Array.isArray(e)
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar e = Object.entries(obj);\nreturn Array.isArray(e)\n&& e.length === 3\n&& String(e[0]) === \"a,foo\"\n&& String(e[1]) === \"b,bar\"\n&& String(e[2]) === \"c,baz\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar e = Object.entries(obj);\nreturn Array.isArray(e)\n&& e.length === 3\n&& String(e[0]) === \"a,foo\"\n&& String(e[1]) === \"b,bar\"\n&& String(e[2]) === \"c,baz\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20180319">Yes</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1709,7 +1727,7 @@ return Array.isArray(e)
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node7">Yes</td>
 <td class="yes obsolete" data-browser="node7_6">Yes</td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
@@ -1719,6 +1737,7 @@ return Array.isArray(e)
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1740,20 +1759,20 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n&& D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n&& D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n&& D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n&& D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20180319">Yes</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1797,7 +1816,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node7">Yes</td>
 <td class="yes obsolete" data-browser="node7_6">Yes</td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
@@ -1807,6 +1826,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1823,20 +1843,20 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nvar P = new Proxy({a:1}, {\n  getOwnPropertyDescriptor: function(t, k) {}\n});\nreturn !Object.getOwnPropertyDescriptors(P).hasOwnProperty('a');\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nvar P = new Proxy({a:1}, {\n  getOwnPropertyDescriptor: function(t, k) {}\n});\nreturn !Object.getOwnPropertyDescriptors(P).hasOwnProperty('a');\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1890,6 +1910,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1967,6 +1988,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/2</td>
@@ -1985,24 +2007,24 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn 'hello'.padStart(10) === '     hello'\n&& 'hello'.padStart(10, '1234') === '12341hello'\n&& 'hello'.padStart() === 'hello'\n&& 'hello'.padStart(6, '123') === '1hello'\n&& 'hello'.padStart(3) === 'hello'\n&& 'hello'.padStart(3, '123') === 'hello';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn 'hello'.padStart(10) === '     hello'\n&& 'hello'.padStart(10, '1234') === '12341hello'\n&& 'hello'.padStart() === 'hello'\n&& 'hello'.padStart(6, '123') === '1hello'\n&& 'hello'.padStart(3) === 'hello'\n&& 'hello'.padStart(3, '123') === 'hello';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20180319">Yes</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2043,8 +2065,8 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
 <td class="no" data-browser="node6_5">No</td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
@@ -2052,6 +2074,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2070,24 +2093,24 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\nreturn 'hello'.padEnd(10) === 'hello     '\n&& 'hello'.padEnd(10, '1234') === 'hello12341'\n&& 'hello'.padEnd() === 'hello'\n&& 'hello'.padEnd(6, '123') === 'hello1'\n&& 'hello'.padEnd(3) === 'hello'\n&& 'hello'.padEnd(3, '123') === 'hello';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\nreturn 'hello'.padEnd(10) === 'hello     '\n&& 'hello'.padEnd(10, '1234') === 'hello12341'\n&& 'hello'.padEnd() === 'hello'\n&& 'hello'.padEnd(6, '123') === 'hello1'\n&& 'hello'.padEnd(3) === 'hello'\n&& 'hello'.padEnd(3, '123') === 'hello';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20180319">Yes</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2128,8 +2151,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
 <td class="no" data-browser="node6_5">No</td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
@@ -2137,6 +2160,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2214,6 +2238,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/2</td>
@@ -2294,6 +2319,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2374,6 +2400,7 @@ return Math.min(1,2,3,) === 1;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2451,6 +2478,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/15</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/15</td>
+<td class="tally" data-browser="graalvm" data-tally="0.8666666666666667" style="background-color:hsl(104,47%,50%)">13/15</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/15</td>
@@ -2475,24 +2503,24 @@ p.then(function(result) {
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nasync function a(){\n  return \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){\n  return \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-regenerator-note"><sup>[13]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-regenerator-note"><sup>[13]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20180319">Yes</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2533,7 +2561,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
 <td class="no" data-browser="node6_5">No</td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node7_6">Yes</td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
@@ -2542,6 +2570,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2583,7 +2612,7 @@ p.catch(function(result) {
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2633,6 +2662,7 @@ p.catch(function(result) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2664,7 +2694,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2714,6 +2744,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2745,7 +2776,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2795,6 +2826,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2815,24 +2847,24 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\n(async function (){\n  await Promise.resolve();\n  var a1 = await new Promise(function(resolve) { setTimeout(resolve,800,\"foo\"); });\n  var a2 = await new Promise(function(resolve) { setTimeout(resolve,800,\"bar\"); });\n  if (a1 + a2 === \"foobar\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\n(async function (){\n  await Promise.resolve();\n  var a1 = await new Promise(function(resolve) { setTimeout(resolve,800,\"foo\"); });\n  var a2 = await new Promise(function(resolve) { setTimeout(resolve,800,\"bar\"); });\n  if (a1 + a2 === \"foobar\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-regenerator-note"><sup>[13]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-regenerator-note"><sup>[13]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20180319">Yes</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-async-await-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-async-await-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2873,7 +2905,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
 <td class="no" data-browser="node6_5">No</td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node7_6">Yes</td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
@@ -2882,6 +2914,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2921,7 +2954,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -2971,6 +3004,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3002,7 +3036,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -3052,6 +3086,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3088,7 +3123,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -3138,6 +3173,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3169,7 +3205,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -3219,6 +3255,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3260,7 +3297,7 @@ p.then(function(result) {
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -3310,6 +3347,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3351,7 +3389,7 @@ p.then(function(result) {
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -3401,6 +3439,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3423,8 +3462,8 @@ p.then(function(result) {
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nvar a = async () => await Promise.resolve(\"foo\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nvar a = async () => await Promise.resolve(\"foo\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-regenerator-note"><sup>[13]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-regenerator-note"><sup>[13]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20180319">Yes</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
@@ -3440,7 +3479,7 @@ p.then(function(result) {
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -3481,7 +3520,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
 <td class="no" data-browser="node6_5">No</td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node7_6">Yes</td>
 <td class="yes obsolete" data-browser="node8">Yes</td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
@@ -3490,6 +3529,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3522,7 +3562,7 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -3572,6 +3612,7 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3652,6 +3693,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3691,7 +3733,7 @@ p.then(function(result) {
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge14">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
@@ -3741,6 +3783,7 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3818,6 +3861,7 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/17</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/17</td>
+<td class="tally" data-browser="graalvm" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/17</td>
@@ -3849,62 +3893,63 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
-<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
-<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_SharedArrayBuffer[Symbol.species]"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_SharedArrayBuffer[Symbol.species]">&#xA7;</a>SharedArrayBuffer[Symbol.species]</span><script data-source="
 return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
@@ -3929,41 +3974,41 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
-<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -3978,13 +4023,14 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
-<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength_SharedArrayBuffer.prototype.byteLength_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength_SharedArrayBuffer.prototype.byteLength_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength">SharedArrayBuffer.prototype.byteLength</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
@@ -4009,62 +4055,63 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="no obsolete" data-browser="safari10_1">No</td>
-<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
-<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.slice_SharedArrayBuffer.prototype.slice_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.slice_SharedArrayBuffer.prototype.slice_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.slice">SharedArrayBuffer.prototype.slice</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
@@ -4089,41 +4136,41 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
-<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -4138,13 +4185,14 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
-<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.toString_SharedArrayBuffer.prototype[Symbol.toStringTag]_/a"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.toString_SharedArrayBuffer.prototype[Symbol.toStringTag]_/a">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.toString">SharedArrayBuffer.prototype[Symbol.toStringTag]</a></span><script data-source="
 return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuffer&apos;;
@@ -4169,62 +4217,63 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
-<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
-<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.add_Atomics.add_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.add_Atomics.add_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.add">Atomics.add</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.add == &apos;function&apos;;
@@ -4249,62 +4298,63 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.and_Atomics.and_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.and_Atomics.and_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.and">Atomics.and</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.and == &apos;function&apos;;
@@ -4329,62 +4379,63 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.compareExchange_Atomics.compareExchange_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.compareExchange_Atomics.compareExchange_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.compareExchange">Atomics.compareExchange</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.compareExchange == &apos;function&apos;;
@@ -4409,62 +4460,63 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.exchange_Atomics.exchange_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.exchange_Atomics.exchange_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.exchange">Atomics.exchange</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.exchange == &apos;function&apos;;
@@ -4489,62 +4541,63 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.wait_Atomics.wait_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.wait_Atomics.wait_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.wait">Atomics.wait</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.wait == &apos;function&apos;;
@@ -4569,62 +4622,63 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.wake_Atomics.wake_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.wake_Atomics.wake_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.wake">Atomics.wake</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.wake == &apos;function&apos;;
@@ -4649,62 +4703,63 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.isLockFree_Atomics.isLockFree_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.isLockFree_Atomics.isLockFree_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.isLockFree">Atomics.isLockFree</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.isLockFree == &apos;function&apos;;
@@ -4729,62 +4784,63 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.load_Atomics.load_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.load_Atomics.load_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.load">Atomics.load</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.load == &apos;function&apos;;
@@ -4809,62 +4865,63 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.or_Atomics.or_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.or_Atomics.or_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.or">Atomics.or</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.or == &apos;function&apos;;
@@ -4889,62 +4946,63 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.store_Atomics.store_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.store_Atomics.store_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.store">Atomics.store</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.store == &apos;function&apos;;
@@ -4969,62 +5027,63 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.sub_Atomics.sub_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.sub_Atomics.sub_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.sub">Atomics.sub</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.sub == &apos;function&apos;;
@@ -5049,62 +5108,63 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.xor_Atomics.xor_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.xor_Atomics.xor_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.xor">Atomics.xor</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.xor == &apos;function&apos;;
@@ -5129,66 +5189,67 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="edge16">Yes</td>
-<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[15]</sup></a></td>
-<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[16]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no unstable" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[17]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox54">Flag<a href="#firefox-sharedmem-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#fx-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
-<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="chrome63">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome64">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="chrome65">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome66">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="chrome67">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome68">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="chrome69">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="yes obsolete" data-browser="safari10_1">Yes</td>
 <td class="yes" data-browser="safari11">Yes</td>
-<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[19]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes" data-browser="ios11">Yes</td>
-<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[22]</sup></a></td>
 </tr>
-<tr class="category"><td colspan="78">2017 misc</td>
+<tr class="category"><td colspan="79">2017 misc</td>
 </tr>
-<tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[22]</sup></a></span><script data-source="
+<tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[23]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
 ownKeys: function() {
 return [&apos;a&apos;,&apos;a&apos;,&apos;b&apos;,&apos;b&apos;];
@@ -5265,6 +5326,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5348,6 +5410,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5431,6 +5494,7 @@ return (function(){
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5439,7 +5503,7 @@ return (function(){
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="78">2017 annex b</td>
+<tr class="category"><td colspan="79">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -5510,6 +5574,7 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.625">6/16</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.625">6/16</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">16/16</td>
@@ -5528,20 +5593,20 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\nvar obj = {};\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5595,6 +5660,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5614,20 +5680,20 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");try{return Function("asyncTestPassed","\nvar obj = {};\nvar sym = Symbol();\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("65");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nvar sym = Symbol();\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5681,8 +5747,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
-<td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
+<td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
 <td class="yes obsolete" data-browser="ios10">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5700,20 +5767,20 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\nvar key = '__accessors_test__';\n__defineGetter__.call(1, key, function(){});\ntry {\n__defineGetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\nvar key = '__accessors_test__';\n__defineGetter__.call(1, key, function(){});\ntry {\n__defineGetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5735,8 +5802,8 @@ return true;
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
@@ -5761,12 +5828,13 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node7_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5785,20 +5853,20 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\nvar obj = {};\nfunction bar() {}\nObject.prototype.__defineSetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nfunction bar() {}\nObject.prototype.__defineSetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -5852,6 +5920,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5871,20 +5940,20 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nvar obj = {};\nvar sym = Symbol();\nfunction bar(baz) {}\nObject.prototype.__defineSetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nvar sym = Symbol();\nfunction bar(baz) {}\nObject.prototype.__defineSetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5938,8 +6007,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
-<td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
+<td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
 <td class="yes obsolete" data-browser="ios10">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5957,20 +6027,20 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nvar key = '__accessors_test__';\n__defineSetter__.call(1, key, function(){});\ntry {\n__defineSetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nvar key = '__accessors_test__';\n__defineSetter__.call(1, key, function(){});\ntry {\n__defineSetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5992,8 +6062,8 @@ return true;
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
@@ -6018,12 +6088,13 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node7_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6044,20 +6115,20 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6111,6 +6182,7 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6131,20 +6203,20 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6198,6 +6270,7 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6219,20 +6292,20 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { get: function() { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupGetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupGetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { get: function() { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupGetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupGetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6286,8 +6359,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
-<td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
+<td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
 <td class="yes obsolete" data-browser="ios10">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6304,20 +6378,20 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\n__lookupGetter__.call(1, 'key');\ntry {\n__lookupGetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\n__lookupGetter__.call(1, 'key');\ntry {\n__lookupGetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6339,8 +6413,8 @@ return true;
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
@@ -6365,12 +6439,13 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node7_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6388,20 +6463,20 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");try{return Function("asyncTestPassed","\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineGetter__(\"foo\", function () {})\nreturn b.__lookupGetter__(\"foo\") === undefined\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("74");return Function("asyncTestPassed","'use strict';"+"\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineGetter__(\"foo\", function () {})\nreturn b.__lookupGetter__(\"foo\") === undefined\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6455,6 +6530,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6475,20 +6551,20 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("75");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("75");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6542,6 +6618,7 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6562,20 +6639,20 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6629,6 +6706,7 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6650,20 +6728,20 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");try{return Function("asyncTestPassed","\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("77");return Function("asyncTestPassed","'use strict';"+"\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6717,8 +6795,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
-<td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
+<td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
 <td class="yes obsolete" data-browser="ios10">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6735,20 +6814,20 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");try{return Function("asyncTestPassed","\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("78");return Function("asyncTestPassed","'use strict';"+"\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6770,8 +6849,8 @@ return true;
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
@@ -6796,12 +6875,13 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node7_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6819,20 +6899,20 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");try{return Function("asyncTestPassed","\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineSetter__(\"foo\", function () {})\nreturn b.__lookupSetter__(\"foo\") === undefined\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("79");return Function("asyncTestPassed","'use strict';"+"\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineSetter__(\"foo\", function () {})\nreturn b.__lookupSetter__(\"foo\") === undefined\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6886,6 +6966,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6963,6 +7044,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/4</td>
@@ -7047,6 +7129,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7131,6 +7214,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7220,6 +7304,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7309,6 +7394,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7390,6 +7476,7 @@ return i === 0;
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="graalvm" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7398,7 +7485,7 @@ return i === 0;
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="78">2018 features</td>
+<tr class="category"><td colspan="79">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -7469,6 +7556,7 @@ return i === 0;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/2</td>
@@ -7517,7 +7605,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
@@ -7543,13 +7631,14 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no" data-browser="node6_5">No</td>
 <td class="no obsolete" data-browser="node7">No</td>
 <td class="no obsolete" data-browser="node7_6">No</td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7599,7 +7688,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome60">Yes</td>
 <td class="yes obsolete" data-browser="chrome61">Yes</td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
@@ -7625,13 +7714,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no" data-browser="node6_5">No</td>
 <td class="no obsolete" data-browser="node7">No</td>
 <td class="no obsolete" data-browser="node7_6">No</td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-experimental-note"><sup>[3]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7709,6 +7799,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally" data-browser="graalvm" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/3</td>
@@ -7748,20 +7839,20 @@ function check() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("90");try{return Function("asyncTestPassed","\nvar p1 = Promise.resolve(\"foo\");\nvar p2 = Promise.reject(\"bar\");\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score += (arguments.length === 0);\n  check();\n}\np1.then(thenFn);\np1.finally(finallyFn);\np1.finally(function() {\n  // should return a new Promise\n  score += p1.finally() !== p1;\n  check();\n});\np2.catch(catchFn);\np2.finally(finallyFn);\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("90");return Function("asyncTestPassed","'use strict';"+"\nvar p1 = Promise.resolve(\"foo\");\nvar p2 = Promise.reject(\"bar\");\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score += (arguments.length === 0);\n  check();\n}\np1.then(thenFn);\np1.finally(finallyFn);\np1.finally(function() {\n  // should return a new Promise\n  score += p1.finally() !== p1;\n  check();\n});\np2.catch(catchFn);\np2.finally(finallyFn);\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7784,8 +7875,8 @@ function check() {
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
-<td class="no obsolete" data-browser="chrome61">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome62">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome61">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome62">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
 <td class="yes obsolete" data-browser="chrome65">Yes</td>
@@ -7810,11 +7901,12 @@ function check() {
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
-<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7846,20 +7938,20 @@ function check() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("91");try{return Function("asyncTestPassed","\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score++;\n  check();\n  return Promise.resolve(\"foobar\");\n}\nPromise.resolve(\"foo\").finally(finallyFn).then(thenFn);\nPromise.reject(\"bar\").finally(finallyFn).catch(catchFn);\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("91");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score++;\n  check();\n  return Promise.resolve(\"foobar\");\n}\nPromise.resolve(\"foo\").finally(finallyFn).then(thenFn);\nPromise.reject(\"bar\").finally(finallyFn).catch(catchFn);\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7882,8 +7974,8 @@ function check() {
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
-<td class="no obsolete" data-browser="chrome61">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome62">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome61">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome62">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
 <td class="yes obsolete" data-browser="chrome65">Yes</td>
@@ -7908,11 +8000,12 @@ function check() {
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
-<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7946,20 +8039,20 @@ function check() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise\n  .reject(\"foobar\")\n  .finally(function() {\n    return Promise.reject(\"foo\");\n  })\n  .catch(function(result) {\n    score += (result === \"foo\");\n    check();\n    return Promise.reject(\"foobar\");\n  })\n  .finally(function() {\n    throw new Error('bar');\n  })\n  .catch(function(result) {\n    score += (result.message === \"bar\");\n    check();\n  });\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("92");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise\n  .reject(\"foobar\")\n  .finally(function() {\n    return Promise.reject(\"foo\");\n  })\n  .catch(function(result) {\n    score += (result === \"foo\");\n    check();\n    return Promise.reject(\"foobar\");\n  })\n  .finally(function() {\n    throw new Error('bar');\n  })\n  .catch(function(result) {\n    score += (result.message === \"bar\");\n    check();\n  });\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="yes obsolete" data-browser="closure20180402">Yes</td>
 <td class="yes obsolete" data-browser="closure20180506">Yes</td>
 <td class="yes" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7982,8 +8075,8 @@ function check() {
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
-<td class="no obsolete" data-browser="chrome61">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome62">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome61">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome62">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
 <td class="yes obsolete" data-browser="chrome65">Yes</td>
@@ -8008,11 +8101,12 @@ function check() {
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
-<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8062,8 +8156,8 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="no unstable" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="unknown obsolete" data-browser="chrome59">?</td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
@@ -8088,12 +8182,13 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="unknown obsolete" data-browser="node7">?</td>
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8149,10 +8244,10 @@ return result.groups.year === &apos;2016&apos;
 <td class="no unstable" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
 <td class="yes obsolete" data-browser="chrome65">Yes</td>
 <td class="yes" data-browser="chrome66">Yes</td>
@@ -8175,12 +8270,13 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="node7">No</td>
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8229,9 +8325,9 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no unstable" data-browser="firefox62">No</td>
 <td class="no unstable" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
@@ -8252,16 +8348,17 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no" data-browser="node4">No</td>
-<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged" data-browser="node6_5">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8310,11 +8407,11 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no unstable" data-browser="firefox62">No</td>
 <td class="no unstable" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
 <td class="yes obsolete" data-browser="chrome65">Yes</td>
 <td class="yes" data-browser="chrome66">Yes</td>
@@ -8337,12 +8434,13 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no obsolete" data-browser="node7">No</td>
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8420,6 +8518,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/2</td>
@@ -8464,8 +8563,8 @@ iterator.next().then(function(step){
 <td class="no unstable" data-browser="edge18">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox54">No</td>
-<td class="no obsolete" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[26]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
@@ -8477,7 +8576,7 @@ iterator.next().then(function(step){
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
 <td class="no obsolete" data-browser="chrome61">No</td>
-<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
 <td class="yes obsolete" data-browser="chrome65">Yes</td>
@@ -8503,10 +8602,11 @@ iterator.next().then(function(step){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8561,8 +8661,8 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no unstable" data-browser="edge18">No</td>
 <td class="no" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox54">No</td>
-<td class="no obsolete" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox55">No<a href="#firefox-nightly-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox56">No<a href="#firefox-nightly-note"><sup>[26]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
@@ -8574,7 +8674,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
 <td class="no obsolete" data-browser="chrome61">No</td>
-<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
 <td class="yes obsolete" data-browser="chrome65">Yes</td>
@@ -8600,10 +8700,11 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8612,7 +8713,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="ios11">No</td>
 <td class="no" data-browser="ios11_3">No</td>
 </tr>
-<tr class="category"><td colspan="78">2018 misc</td>
+<tr class="category"><td colspan="79">2018 misc</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -8660,9 +8761,9 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome62">Yes</td>
 <td class="yes obsolete" data-browser="chrome63">Yes</td>
 <td class="yes obsolete" data-browser="chrome64">Yes</td>
@@ -8687,12 +8788,13 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no obsolete" data-browser="node7">No</td>
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8701,7 +8803,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="78">2019 misc</td>
+<tr class="category"><td colspan="79">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://tc39.github.io/proposal-optional-catch-binding/">optional catch binding</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
@@ -8772,6 +8874,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/3</td>
@@ -8831,7 +8934,7 @@ return false;
 <td class="no obsolete" data-browser="chrome62">No</td>
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
-<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes" data-browser="chrome66">Yes</td>
 <td class="yes" data-browser="chrome67">Yes</td>
 <td class="yes unstable" data-browser="chrome68">Yes</td>
@@ -8858,6 +8961,7 @@ return false;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8918,7 +9022,7 @@ return false;
 <td class="no obsolete" data-browser="chrome62">No</td>
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
-<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes" data-browser="chrome66">Yes</td>
 <td class="yes" data-browser="chrome67">Yes</td>
 <td class="yes unstable" data-browser="chrome68">Yes</td>
@@ -8945,6 +9049,7 @@ return false;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9010,7 +9115,7 @@ return it.next().value;
 <td class="no obsolete" data-browser="chrome62">No</td>
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
-<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[24]</sup></a></td>
 <td class="yes" data-browser="chrome66">Yes</td>
 <td class="yes" data-browser="chrome67">Yes</td>
 <td class="yes unstable" data-browser="chrome68">Yes</td>
@@ -9037,6 +9142,7 @@ return it.next().value;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9049,7 +9155,7 @@ return it.next().value;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="chrome-experimental-note">  <sup>[3]</sup> The feature have to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[4]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[5]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[6]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[7]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="strict-fn-non-strict-params-note">  <sup>[8]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[9]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[11]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="edge-experimental-flag-note">  <sup>[12]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-regenerator-note">  <sup>[13]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="typescript-async-await-note">  <sup>[14]</sup> TypeScript <code>async</code> / <code>await</code> requires native generators support.</p><p id="edg-shared-memory-spectre-note">  <sup>[15]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="firefox-developer-note">  <sup>[16]</sup> The feature is available only in Firefox Developer Edition and Firefox Nightly builds.</p><p id="firefox-sharedmem-note">  <sup>[17]</sup> The feature have to be enabled via &quot;javascript.options.shared_memory&quot; setting under <code>about:config</code>.  It is enabled by default in Firefox Developer Edition and Firefox Nightly builds.</p><p id="fx-shared-memory-spectre-note">  <sup>[18]</sup> The feature was <a href="https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[19]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="chr-shared-memory-spectre-note">  <sup>[20]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[21]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="proxy-duplictate-ownkeys-updated-note">  <sup>[22]</sup> The behaviour of the Proxy &#x201C;ownKeys&#x201D; handler in presence of duplicate keys has been <a href="https://github.com/tc39/ecma262/issues/833">modified later</a>.</p><p id="chrome-harmony-note">  <sup>[23]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="chrome-promise-note">  <sup>[24]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="firefox-nightly-note">  <sup>[25]</sup> The feature is available only in Firefox Nightly builds.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="chrome-experimental-note">  <sup>[4]</sup> The feature have to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="strict-fn-non-strict-params-note">  <sup>[9]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[12]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="edge-experimental-flag-note">  <sup>[13]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="typescript-async-await-note">  <sup>[15]</sup> TypeScript <code>async</code> / <code>await</code> requires native generators support.</p><p id="edg-shared-memory-spectre-note">  <sup>[16]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="firefox-developer-note">  <sup>[17]</sup> The feature is available only in Firefox Developer Edition and Firefox Nightly builds.</p><p id="firefox-sharedmem-note">  <sup>[18]</sup> The feature have to be enabled via &quot;javascript.options.shared_memory&quot; setting under <code>about:config</code>.  It is enabled by default in Firefox Developer Edition and Firefox Nightly builds.</p><p id="fx-shared-memory-spectre-note">  <sup>[19]</sup> The feature was <a href="https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[20]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="chr-shared-memory-spectre-note">  <sup>[21]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[22]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="proxy-duplictate-ownkeys-updated-note">  <sup>[23]</sup> The behaviour of the Proxy &#x201C;ownKeys&#x201D; handler in presence of duplicate keys has been <a href="https://github.com/tc39/ecma262/issues/833">modified later</a>.</p><p id="chrome-harmony-note">  <sup>[24]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="chrome-promise-note">  <sup>[25]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="firefox-nightly-note">  <sup>[26]</sup> The feature is available only in Firefox Nightly builds.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/es5/index.html
+++ b/es5/index.html
@@ -189,6 +189,7 @@
 <th class="platform nashorn1_8 engine" data-browser="nashorn1_8"><a href="#nashorn1_8" class="browser-name"><abbr title="Oracle Nashorn 1.8">JJS 1.8</abbr></a></th>
 <th class="platform nashorn9 engine obsolete" data-browser="nashorn9"><a href="#nashorn9" class="browser-name"><abbr title="Oracle Nashorn 9">JJS 9</abbr></a></th>
 <th class="platform nashorn10 engine" data-browser="nashorn10"><a href="#nashorn10" class="browser-name"><abbr title="Oracle Nashorn 10">JJS 10</abbr></a></th>
+<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC3">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios9 mobile obsolete" data-browser="ios9"><a href="#ios9" class="browser-name"><abbr title="iOS Safari">iOS 9</abbr></a></th>
@@ -269,6 +270,7 @@
 <td class="tally" data-browser="nashorn1_8" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">5/5</td>
 <td class="tally" data-browser="nashorn10" data-tally="1">5/5</td>
+<td class="tally" data-browser="graalvm" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">5/5</td>
@@ -348,6 +350,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -429,6 +432,7 @@ return value === 1;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -508,6 +512,7 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -587,6 +592,7 @@ return [1,].length === 1;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -666,6 +672,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -674,7 +681,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr><th colspan="77" class="separator"></th>
+<tr><th colspan="78" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -744,6 +751,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="nashorn1_8" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">13/13</td>
 <td class="tally" data-browser="nashorn10" data-tally="1">13/13</td>
+<td class="tally" data-browser="graalvm" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">13/13</td>
@@ -825,6 +833,7 @@ return typeof Object.create == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -842,7 +851,7 @@ return typeof Object.defineProperty == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="yes obsolete" data-browser="konq4_13">Yes</td>
 <td class="yes" data-browser="konq4_14">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes<a href="#define-property-ie-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="ie8">Yes<a href="#define-property-ie-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -906,6 +915,7 @@ return typeof Object.defineProperty == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -987,6 +997,7 @@ return typeof Object.defineProperties == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1068,6 +1079,7 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1149,6 +1161,7 @@ return typeof Object.keys == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1230,6 +1243,7 @@ return typeof Object.seal == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1311,6 +1325,7 @@ return typeof Object.freeze == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1392,6 +1407,7 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1473,6 +1489,7 @@ return typeof Object.isSealed == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1554,6 +1571,7 @@ return typeof Object.isFrozen == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1635,6 +1653,7 @@ return typeof Object.isExtensible == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1652,7 +1671,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="yes obsolete" data-browser="konq4_13">Yes</td>
 <td class="yes" data-browser="konq4_14">Yes</td>
-<td class="yes obsolete" data-browser="ie8">Yes<a href="#get-own-property-descriptor-ie-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="ie8">Yes<a href="#get-own-property-descriptor-ie-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -1716,6 +1735,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1797,6 +1817,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1873,6 +1894,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally" data-browser="nashorn1_8" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">12/12</td>
 <td class="tally" data-browser="nashorn10" data-tally="1">12/12</td>
+<td class="tally" data-browser="graalvm" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
@@ -1954,6 +1976,7 @@ return typeof Array.isArray == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2035,6 +2058,7 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2116,6 +2140,7 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2130,7 +2155,7 @@ return typeof Array.prototype.every == &apos;function&apos;;
 function () {
 return typeof Array.prototype.every == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[7]</sup></a></td>
 <td class="yes obsolete" data-browser="konq4_13">Yes</td>
 <td class="yes" data-browser="konq4_14">Yes</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -2197,6 +2222,7 @@ return typeof Array.prototype.every == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2211,7 +2237,7 @@ return typeof Array.prototype.some == &apos;function&apos;;
 function () {
 return typeof Array.prototype.some == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[7]</sup></a></td>
 <td class="yes obsolete" data-browser="konq4_13">Yes</td>
 <td class="yes" data-browser="konq4_14">Yes</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -2278,6 +2304,7 @@ return typeof Array.prototype.some == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2292,7 +2319,7 @@ return typeof Array.prototype.forEach == &apos;function&apos;;
 function () {
 return typeof Array.prototype.forEach == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[7]</sup></a></td>
 <td class="yes obsolete" data-browser="konq4_13">Yes</td>
 <td class="yes" data-browser="konq4_14">Yes</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -2359,6 +2386,7 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2373,7 +2401,7 @@ return typeof Array.prototype.map == &apos;function&apos;;
 function () {
 return typeof Array.prototype.map == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[7]</sup></a></td>
 <td class="yes obsolete" data-browser="konq4_13">Yes</td>
 <td class="yes" data-browser="konq4_14">Yes</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -2440,6 +2468,7 @@ return typeof Array.prototype.map == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2454,7 +2483,7 @@ return typeof Array.prototype.filter == &apos;function&apos;;
 function () {
 return typeof Array.prototype.filter == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[7]</sup></a></td>
 <td class="yes obsolete" data-browser="konq4_13">Yes</td>
 <td class="yes" data-browser="konq4_14">Yes</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -2521,6 +2550,7 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2535,7 +2565,7 @@ return typeof Array.prototype.reduce == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduce == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[7]</sup></a></td>
 <td class="yes obsolete" data-browser="konq4_13">Yes</td>
 <td class="yes" data-browser="konq4_14">Yes</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -2602,6 +2632,7 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2616,7 +2647,7 @@ return typeof Array.prototype.reduceRight == &apos;function&apos;;
 function () {
 return typeof Array.prototype.reduceRight == 'function';
     }())</script></td>
-<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[7]</sup></a></td>
 <td class="yes obsolete" data-browser="konq4_13">Yes</td>
 <td class="yes" data-browser="konq4_14">Yes</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -2683,6 +2714,7 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2804,6 +2836,7 @@ return true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2895,6 +2928,7 @@ try {
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2971,6 +3005,7 @@ try {
 <td class="tally" data-browser="nashorn1_8" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">2/2</td>
 <td class="tally" data-browser="nashorn10" data-tally="1">2/2</td>
+<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">2/2</td>
@@ -3052,6 +3087,7 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -3133,6 +3169,7 @@ return typeof String.prototype.trim == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -3209,6 +3246,7 @@ return typeof String.prototype.trim == 'function';
 <td class="tally" data-browser="nashorn1_8" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">3/3</td>
 <td class="tally" data-browser="nashorn10" data-tally="1">3/3</td>
+<td class="tally" data-browser="graalvm" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -3290,6 +3328,7 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -3371,6 +3410,7 @@ return typeof Date.now == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -3460,6 +3500,7 @@ try {
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3541,6 +3582,7 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -3622,6 +3664,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -3630,7 +3673,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="ios11">Yes</td>
 <td class="yes" data-browser="ios11_3">Yes</td>
 </tr>
-<tr><th colspan="77" class="separator"></th>
+<tr><th colspan="78" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -3700,6 +3743,7 @@ return typeof JSON == 'object';
 <td class="tally" data-browser="nashorn1_8" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">3/3</td>
 <td class="tally" data-browser="nashorn10" data-tally="1">3/3</td>
+<td class="tally" data-browser="graalvm" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">3/3</td>
@@ -3782,6 +3826,7 @@ return result;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -3864,6 +3909,7 @@ return result;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -3946,6 +3992,7 @@ return result;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -4022,6 +4069,7 @@ return result;
 <td class="tally" data-browser="nashorn1_8" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">8/8</td>
 <td class="tally" data-browser="nashorn10" data-tally="1">8/8</td>
+<td class="tally" data-browser="graalvm" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -4111,6 +4159,7 @@ try {
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -4192,6 +4241,7 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -4271,6 +4321,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -4350,6 +4401,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -4430,6 +4482,7 @@ return _\u200c\u200d;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -4511,6 +4564,7 @@ return true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -4598,6 +4652,7 @@ return result;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4683,6 +4738,7 @@ catch(e) {
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -4759,6 +4815,7 @@ catch(e) {
 <td class="tally" data-browser="nashorn1_8" data-tally="0.8947368421052632" style="background-color:hsl(107,46%,50%)">17/19</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="0.8947368421052632" style="background-color:hsl(107,46%,50%)">17/19</td>
 <td class="tally" data-browser="nashorn10" data-tally="0.8947368421052632" style="background-color:hsl(107,46%,50%)">17/19</td>
+<td class="tally" data-browser="graalvm" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">19/19</td>
@@ -4843,6 +4900,7 @@ return true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -4861,13 +4919,13 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="no" data-browser="konq4_14">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
 <td class="no obsolete" data-browser="ie9">No</td>
-<td class="yes obsolete" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes" data-browser="edge17">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
-<td class="yes unstable" data-browser="edge18">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="edge16">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="edge17">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+<td class="yes unstable" data-browser="edge18">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="firefox52">Yes</td>
 <td class="yes obsolete" data-browser="firefox54">Yes</td>
 <td class="yes obsolete" data-browser="firefox55">Yes</td>
@@ -4923,6 +4981,7 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5005,6 +5064,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5101,6 +5161,7 @@ return test(String, &apos;&apos;)
 <td class="no" data-browser="nashorn1_8">No</td>
 <td class="no obsolete" data-browser="nashorn9">No</td>
 <td class="no" data-browser="nashorn10">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5183,6 +5244,7 @@ return true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5263,6 +5325,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5347,6 +5410,7 @@ return true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5431,6 +5495,7 @@ return true;
 <td class="no" data-browser="nashorn1_8">No</td>
 <td class="no obsolete" data-browser="nashorn9">No</td>
 <td class="no" data-browser="nashorn10">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5517,6 +5582,7 @@ return true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5600,6 +5666,7 @@ return true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5681,6 +5748,7 @@ return true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5763,6 +5831,7 @@ return true;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5849,6 +5918,7 @@ return (function(x){
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -5929,6 +5999,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6009,6 +6080,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6089,6 +6161,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6169,6 +6242,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6249,6 +6323,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6329,6 +6404,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
 <td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -6341,7 +6417,7 @@ return typeof foo === &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="khtml-note">  <sup>[1]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-old-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="define-property-ie-note">  <sup>[4]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="get-own-property-descriptor-ie-note">  <sup>[5]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="sparse_arrays-note">  <sup>[6]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, <code>`0 in [,]`</code> and <code>`0 in [undefined]`</code> both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="strict-mode-ie10-note">  <sup>[7]</sup> IE10 PP2 fails this test.</p></div>
+    <p id="khtml-note">  <sup>[1]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-old-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[4]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="define-property-ie-note">  <sup>[5]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="get-own-property-descriptor-ie-note">  <sup>[6]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="sparse_arrays-note">  <sup>[7]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, <code>`0 in [,]`</code> and <code>`0 in [undefined]`</code> both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="strict-mode-ie10-note">  <sup>[8]</sup> IE10 PP2 fails this test.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -183,6 +183,7 @@
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
+<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC3">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios9 mobile obsolete" data-browser="ios9"><a href="#ios9" class="browser-name"><abbr title="iOS Safari">iOS 9</abbr></a></th>
@@ -250,6 +251,7 @@
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/2</td>
@@ -271,9 +273,9 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -316,6 +318,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -337,9 +340,9 @@ return Intl.constructor === Object;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -382,6 +385,7 @@ return Intl.constructor === Object;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -445,6 +449,7 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally" data-browser="graalvm" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/4</td>
@@ -466,9 +471,9 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -511,6 +516,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -532,9 +538,9 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -577,6 +583,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -598,9 +605,9 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -643,6 +650,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -692,9 +700,9 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -737,6 +745,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -800,6 +809,7 @@ try {
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
+<td class="tally" data-browser="graalvm" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/1</td>
@@ -821,9 +831,9 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -866,6 +876,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -929,6 +940,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
+<td class="tally" data-browser="graalvm" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/1</td>
@@ -950,9 +962,9 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -995,6 +1007,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1058,6 +1071,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/5</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/5</td>
+<td class="tally" data-browser="graalvm" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/5</td>
@@ -1079,9 +1093,9 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -1124,6 +1138,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1145,9 +1160,9 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -1190,6 +1205,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1211,9 +1227,9 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -1256,6 +1272,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1277,9 +1294,9 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -1322,6 +1339,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1371,9 +1389,9 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -1416,6 +1434,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1479,6 +1498,7 @@ try {
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/6</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/6</td>
+<td class="tally" data-browser="graalvm" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/6</td>
@@ -1500,9 +1520,9 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -1545,6 +1565,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1566,9 +1587,9 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -1611,6 +1632,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1632,9 +1654,9 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -1677,6 +1699,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1726,9 +1749,9 @@ try {
 <td class="yes" data-browser="edge16">Yes</td>
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes unstable" data-browser="edge18">Yes</td>
-<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox54">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox55">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox56">Yes</td>
 <td class="yes obsolete" data-browser="firefox57">Yes</td>
 <td class="yes obsolete" data-browser="firefox58">Yes</td>
@@ -1771,6 +1794,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1838,6 +1862,7 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1912,6 +1937,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1975,6 +2001,7 @@ try {
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally" data-browser="graalvm" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">1/1</td>
@@ -2041,6 +2068,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2104,6 +2132,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally" data-browser="graalvm" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">1/1</td>
@@ -2170,6 +2199,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2233,6 +2263,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally" data-browser="graalvm" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">1/1</td>
@@ -2299,6 +2330,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2362,6 +2394,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally" data-browser="graalvm" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">1/1</td>
@@ -2428,6 +2461,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2491,6 +2525,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally" data-browser="graalvm" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">1/1</td>
@@ -2557,6 +2592,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2620,6 +2656,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally" data-browser="graalvm" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">1/1</td>
@@ -2686,6 +2723,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2749,6 +2787,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
+<td class="tally" data-browser="graalvm" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="1">1/1</td>
@@ -2815,6 +2854,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -2827,7 +2867,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="firefox-nomob-note">  <sup>[3]</sup> The feature is available on desktop versions only, it is not available on mobile versions yet.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="firefox-nomob-note">  <sup>[4]</sup> The feature is available on desktop versions only, it is not available on mobile versions yet.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -192,6 +192,7 @@
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
+<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC3">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios9 mobile obsolete" data-browser="ios9"><a href="#ios9" class="browser-name"><abbr title="iOS Safari">iOS 9</abbr></a></th>
@@ -204,7 +205,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="76">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="77">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-string-left-right-trim">string trimming</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -273,6 +274,7 @@
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally" data-browser="graalvm" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -286,20 +288,20 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
@@ -351,6 +353,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -364,20 +367,20 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="edge15">Yes</td>
@@ -429,6 +432,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -442,20 +446,20 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("3");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimStart() === 'abc   \\t\\n';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("3");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimStart() === 'abc   \\t\\n';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -469,7 +473,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="firefox57">No</td>
 <td class="no obsolete" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="firefox59">No</td>
-<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="firefox61">Yes</td>
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
@@ -507,6 +511,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -520,20 +525,20 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimEnd() === ' \\t \\n abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("4");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimEnd() === ' \\t \\n abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -547,7 +552,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="firefox57">No</td>
 <td class="no obsolete" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="firefox59">No</td>
-<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="firefox61">Yes</td>
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
@@ -585,6 +590,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -660,6 +666,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">2/2</td>
+<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/2</td>
@@ -675,20 +682,20 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");try{return Function("asyncTestPassed","\nvar actualGlobal = Function('return this')();\nactualGlobal.__system_global_test__ = 42;\nreturn typeof global === 'object' && global && global === actualGlobal && !global.lacksGlobal && global.__system_global_test__ === 42;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("6");return Function("asyncTestPassed","'use strict';"+"\nvar actualGlobal = Function('return this')();\nactualGlobal.__system_global_test__ = 42;\nreturn typeof global === 'object' && global && global === actualGlobal && !global.lacksGlobal && global.__system_global_test__ === 42;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -696,16 +703,16 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="edge17">No</td>
 <td class="no unstable" data-browser="edge18">No</td>
 <td class="no" data-browser="firefox52">No</td>
-<td class="no obsolete" data-browser="firefox54">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox55">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox56">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox54">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox55">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox56">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
@@ -724,8 +731,8 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="safari11">No</td>
 <td class="no" data-browser="safari11_1">No</td>
 <td class="no unstable" data-browser="safari12">No</td>
-<td class="no unstable" data-browser="safaritp">No<a href="#wk-global-property-note"><sup>[7]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#wk-global-property-note"><sup>[7]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#wk-global-property-note"><sup>[8]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#wk-global-property-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -740,6 +747,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -760,20 +768,20 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\nvar actualGlobal = Function('return this')();\nif (typeof global !== 'object') { return false; }\nif (!('global' in actualGlobal)) { return false; }\nif (Object.prototype.propertyIsEnumerable.call(actualGlobal, 'global')) { return false; }\nif (typeof Object.getOwnPropertyDescriptor !== 'function') { return true; } // ES3\n\nvar descriptor = Object.getOwnPropertyDescriptor(actualGlobal, 'global');\nreturn descriptor.value === actualGlobal && !descriptor.enumerable && descriptor.configurable && descriptor.writable;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\nvar actualGlobal = Function('return this')();\nif (typeof global !== 'object') { return false; }\nif (!('global' in actualGlobal)) { return false; }\nif (Object.prototype.propertyIsEnumerable.call(actualGlobal, 'global')) { return false; }\nif (typeof Object.getOwnPropertyDescriptor !== 'function') { return true; } // ES3\n\nvar descriptor = Object.getOwnPropertyDescriptor(actualGlobal, 'global');\nreturn descriptor.value === actualGlobal && !descriptor.enumerable && descriptor.configurable && descriptor.writable;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -781,16 +789,16 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="edge17">No</td>
 <td class="no unstable" data-browser="edge18">No</td>
 <td class="no" data-browser="firefox52">No</td>
-<td class="no obsolete" data-browser="firefox54">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox55">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox56">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox57">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox58">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no unstable" data-browser="firefox62">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
-<td class="no unstable" data-browser="firefox63">No<a href="#ffox-global-property-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox54">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox55">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox56">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox57">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox58">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no unstable" data-browser="firefox62">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
+<td class="no unstable" data-browser="firefox63">No<a href="#ffox-global-property-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
@@ -809,8 +817,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="safari11">No</td>
 <td class="no" data-browser="safari11_1">No</td>
 <td class="no unstable" data-browser="safari12">No</td>
-<td class="no unstable" data-browser="safaritp">No<a href="#wk-global-property-note"><sup>[7]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#wk-global-property-note"><sup>[7]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#wk-global-property-note"><sup>[8]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#wk-global-property-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -825,6 +833,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -848,20 +857,20 @@ return a === &apos;1a2b&apos;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("8");try{return Function("asyncTestPassed","\nvar iterator = '11a2bb'.matchAll(/(\\d)(\\D)/g);\nif(iterator[Symbol.iterator]() !== iterator)return false;\nvar a = '', b = '', c = '', step;\nwhile(!(step = iterator.next()).done){\n  a += step.value[0];\n  b += step.value[1];\n  c += step.value[2];\n}\nreturn a === '1a2b'\n  && b === '12'\n  && c === 'ab';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("8");return Function("asyncTestPassed","'use strict';"+"\nvar iterator = '11a2bb'.matchAll(/(\\d)(\\D)/g);\nif(iterator[Symbol.iterator]() !== iterator)return false;\nvar a = '', b = '', c = '', step;\nwhile(!(step = iterator.next()).done){\n  a += step.value[0];\n  b += step.value[1];\n  c += step.value[2];\n}\nreturn a === '1a2b'\n  && b === '12'\n  && c === 'ab';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -890,7 +899,7 @@ return a === &apos;1a2b&apos;
 <td class="no" data-browser="chrome66">No</td>
 <td class="no" data-browser="chrome67">No</td>
 <td class="no unstable" data-browser="chrome68">No</td>
-<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="no obsolete" data-browser="safari10_1">No</td>
@@ -913,6 +922,7 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -988,6 +998,7 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/3</td>
@@ -1042,11 +1053,11 @@ return new C().x === &apos;x&apos;;
 <td class="no obsolete" data-browser="chrome62">No</td>
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
-<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="chrome66">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="chrome66">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="no obsolete" data-browser="safari10_1">No</td>
@@ -1069,6 +1080,7 @@ return new C().x === &apos;x&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1130,10 +1142,10 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
 <td class="no obsolete" data-browser="chrome65">No</td>
-<td class="no flagged" data-browser="chrome66">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="chrome66">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="no obsolete" data-browser="safari10_1">No</td>
@@ -1156,6 +1168,7 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1214,10 +1227,10 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
 <td class="no obsolete" data-browser="chrome65">No</td>
-<td class="no flagged" data-browser="chrome66">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="chrome66">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="no obsolete" data-browser="safari10_1">No</td>
@@ -1240,6 +1253,7 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1315,6 +1329,7 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/2</td>
@@ -1396,6 +1411,7 @@ return C.x === &apos;x&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1480,6 +1496,7 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1555,6 +1572,7 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally" data-browser="graalvm" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
@@ -1602,13 +1620,13 @@ return fn + &apos;&apos; === str;
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome64">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome64">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="chrome66">Yes</td>
 <td class="yes" data-browser="chrome67">Yes</td>
 <td class="yes unstable" data-browser="chrome68">Yes</td>
@@ -1629,12 +1647,13 @@ return fn + &apos;&apos; === str;
 <td class="no obsolete" data-browser="node7">No</td>
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1714,6 +1733,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1793,6 +1813,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios9">Yes</td>
@@ -1872,6 +1893,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1951,6 +1973,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -1997,13 +2020,13 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome64">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome64">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="chrome66">Yes</td>
 <td class="yes" data-browser="chrome67">Yes</td>
 <td class="yes unstable" data-browser="chrome68">Yes</td>
@@ -2024,12 +2047,13 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="node7">No</td>
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2076,13 +2100,13 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome64">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome59">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome60">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome61">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome62">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome63">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome64">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome65">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="chrome66">Yes</td>
 <td class="yes" data-browser="chrome67">Yes</td>
 <td class="yes unstable" data-browser="chrome68">Yes</td>
@@ -2103,12 +2127,13 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no obsolete" data-browser="node7">No</td>
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2117,7 +2142,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="ios11">No</td>
 <td class="no" data-browser="ios11_3">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[9]</sup></a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[10]</sup></a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally unstable" data-browser="babel7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -2184,6 +2209,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/2</td>
@@ -2223,9 +2249,9 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="firefox56">No</td>
 <td class="no obsolete" data-browser="firefox57">No</td>
 <td class="no obsolete" data-browser="firefox58">No</td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#ffox-flatten-note"><sup>[10]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[10]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#ffox-flatten-note"><sup>[10]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#ffox-flatten-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#ffox-flatten-note"><sup>[11]</sup></a></td>
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
@@ -2262,6 +2288,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2277,20 +2304,20 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nreturn [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {\n  return [it.a, it.b];\n}).join('') === '1234';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nreturn [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {\n  return [it.a, it.b];\n}).join('') === '1234';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -2303,9 +2330,9 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="firefox56">No</td>
 <td class="no obsolete" data-browser="firefox57">No</td>
 <td class="no obsolete" data-browser="firefox58">No</td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
-<td class="no" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="yes unstable" data-browser="firefox62">Yes</td>
 <td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
@@ -2342,6 +2369,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2420,6 +2448,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2495,6 +2524,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
+<td class="tally" data-browser="graalvm" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/8</td>
@@ -2573,6 +2603,7 @@ return (1n + 2n) === 3n;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2651,6 +2682,7 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2729,6 +2761,7 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2807,6 +2840,7 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2888,6 +2922,7 @@ return view[0] === -0x8000000000000000n;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -2969,6 +3004,7 @@ return view[0] === 0n;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3047,6 +3083,7 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3125,6 +3162,7 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3133,7 +3171,7 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no" data-browser="ios11">No</td>
 <td class="no" data-browser="ios11_3">No</td>
 </tr>
-<tr class="category"><td colspan="76">Draft (stage 2)</td>
+<tr class="category"><td colspan="77">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -3211,6 +3249,7 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3286,6 +3325,7 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/1</td>
@@ -3307,8 +3347,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel6">No<a href="#babel-decorators-legacy-note"><sup>[11]</sup></a></td>
-<td class="no unstable" data-browser="babel7">No<a href="#babel-decorators-legacy-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="babel6">No<a href="#babel-decorators-legacy-note"><sup>[12]</sup></a></td>
+<td class="no unstable" data-browser="babel7">No<a href="#babel-decorators-legacy-note"><sup>[12]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
@@ -3372,6 +3412,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3453,6 +3494,7 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3535,6 +3577,7 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3610,6 +3653,7 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/4</td>
@@ -3694,6 +3738,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3782,6 +3827,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3865,6 +3911,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -3948,6 +3995,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4002,9 +4050,9 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="chrome64">No</td>
 <td class="no obsolete" data-browser="chrome65">No</td>
 <td class="no" data-browser="chrome66">No</td>
-<td class="no flagged" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="safari9">No</td>
 <td class="no obsolete" data-browser="safari10">No</td>
 <td class="no obsolete" data-browser="safari10_1">No</td>
@@ -4027,6 +4075,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4106,6 +4155,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4181,6 +4231,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/4</td>
@@ -4262,6 +4313,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4344,6 +4396,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4425,6 +4478,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4506,6 +4560,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4514,7 +4569,7 @@ return set.size === 2
 <td class="no" data-browser="ios11">No</td>
 <td class="no" data-browser="ios11_3">No</td>
 </tr>
-<tr class="category"><td colspan="76">Proposal (stage 1)</td>
+<tr class="category"><td colspan="77">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -4589,6 +4644,7 @@ return do {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4664,6 +4720,7 @@ return do {
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/7</td>
@@ -4677,20 +4734,20 @@ return typeof Observable !== &apos;undefined&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");try{return Function("asyncTestPassed","\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("56");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -4742,6 +4799,7 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4755,20 +4813,20 @@ return typeof Symbol.observable === &apos;symbol&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("57");try{return Function("asyncTestPassed","\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("57");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -4820,6 +4878,7 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4833,20 +4892,20 @@ return &apos;subscribe&apos; in Observable.prototype;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("58");try{return Function("asyncTestPassed","\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("58");return Function("asyncTestPassed","'use strict';"+"\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -4898,6 +4957,7 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -4921,20 +4981,20 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");try{return Function("asyncTestPassed","\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("59");return Function("asyncTestPassed","'use strict';"+"\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -4986,6 +5046,7 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5000,20 +5061,20 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");try{return Function("asyncTestPassed","\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("60");return Function("asyncTestPassed","'use strict';"+"\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5065,6 +5126,7 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5078,20 +5140,20 @@ return Observable.of(1, 2, 3) instanceof Observable;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");try{return Function("asyncTestPassed","\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("61");return Function("asyncTestPassed","'use strict';"+"\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5143,6 +5205,7 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5156,20 +5219,20 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");try{return Function("asyncTestPassed","\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("62");return Function("asyncTestPassed","'use strict';"+"\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5221,6 +5284,7 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5300,6 +5364,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5316,20 +5381,20 @@ return Math.signbit(-0) === false
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\nreturn Math.signbit(-0) === false\n  && Math.signbit(0) === true\n  && Math.signbit(-42) === false\n  && Math.signbit(42) === true;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.signbit(-0) === false\n  && Math.signbit(0) === true\n  && Math.signbit(-42) === false\n  && Math.signbit(42) === true;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5381,6 +5446,7 @@ return Math.signbit(-0) === false
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5456,6 +5522,7 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/7</td>
@@ -5471,20 +5538,20 @@ return Math.clamp(2, 4, 6) === 4
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5536,6 +5603,7 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5549,20 +5617,20 @@ return Math.DEG_PER_RAD === Math.PI / 180;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5614,6 +5682,7 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5628,20 +5697,20 @@ return Math.degrees(Math.PI / 2) === 90
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5693,6 +5762,7 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5706,20 +5776,20 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5771,6 +5841,7 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5784,20 +5855,20 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5849,6 +5920,7 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5863,20 +5935,20 @@ return Math.radians(90) === Math.PI / 2
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -5928,6 +6000,7 @@ return Math.radians(90) === Math.PI / 2
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -5941,20 +6014,20 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6006,6 +6079,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6081,6 +6155,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/7</td>
@@ -6094,20 +6169,20 @@ return typeof Promise.try === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");try{return Function("asyncTestPassed","\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("74");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6159,6 +6234,7 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6172,20 +6248,20 @@ return Promise.try(function () {}) instanceof Promise;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("75");try{return Function("asyncTestPassed","\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("75");return Function("asyncTestPassed","'use strict';"+"\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6237,6 +6313,7 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6252,20 +6329,20 @@ return score === 1;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6317,6 +6394,7 @@ return score === 1;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6337,20 +6415,20 @@ Promise.try(function() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("77");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6402,6 +6480,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6422,20 +6501,20 @@ Promise.try(function() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("78");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6487,6 +6566,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6507,20 +6587,20 @@ Promise.try(function() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("79");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6572,6 +6652,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6592,20 +6673,20 @@ Promise.try(function() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("80");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6657,6 +6738,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6732,6 +6814,7 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/8</td>
@@ -6748,20 +6831,20 @@ return C.get(A) + C.get(B) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("82");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6813,6 +6896,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6831,20 +6915,20 @@ return C.get(A) + C.get(B) === 5;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("83");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6896,6 +6980,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6912,20 +6997,20 @@ return C.has(A) + C.has(B);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -6977,6 +7062,7 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -6993,20 +7079,20 @@ return C.has(3) + C.has(4);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -7058,6 +7144,7 @@ return C.has(3) + C.has(4);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7074,20 +7161,20 @@ return C.get(A) + C.get(B) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("86");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("86");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -7139,6 +7226,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7157,20 +7245,20 @@ return C.get(A) + C.get(B) === 5;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("87");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -7222,6 +7310,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7238,20 +7327,20 @@ return C.has(A) + C.has(B);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -7303,6 +7392,7 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7319,20 +7409,20 @@ return C.has(A) + C.has(B);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("89");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("89");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes" data-browser="babel6">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable" data-browser="babel7">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20180319">No</td>
 <td class="no obsolete" data-browser="closure20180402">No</td>
 <td class="no obsolete" data-browser="closure20180506">No</td>
 <td class="no" data-browser="closure20180610">No</td>
-<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_3">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_4">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_5">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes" data-browser="typescript2_8">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="edge15">No</td>
@@ -7384,6 +7474,7 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7434,12 +7525,12 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="firefox55">No</td>
 <td class="no obsolete" data-browser="firefox56">No</td>
 <td class="no obsolete" data-browser="firefox57">No</td>
-<td class="no flagged obsolete" data-browser="firefox58">Flag<a href="#ffox-pipeline-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#ffox-pipeline-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#ffox-pipeline-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox61">Flag<a href="#ffox-pipeline-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox62">Flag<a href="#ffox-pipeline-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox63">Flag<a href="#ffox-pipeline-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox58">Flag<a href="#ffox-pipeline-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#ffox-pipeline-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox60">Flag<a href="#ffox-pipeline-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox61">Flag<a href="#ffox-pipeline-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox62">Flag<a href="#ffox-pipeline-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox63">Flag<a href="#ffox-pipeline-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome59">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
@@ -7474,6 +7565,7 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7556,6 +7648,7 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7631,6 +7724,7 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/3</td>
@@ -7711,6 +7805,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7791,6 +7886,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7871,6 +7967,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -7953,6 +8050,7 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8028,6 +8126,7 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/12</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/12</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/12</td>
@@ -8110,6 +8209,7 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8192,6 +8292,7 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8274,6 +8375,7 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8356,6 +8458,7 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8438,6 +8541,7 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8520,6 +8624,7 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8602,6 +8707,7 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8687,6 +8793,7 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8770,6 +8877,7 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8852,6 +8960,7 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -8934,6 +9043,7 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9016,6 +9126,7 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9091,6 +9202,7 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/8</td>
@@ -9169,6 +9281,7 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9247,6 +9360,7 @@ return Object.isFrozen([# 42 #]);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9325,6 +9439,7 @@ return Object.isSealed({| foo: 42 |});
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9403,6 +9518,7 @@ return Object.isSealed([| 42 |]);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9489,6 +9605,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9576,6 +9693,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9662,6 +9780,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9749,6 +9868,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9827,6 +9947,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9910,6 +10031,7 @@ return results.length === 3
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -9985,6 +10107,7 @@ return results.length === 3
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/2</td>
@@ -10063,6 +10186,7 @@ return [1, 2, 3].lastItem === 3;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10141,6 +10265,7 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10216,6 +10341,7 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/15</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/15</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ios9" data-tally="0">0/15</td>
@@ -10299,6 +10425,7 @@ return map.size === 2
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10380,6 +10507,7 @@ return map.size === 2
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10461,6 +10589,7 @@ return map.size === 2
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10543,6 +10672,7 @@ return map.size === 3
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10625,6 +10755,7 @@ return map.size === 3
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10707,6 +10838,7 @@ return map.size === 3
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10789,6 +10921,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10871,6 +11004,7 @@ return set.deleteAll(2, 3) === true
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -10949,6 +11083,7 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -11030,6 +11165,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -11108,6 +11244,7 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -11186,6 +11323,7 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -11268,6 +11406,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -11346,6 +11485,7 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -11424,6 +11564,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios9">No</td>
@@ -11432,7 +11573,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no" data-browser="ios11">No</td>
 <td class="no" data-browser="ios11_3">No</td>
 </tr>
-<tr class="category"><td colspan="76">Strawman (stage 0)</td>
+<tr class="category"><td colspan="77">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -11501,6 +11642,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -11581,6 +11723,7 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11660,6 +11803,7 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11673,20 +11817,20 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("143");try{return Function("asyncTestPassed","\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("143");return Function("asyncTestPassed","'use strict';"+"\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11738,6 +11882,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11813,6 +11958,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -11892,6 +12038,7 @@ return f();
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11970,6 +12117,7 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12053,6 +12201,7 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12142,6 +12291,7 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12227,6 +12377,7 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12302,6 +12453,7 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12382,6 +12534,7 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12462,6 +12615,7 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12537,6 +12691,7 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -12615,6 +12770,7 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12693,6 +12849,7 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12771,6 +12928,7 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12849,6 +13007,7 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12927,6 +13086,7 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13005,6 +13165,7 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13083,6 +13244,7 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13099,20 +13261,20 @@ passed = true;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("161");try{return Function("asyncTestPassed","\nvar passed = false;\nsetTimeout(function(){ passed = false; }, 1);\nasap(function(){ if(passed)asyncTestPassed(); });\npassed = true;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("161");return Function("asyncTestPassed","'use strict';"+"\nvar passed = false;\nsetTimeout(function(){ passed = false; }, 1);\nasap(function(){ if(passed)asyncTestPassed(); });\npassed = true;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13164,6 +13326,7 @@ passed = true;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13239,6 +13402,7 @@ passed = true;
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13323,6 +13487,7 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13414,6 +13579,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13489,6 +13655,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13569,6 +13736,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13650,6 +13818,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13658,7 +13827,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="ios11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios11_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="76">Pre-strawman</td>
+<tr class="category"><td colspan="77">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -13727,6 +13896,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -13740,20 +13910,20 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("169");try{return Function("asyncTestPassed","\nreturn typeof Reflect.defineMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("169");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.defineMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13805,6 +13975,7 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13818,20 +13989,20 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("170");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("170");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13883,6 +14054,7 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13896,20 +14068,20 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasOwnMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("171");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasOwnMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13961,6 +14133,7 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13974,20 +14147,20 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("172");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("172");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14039,6 +14212,7 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14052,20 +14226,20 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("173");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("173");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14117,6 +14291,7 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14130,20 +14305,20 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("174");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadataKeys == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("174");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadataKeys == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14195,6 +14370,7 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14208,20 +14384,20 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadataKeys == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("175");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadataKeys == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14273,6 +14449,7 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14286,20 +14463,20 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("176");try{return Function("asyncTestPassed","\nreturn typeof Reflect.deleteMetadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("176");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.deleteMetadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14351,6 +14528,7 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14364,20 +14542,20 @@ return typeof Reflect.metadata == &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("177");try{return Function("asyncTestPassed","\nreturn typeof Reflect.metadata == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("177");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.metadata == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
-<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[3]</sup></a></td>
+<td class="yes not-applicable" data-browser="babel6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes unstable not-applicable" data-browser="babel7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript2_8" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14429,6 +14607,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="graalvm" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android4_4_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ios9" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14441,7 +14620,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="babel-core-js-note">  <sup>[3]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[4]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="firefox-nightly-note">  <sup>[5]</sup> The feature is available only in Firefox Nightly builds.</p><p id="ffox-global-property-note">  <sup>[6]</sup> The feature was disabled due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1325907">some</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1326032">compatibility</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1328218">issues</a>.</p><p id="wk-global-property-note">  <sup>[7]</sup> The feature was disabled due to <a href="https://bugs.webkit.org/show_bug.cgi?id=165171">compatibility issues</a>.</p><p id="chrome-harmony-note">  <sup>[8]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="flatten-compat-issue-note">  <sup>[9]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[10]</sup> Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p><p id="babel-decorators-legacy-note">  <sup>[11]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="ffox-pipeline-note">  <sup>[12]</sup> Requires the <code>--enable-pipeline-operator</code> compile option.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="babel-core-js-note">  <sup>[4]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[5]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="firefox-nightly-note">  <sup>[6]</sup> The feature is available only in Firefox Nightly builds.</p><p id="ffox-global-property-note">  <sup>[7]</sup> The feature was disabled due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1325907">some</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1326032">compatibility</a> <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1328218">issues</a>.</p><p id="wk-global-property-note">  <sup>[8]</sup> The feature was disabled due to <a href="https://bugs.webkit.org/show_bug.cgi?id=165171">compatibility issues</a>.</p><p id="chrome-harmony-note">  <sup>[9]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="flatten-compat-issue-note">  <sup>[10]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[11]</sup> Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p><p id="babel-decorators-legacy-note">  <sup>[12]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="ffox-pipeline-note">  <sup>[13]</sup> Requires the <code>--enable-pipeline-operator</code> compile option.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "pretest": "npm run lint",
     "build:compilers": "node build.js compilers",
     "git:clean": "if type git > /dev/null 2>&1; then git stash save --keep-index; fi",
-    "test:no_change": "npm run --silent git:clean && if npm run --silent build | grep 'Write to file'; then echo 'Please run `npm run build` and commit the changes.' && exit 1; fi"
+    "test:no_change": "npm run --silent git:clean && if npm run --silent build | grep 'Write to file'; then echo 'Please run `npm run build` and commit the changes.' && exit 1; fi",
+    "graalvm": "node --jvm --shared-array-buffer --intl-402 node.js"
   },
   "config": {
     "unsafe-perm": true


### PR DESCRIPTION
Hi,

GraalVM (https://www.graalvm.org) is coming with JavaScript (and Node.js) support. This PR adds results for this engine.

GraalVM JavaScript is based on the Graal Java JIT compiler (https://github.com/oracle/graal). The source code is available at https://github.com/graalvm/graaljs

Supporting Node.js, GraalVM can reuse the `node.js` file to generate the results. The commandline to reproduce is `/path/to/graalvm-ce-1.0.0-rc3/bin/node --jvm --shared-array-buffer --intl-402 node.js`. The results are based on GraalVM CE 1.0.0 RC3 (https://github.com/oracle/graal/releases/tag/vm-1.0.0-rc3).

-- Christian


