### PR TITLE
Update Closure Compiler to v20181008

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -2561,6 +2561,7 @@ exports.tests = [
      return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
      */},
     res: {
+      closure20181008: true,
       ie11: false,
       firefox2: false,
       firefox53: true,

--- a/environments.json
+++ b/environments.json
@@ -132,6 +132,18 @@
     "short": "Closure 2018.09",
     "family": "Closure",
     "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20181008": {
+    "full": "Closure Compiler v20181008",
+    "short": "Closure 2018.10",
+    "family": "Closure",
+    "platformtype": "compiler",
     "obsolete": false,
     "test_suites": [
       "es6",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -134,7 +134,8 @@
 <th class="platform closure20180610 compiler obsolete" data-browser="closure20180610"><a href="#closure20180610" class="browser-name"><abbr title="Closure Compiler v20180610">Closure 2018.06</abbr></a></th>
 <th class="platform closure20180716 compiler obsolete" data-browser="closure20180716"><a href="#closure20180716" class="browser-name"><abbr title="Closure Compiler v20180716">Closure 2018.07</abbr></a></th>
 <th class="platform closure20180805 compiler obsolete" data-browser="closure20180805"><a href="#closure20180805" class="browser-name"><abbr title="Closure Compiler v20180805">Closure 2018.08</abbr></a></th>
-<th class="platform closure20180910 compiler" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
+<th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
+<th class="platform closure20181008 compiler" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform typescript1 compiler obsolete" data-browser="typescript1"><a href="#typescript1" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_6 compiler obsolete" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_7 compiler obsolete" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
@@ -207,7 +208,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="81">2016 features</td>
+      <tr class="category"><td colspan="82">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -220,7 +221,8 @@
 <td class="tally obsolete" data-browser="closure20180610" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20180910" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -303,7 +305,8 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -386,7 +389,8 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -474,7 +478,8 @@ return true;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -554,7 +559,8 @@ return true;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20180910" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20181008" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">3/3</td>
@@ -641,7 +647,8 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -746,7 +753,8 @@ return 24;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -834,7 +842,8 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -903,7 +912,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="81">2016 misc</td>
+<tr class="category"><td colspan="82">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -926,7 +935,8 @@ return true;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1022,7 +1032,8 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -1110,7 +1121,8 @@ return true;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1194,7 +1206,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -1279,7 +1292,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -1369,7 +1383,8 @@ return passed;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1461,7 +1476,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1530,7 +1546,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="81">2017 features</td>
+<tr class="category"><td colspan="82">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1543,7 +1559,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20180910" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20181008" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">4/4</td>
@@ -1629,7 +1646,8 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1719,7 +1737,8 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1810,7 +1829,8 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1896,7 +1916,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1976,7 +1997,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="closure20180610" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20180910" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
@@ -2064,7 +2086,8 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2152,7 +2175,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2232,7 +2256,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20180910" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
@@ -2315,7 +2340,8 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -2398,7 +2424,8 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -2478,7 +2505,8 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally" data-browser="closure20180910" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally" data-browser="closure20181008" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
@@ -2572,7 +2600,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2666,7 +2695,8 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2750,7 +2780,8 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7">?</td>
@@ -2834,7 +2865,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2924,7 +2956,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3016,7 +3049,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3100,7 +3134,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7">?</td>
@@ -3189,7 +3224,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3273,7 +3309,8 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7">?</td>
@@ -3367,7 +3404,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3461,7 +3499,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3553,7 +3592,8 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3638,7 +3678,8 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3721,7 +3762,8 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3813,7 +3855,8 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3893,7 +3936,8 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/17</td>
@@ -3976,7 +4020,8 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4059,7 +4104,8 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4142,7 +4188,8 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4225,7 +4272,8 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4308,7 +4356,8 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4391,7 +4440,8 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4474,7 +4524,8 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4557,7 +4608,8 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4640,7 +4692,8 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4723,7 +4776,8 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4806,7 +4860,8 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4889,7 +4944,8 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4972,7 +5028,8 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5055,7 +5112,8 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5138,7 +5196,8 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5221,7 +5280,8 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5304,7 +5364,8 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5373,7 +5434,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
 </tr>
-<tr class="category"><td colspan="81">2017 misc</td>
+<tr class="category"><td colspan="82">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[22]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -5394,7 +5455,8 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5480,7 +5542,8 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5566,7 +5629,8 @@ return (function(){
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5635,7 +5699,7 @@ return (function(){
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="81">2017 annex b</td>
+<tr class="category"><td colspan="82">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -5648,7 +5712,8 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -5736,7 +5801,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5825,7 +5891,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5914,7 +5981,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6002,7 +6070,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6091,7 +6160,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6180,7 +6250,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6270,7 +6341,8 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6360,7 +6432,8 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6451,7 +6524,8 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6539,7 +6613,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6626,7 +6701,8 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6716,7 +6792,8 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6806,7 +6883,8 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6897,7 +6975,8 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6985,7 +7064,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7072,7 +7152,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7152,7 +7233,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -7239,7 +7321,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7326,7 +7409,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7418,7 +7502,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7510,7 +7595,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7594,7 +7680,8 @@ return i === 0;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7663,7 +7750,7 @@ return i === 0;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="81">2018 features</td>
+<tr class="category"><td colspan="82">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -7676,7 +7763,8 @@ return i === 0;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20180910" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
@@ -7760,7 +7848,8 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -7845,7 +7934,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -7925,7 +8015,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20180910" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">3/3</td>
@@ -8034,7 +8125,8 @@ function check() {
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8135,7 +8227,8 @@ function check() {
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8238,7 +8331,8 @@ function check() {
 <td class="yes obsolete" data-browser="closure20180610">Yes</td>
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8322,7 +8416,8 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7">?</td>
@@ -8412,7 +8507,8 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8496,7 +8592,8 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8580,7 +8677,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8660,7 +8758,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="closure20180910" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
@@ -8750,7 +8849,8 @@ iterator.next().then(function(step){
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -8850,7 +8950,8 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="yes" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -8919,7 +9020,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="ios11_3">No</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="81">2018 misc</td>
+<tr class="category"><td colspan="82">2018 misc</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -8942,7 +9043,8 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="yes" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9011,7 +9113,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="81">2019 misc</td>
+<tr class="category"><td colspan="82">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://tc39.github.io/proposal-optional-catch-binding/">optional catch binding</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
@@ -9024,7 +9126,8 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">3/3</td>
@@ -9113,7 +9216,8 @@ return false;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -9203,7 +9307,8 @@ return false;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -9298,7 +9403,8 @@ return it.next().value;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -140,7 +140,8 @@
 <th class="platform closure20180610 compiler obsolete" data-browser="closure20180610"><a href="#closure20180610" class="browser-name"><abbr title="Closure Compiler v20180610">Closure 2018.06</abbr></a></th>
 <th class="platform closure20180716 compiler obsolete" data-browser="closure20180716"><a href="#closure20180716" class="browser-name"><abbr title="Closure Compiler v20180716">Closure 2018.07</abbr></a></th>
 <th class="platform closure20180805 compiler obsolete" data-browser="closure20180805"><a href="#closure20180805" class="browser-name"><abbr title="Closure Compiler v20180805">Closure 2018.08</abbr></a></th>
-<th class="platform closure20180910 compiler" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
+<th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
+<th class="platform closure20181008 compiler" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform typescript1 compiler obsolete" data-browser="typescript1"><a href="#typescript1" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_6 compiler obsolete" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_7 compiler obsolete" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
@@ -211,7 +212,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="79">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="80">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-string-left-right-trim">string trimming</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -224,7 +225,8 @@
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">4/4</td>
@@ -305,7 +307,8 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -386,7 +389,8 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -467,7 +471,8 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -548,7 +553,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -626,7 +632,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/2</td>
@@ -709,7 +716,8 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -796,7 +804,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -887,7 +896,8 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -965,7 +975,8 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -1049,7 +1060,8 @@ return new C().x === &apos;x&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -1139,7 +1151,8 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1226,7 +1239,8 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1304,7 +1318,8 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -1388,7 +1403,8 @@ return C.x === &apos;x&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -1475,7 +1491,8 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1553,7 +1570,8 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/7</td>
@@ -1636,7 +1654,8 @@ return fn + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1718,7 +1737,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1800,7 +1820,8 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1882,7 +1903,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1964,7 +1986,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2046,7 +2069,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2128,7 +2152,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2206,7 +2231,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -2287,7 +2313,8 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2370,7 +2397,8 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -2451,7 +2479,8 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2529,7 +2558,8 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/8</td>
@@ -2610,7 +2640,8 @@ return (1n + 2n) === 3n;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2691,7 +2722,8 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2772,7 +2804,8 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2853,7 +2886,8 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2937,7 +2971,8 @@ return view[0] === -0x8000000000000000n;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3021,7 +3056,8 @@ return view[0] === 0n;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3102,7 +3138,8 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3183,7 +3220,8 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3265,7 +3303,8 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3332,7 +3371,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="79">Draft (stage 2)</td>
+<tr class="category"><td colspan="80">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -3354,7 +3393,8 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3432,7 +3472,8 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">1/1</td>
@@ -3521,7 +3562,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -3605,7 +3647,8 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3690,7 +3733,8 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3768,7 +3812,8 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/4</td>
@@ -3855,7 +3900,8 @@ try {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3946,7 +3992,8 @@ try {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4032,7 +4079,8 @@ try {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4118,7 +4166,8 @@ try {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4200,7 +4249,8 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -4278,7 +4328,8 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/4</td>
@@ -4362,7 +4413,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4447,7 +4499,8 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4531,7 +4584,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4615,7 +4669,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4682,7 +4737,7 @@ return set.size === 2
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="79">Proposal (stage 1)</td>
+<tr class="category"><td colspan="80">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -4701,7 +4756,8 @@ return do {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4779,7 +4835,8 @@ return do {
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">7/7</td>
@@ -4860,7 +4917,8 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -4941,7 +4999,8 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5022,7 +5081,8 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5113,7 +5173,8 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5195,7 +5256,8 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5276,7 +5338,8 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5357,7 +5420,8 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5439,7 +5503,8 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5523,7 +5588,8 @@ return Math.signbit(-0) === false
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5601,7 +5667,8 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">7/7</td>
@@ -5684,7 +5751,8 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5765,7 +5833,8 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5847,7 +5916,8 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5928,7 +5998,8 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6009,7 +6080,8 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6091,7 +6163,8 @@ return Math.radians(90) === Math.PI / 2
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6172,7 +6245,8 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6250,7 +6324,8 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">7/7</td>
@@ -6331,7 +6406,8 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6412,7 +6488,8 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6495,7 +6572,8 @@ return score === 1;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6583,7 +6661,8 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6671,7 +6750,8 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6759,7 +6839,8 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6847,7 +6928,8 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6925,7 +7007,8 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">8/8</td>
@@ -7009,7 +7092,8 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7095,7 +7179,8 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7179,7 +7264,8 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7263,7 +7349,8 @@ return C.has(3) + C.has(4);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7347,7 +7434,8 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7433,7 +7521,8 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7517,7 +7606,8 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7601,7 +7691,8 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7694,7 +7785,8 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -7779,7 +7871,8 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -7857,7 +7950,8 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/3</td>
@@ -7940,7 +8034,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8023,7 +8118,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8106,7 +8202,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8191,7 +8288,8 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8269,7 +8367,8 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/12</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/12</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/12</td>
@@ -8354,7 +8453,8 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8439,7 +8539,8 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8524,7 +8625,8 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8609,7 +8711,8 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8694,7 +8797,8 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8779,7 +8883,8 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8864,7 +8969,8 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8952,7 +9058,8 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9038,7 +9145,8 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9123,7 +9231,8 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9208,7 +9317,8 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9293,7 +9403,8 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9371,7 +9482,8 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/8</td>
@@ -9452,7 +9564,8 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9533,7 +9646,8 @@ return Object.isFrozen([# 42 #]);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9614,7 +9728,8 @@ return Object.isSealed({| foo: 42 |});
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9695,7 +9810,8 @@ return Object.isSealed([| 42 |]);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9784,7 +9900,8 @@ try {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9874,7 +9991,8 @@ try {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9963,7 +10081,8 @@ try {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10053,7 +10172,8 @@ try {
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10134,7 +10254,8 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10220,7 +10341,8 @@ return results.length === 3
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10298,7 +10420,8 @@ return results.length === 3
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/2</td>
@@ -10379,7 +10502,8 @@ return [1, 2, 3].lastItem === 3;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10460,7 +10584,8 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10538,7 +10663,8 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/15</td>
-<td class="tally" data-browser="closure20180910" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/15</td>
+<td class="tally" data-browser="closure20181008" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/15</td>
@@ -10624,7 +10750,8 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10708,7 +10835,8 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10792,7 +10920,8 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10877,7 +11006,8 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10962,7 +11092,8 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11047,7 +11178,8 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11132,7 +11264,8 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11217,7 +11350,8 @@ return set.deleteAll(2, 3) === true
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11298,7 +11432,8 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11382,7 +11517,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11463,7 +11599,8 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11544,7 +11681,8 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11629,7 +11767,8 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11710,7 +11849,8 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11791,7 +11931,8 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="closure20180610">No</td>
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no" data-browser="closure20180910">No</td>
+<td class="no obsolete" data-browser="closure20180910">No</td>
+<td class="no" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11858,7 +11999,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="79">Strawman (stage 0)</td>
+<tr class="category"><td colspan="80">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -11871,7 +12012,8 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -11954,7 +12096,8 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12036,7 +12179,8 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12117,7 +12261,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -12195,7 +12340,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -12277,7 +12423,8 @@ return f();
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12358,7 +12505,8 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12444,7 +12592,8 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12536,7 +12685,8 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -12624,7 +12774,8 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12702,7 +12853,8 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12785,7 +12937,8 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12868,7 +13021,8 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12946,7 +13100,8 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -13027,7 +13182,8 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13108,7 +13264,8 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13189,7 +13346,8 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13270,7 +13428,8 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13351,7 +13510,8 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13432,7 +13592,8 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13513,7 +13674,8 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13597,7 +13759,8 @@ passed = true;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -13675,7 +13838,8 @@ passed = true;
 <td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13762,7 +13926,8 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13856,7 +14021,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13934,7 +14100,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14017,7 +14184,8 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14101,7 +14269,8 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14168,7 +14337,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="ios11_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="79">Pre-strawman</td>
+<tr class="category"><td colspan="80">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -14181,7 +14350,8 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
@@ -14262,7 +14432,8 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14343,7 +14514,8 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14424,7 +14596,8 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14505,7 +14678,8 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14586,7 +14760,8 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14667,7 +14842,8 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14748,7 +14924,8 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14829,7 +15006,8 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14910,7 +15088,8 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>


### PR DESCRIPTION
Support ES2018 template literal revision

https://github.com/google/closure-compiler/wiki/Releases#october-8-2018-v20181008