### PR TITLE
Adding MDN link for Object.fromEntries

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2534,6 +2534,7 @@ exports.tests = [
   name: 'Object.fromEntries',
   significance: 'small',
   spec: 'https://github.com/tc39/proposal-object-from-entries',
+  mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries',
   category: STAGE3,
   exec: function () {/*
     var object = Object.fromEntries(new Map([['foo', 42], ['bar', 23]]));

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -3247,7 +3247,7 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no" data-browser="ios11">No</td>
 <td class="no" data-browser="ios11_3">No</td>
 </tr>
-<tr significance="0.25"><td id="test-Object.fromEntries"><span><a class="anchor" href="#test-Object.fromEntries">&#xA7;</a><a href="https://github.com/tc39/proposal-object-from-entries">Object.fromEntries</a></span><script data-source="
+<tr significance="0.25"><td id="test-Object.fromEntries"><span><a class="anchor" href="#test-Object.fromEntries">&#xA7;</a><a href="https://github.com/tc39/proposal-object-from-entries">Object.fromEntries</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var object = Object.fromEntries(new Map([[&apos;foo&apos;, 42], [&apos;bar&apos;, 23]]));
 return object.foo === 42 &amp;&amp; object.bar === 23;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nvar object = Object.fromEntries(new Map([['foo', 42], ['bar', 23]]));\nreturn object.foo === 42 && object.bar === 23;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nvar object = Object.fromEntries(new Map([['foo', 42], ['bar', 23]]));\nreturn object.foo === 42 && object.bar === 23;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());


### PR DESCRIPTION
Adding MDN link for `Object.fromEntries`:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries