### PR TITLE
Adding MDN link for Symbol.prototype.description

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2248,6 +2248,7 @@ exports.tests = [
 {
   name: 'Symbol.prototype.description',
   spec: 'https://github.com/tc39/proposal-Symbol-description',
+  mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description',
   category: STAGE3,
   significance: 'small',
   exec: function(){/*

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2434,7 +2434,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no" data-browser="ios11">No</td>
 <td class="no" data-browser="ios11_3">No</td>
 </tr>
-<tr significance="0.25"><td id="test-Symbol.prototype.description"><span><a class="anchor" href="#test-Symbol.prototype.description">&#xA7;</a><a href="https://github.com/tc39/proposal-Symbol-description">Symbol.prototype.description</a></span><script data-source="
+<tr significance="0.25"><td id="test-Symbol.prototype.description"><span><a class="anchor" href="#test-Symbol.prototype.description">&#xA7;</a><a href="https://github.com/tc39/proposal-Symbol-description">Symbol.prototype.description</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nreturn Symbol('foo').description === 'foo';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nreturn Symbol('foo').description === 'foo';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>


### PR DESCRIPTION
Adding MDN link for `Symbol.prototype.description`:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description