### PR TITLE
Fix Firefox 64 version on title row

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -1041,7 +1041,7 @@
   "firefox64": {
     "full": "Firefox 64 Nightly",
     "family": "SpiderMonkey",
-    "short": "FF 63 Nightly",
+    "short": "FF 64 Nightly",
     "release": "2018-12-11",
     "retire": "2019-01-29",
     "unstable": true

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -156,7 +156,7 @@
 <th class="platform firefox61 desktop" data-browser="firefox61"><a href="#firefox61" class="browser-name"><abbr title="Firefox 61">FF 61</abbr></a></th>
 <th class="platform firefox62 desktop" data-browser="firefox62"><a href="#firefox62" class="browser-name"><abbr title="Firefox 62">FF 62</abbr></a></th>
 <th class="platform firefox63 desktop unstable" data-browser="firefox63"><a href="#firefox63" class="browser-name"><abbr title="Firefox 63 Beta">FF 63 Beta</abbr></a></th>
-<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 63 Nightly</abbr></a></th>
+<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 64 Nightly</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome61 desktop obsolete" data-browser="chrome61"><a href="#chrome61" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;61,<br>OP&#xA0;48</abbr></a></th>
 <th class="platform chrome62 desktop obsolete" data-browser="chrome62"><a href="#chrome62" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;62,<br>OP&#xA0;49</abbr></a></th>

--- a/es5/index.html
+++ b/es5/index.html
@@ -144,7 +144,7 @@
 <th class="platform firefox61 desktop" data-browser="firefox61"><a href="#firefox61" class="browser-name"><abbr title="Firefox 61">FF 61</abbr></a></th>
 <th class="platform firefox62 desktop" data-browser="firefox62"><a href="#firefox62" class="browser-name"><abbr title="Firefox 62">FF 62</abbr></a></th>
 <th class="platform firefox63 desktop unstable" data-browser="firefox63"><a href="#firefox63" class="browser-name"><abbr title="Firefox 63 Beta">FF 63 Beta</abbr></a></th>
-<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 63 Nightly</abbr></a></th>
+<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 64 Nightly</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome61 desktop obsolete" data-browser="chrome61"><a href="#chrome61" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;61,<br>OP&#xA0;48</abbr></a></th>
 <th class="platform chrome62 desktop obsolete" data-browser="chrome62"><a href="#chrome62" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;62,<br>OP&#xA0;49</abbr></a></th>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -148,7 +148,7 @@
 <th class="platform firefox61 desktop" data-browser="firefox61"><a href="#firefox61" class="browser-name"><abbr title="Firefox 61">FF 61</abbr></a></th>
 <th class="platform firefox62 desktop" data-browser="firefox62"><a href="#firefox62" class="browser-name"><abbr title="Firefox 62">FF 62</abbr></a></th>
 <th class="platform firefox63 desktop unstable" data-browser="firefox63"><a href="#firefox63" class="browser-name"><abbr title="Firefox 63 Beta">FF 63 Beta</abbr></a></th>
-<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 63 Nightly</abbr></a></th>
+<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 64 Nightly</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome61 desktop obsolete" data-browser="chrome61"><a href="#chrome61" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;61,<br>OP&#xA0;48</abbr></a></th>
 <th class="platform chrome62 desktop obsolete" data-browser="chrome62"><a href="#chrome62" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;62,<br>OP&#xA0;49</abbr></a></th>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -160,7 +160,7 @@
 <th class="platform firefox61 desktop" data-browser="firefox61"><a href="#firefox61" class="browser-name"><abbr title="Firefox 61">FF 61</abbr></a></th>
 <th class="platform firefox62 desktop" data-browser="firefox62"><a href="#firefox62" class="browser-name"><abbr title="Firefox 62">FF 62</abbr></a></th>
 <th class="platform firefox63 desktop unstable" data-browser="firefox63"><a href="#firefox63" class="browser-name"><abbr title="Firefox 63 Beta">FF 63 Beta</abbr></a></th>
-<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 63 Nightly</abbr></a></th>
+<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 64 Nightly</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome61 desktop obsolete" data-browser="chrome61"><a href="#chrome61" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;61,<br>OP&#xA0;48</abbr></a></th>
 <th class="platform chrome62 desktop obsolete" data-browser="chrome62"><a href="#chrome62" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;62,<br>OP&#xA0;49</abbr></a></th>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -137,7 +137,7 @@
 <th class="platform firefox61 desktop" data-browser="firefox61"><a href="#firefox61" class="browser-name"><abbr title="Firefox 61">FF 61</abbr></a></th>
 <th class="platform firefox62 desktop" data-browser="firefox62"><a href="#firefox62" class="browser-name"><abbr title="Firefox 62">FF 62</abbr></a></th>
 <th class="platform firefox63 desktop unstable" data-browser="firefox63"><a href="#firefox63" class="browser-name"><abbr title="Firefox 63 Beta">FF 63 Beta</abbr></a></th>
-<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 63 Nightly</abbr></a></th>
+<th class="platform firefox64 desktop unstable" data-browser="firefox64"><a href="#firefox64" class="browser-name"><abbr title="Firefox 64 Nightly">FF 64 Nightly</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome61 desktop obsolete" data-browser="chrome61"><a href="#chrome61" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;61,<br>OP&#xA0;48</abbr></a></th>
 <th class="platform chrome62 desktop obsolete" data-browser="chrome62"><a href="#chrome62" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;62,<br>OP&#xA0;49</abbr></a></th>


### PR DESCRIPTION
This patch fixes the "short" description of Firefox 64.