### PR TITLE
Firefox 63 now supports object.FromEntries

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2503,6 +2503,9 @@ exports.tests = [
     return object.foo === 42 && object.bar === 23;
   */},
   res: {
+      firefox52: false,
+      firefox62: false,
+      firefox63: true,
       graalvm: false,
   }
 },

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -3285,7 +3285,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no" data-browser="firefox60">No</td>
 <td class="no" data-browser="firefox61">No</td>
 <td class="no unstable" data-browser="firefox62">No</td>
-<td class="no unstable" data-browser="firefox63">No</td>
+<td class="yes unstable" data-browser="firefox63">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome60">No</td>
 <td class="no obsolete" data-browser="chrome61">No</td>


### PR DESCRIPTION
Today's nightly build of Firefox 63 already supports `object.FromEntries`:
https://bugzilla.mozilla.org/show_bug.cgi?id=1469019
