### PR TITLE
Symbol.prototype.description is supported by Chrome 69

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2259,6 +2259,7 @@ exports.tests = [
     firefox45: false,
     firefox63: true,
     chrome67: false,
+    chrome69: chrome.harmony,
     chrome70: true,
     safari11: false,
     safari12: true,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2481,7 +2481,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="chrome66">No</td>
 <td class="no obsolete" data-browser="chrome67">No</td>
 <td class="no" data-browser="chrome68">No</td>
-<td class="no" data-browser="chrome69">No</td>
+<td class="no flagged" data-browser="chrome69">Flag<a href="#chrome-harmony-note"><sup>[9]</sup></a></td>
 <td class="yes unstable" data-browser="chrome70">Yes</td>
 <td class="yes unstable" data-browser="chrome71">Yes</td>
 <td class="no obsolete" data-browser="safari9">No</td>


### PR DESCRIPTION
`Symbol.prototype.description` is supported by Chrome 69 with the `--harmony` flag.