### PR TITLE
Rename spread operator to spread syntax

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1770,7 +1770,7 @@ exports.tests = [
   ],
 },
 {
-  name: 'spread (...) operator',
+  name: 'spread syntax for iterable objects',
   category: 'syntax',
   significance: 'large',
   spec: 'http://www.ecma-international.org/ecma-262/6.0/#sec-argument-lists-runtime-semantics-argumentlistevaluation',


### PR DESCRIPTION
Technically there is no such thing as spread operator in specification and spread is part of grammar and runtime semantics. So I think it's better to call it spread syntax as [in MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax).