### PR TITLE
Add results for Node >=10.13 <11

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -2385,7 +2385,7 @@
       "non-standard"
     ]
   },
-  "node10": {
+  "node10_13": {
     "full": "Node.js",
     "family": "Node.js",
     "short": "Node &gt;=10.13 &lt;11",

--- a/environments.json
+++ b/environments.json
@@ -2385,6 +2385,24 @@
       "non-standard"
     ]
   },
+  "node10": {
+    "full": "Node.js",
+    "family": "Node.js",
+    "short": "Node &gt;=10.13 &lt;11",
+    "platformtype": "engine",
+    "note_id": "harmony-flag",
+    "equals": "chrome68",
+    "release": "2018-10-30",
+    "unstable": false,
+    "test_suites": [
+      "es5",
+      "es6",
+      "es2016plus",
+      "esnext",
+      "esintl",
+      "non-standard"
+    ]
+  },
   "duktape1_0": {
     "full": "Duktape 1.0",
     "family": "Duktape",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -192,6 +192,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
@@ -208,7 +209,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="82">2016 features</td>
+      <tr class="category"><td colspan="83">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -279,6 +280,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -363,6 +365,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -447,6 +450,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -536,6 +540,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -617,6 +622,7 @@ return true;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -705,6 +711,7 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -811,6 +818,7 @@ return 24;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -900,6 +908,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -912,7 +921,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2016 misc</td>
+<tr class="category"><td colspan="83">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -993,6 +1002,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1090,6 +1100,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1179,6 +1190,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1264,6 +1276,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1350,6 +1363,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1441,6 +1455,7 @@ return passed;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -1534,6 +1549,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1546,7 +1562,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2017 features</td>
+<tr class="category"><td colspan="83">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1617,6 +1633,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">4/4</td>
 <td class="tally" data-browser="node8_10" data-tally="1">4/4</td>
+<td class="tally" data-browser="node10" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -1704,6 +1721,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1795,6 +1813,7 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1887,6 +1906,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1974,6 +1994,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2055,6 +2076,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -2144,6 +2166,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2233,6 +2256,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2314,6 +2338,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -2398,6 +2423,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2482,6 +2508,7 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2563,6 +2590,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">15/15</td>
 <td class="tally" data-browser="node8_10" data-tally="1">15/15</td>
+<td class="tally" data-browser="node10" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/15</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/15</td>
@@ -2658,6 +2686,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2753,6 +2782,7 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2838,6 +2868,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2923,6 +2954,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3014,6 +3046,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3107,6 +3140,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3192,6 +3226,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3282,6 +3317,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3367,6 +3403,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3462,6 +3499,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3557,6 +3595,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3650,6 +3689,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3736,6 +3776,7 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3820,6 +3861,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3913,6 +3955,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3994,6 +4037,7 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">17/17</td>
 <td class="tally" data-browser="node8_10" data-tally="1">17/17</td>
+<td class="tally" data-browser="node10" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/17</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/17</td>
@@ -4078,6 +4122,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4162,6 +4207,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4246,6 +4292,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4330,6 +4377,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4414,6 +4462,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4498,6 +4547,7 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4582,6 +4632,7 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4666,6 +4717,7 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4750,6 +4802,7 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4834,6 +4887,7 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4918,6 +4972,7 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5002,6 +5057,7 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5086,6 +5142,7 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5170,6 +5227,7 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5254,6 +5312,7 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5338,6 +5397,7 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5422,6 +5482,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5434,7 +5495,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
 </tr>
-<tr class="category"><td colspan="82">2017 misc</td>
+<tr class="category"><td colspan="83">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[22]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -5513,6 +5574,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -5600,6 +5662,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5687,6 +5750,7 @@ return (function(){
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5699,7 +5763,7 @@ return (function(){
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2017 annex b</td>
+<tr class="category"><td colspan="83">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -5770,6 +5834,7 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.75" data-flagged-tally="1">12/16</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.75" data-flagged-tally="1">12/16</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -5859,6 +5924,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -5949,6 +6015,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6039,6 +6106,7 @@ return true;
 <td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6128,6 +6196,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6218,6 +6287,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6308,6 +6378,7 @@ return true;
 <td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6399,6 +6470,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6490,6 +6562,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6582,6 +6655,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6671,6 +6745,7 @@ return true;
 <td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6759,6 +6834,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6850,6 +6926,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6941,6 +7018,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7033,6 +7111,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7122,6 +7201,7 @@ return true;
 <td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7210,6 +7290,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7291,6 +7372,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
+<td class="tally not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -7379,6 +7461,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7467,6 +7550,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7560,6 +7644,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7653,6 +7738,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7738,6 +7824,7 @@ return i === 0;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7750,7 +7837,7 @@ return i === 0;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2018 features</td>
+<tr class="category"><td colspan="83">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -7821,6 +7908,7 @@ return i === 0;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -7906,6 +7994,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7992,6 +8081,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8073,6 +8163,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/3</td>
+<td class="tally" data-browser="node10" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -8183,6 +8274,7 @@ function check() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
 <td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8285,6 +8377,7 @@ function check() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
 <td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8389,6 +8482,7 @@ function check() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
 <td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8474,6 +8568,7 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8565,6 +8660,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8650,6 +8746,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8735,6 +8832,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8816,6 +8914,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0" data-flagged-tally="1">0/2</td>
+<td class="tally" data-browser="node10" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -8907,6 +9006,7 @@ iterator.next().then(function(step){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9008,6 +9108,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9020,7 +9121,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="ios11_3">No</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2018 misc</td>
+<tr class="category"><td colspan="83">2018 misc</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -9101,6 +9202,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9113,7 +9215,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2019 misc</td>
+<tr class="category"><td colspan="83">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://tc39.github.io/proposal-optional-catch-binding/">optional catch binding</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
@@ -9184,6 +9286,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/3</td>
+<td class="tally" data-browser="node10" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -9274,6 +9377,7 @@ return false;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9365,6 +9469,7 @@ return false;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9461,6 +9566,7 @@ return it.next().value;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -192,7 +192,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
-<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node10_13 engine" data-browser="node10_13"><a href="#node10_13" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
@@ -280,7 +280,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_10" data-tally="1">3/3</td>
-<td class="tally" data-browser="node10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10_13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -365,7 +365,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -450,7 +450,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -540,7 +540,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -622,7 +622,7 @@ return true;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_10" data-tally="1">3/3</td>
-<td class="tally" data-browser="node10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10_13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -711,7 +711,7 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -818,7 +818,7 @@ return 24;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -908,7 +908,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1002,7 +1002,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1100,7 +1100,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1190,7 +1190,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1276,7 +1276,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1363,7 +1363,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1455,7 +1455,7 @@ return passed;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -1549,7 +1549,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1633,7 +1633,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">4/4</td>
 <td class="tally" data-browser="node8_10" data-tally="1">4/4</td>
-<td class="tally" data-browser="node10" data-tally="1">4/4</td>
+<td class="tally" data-browser="node10_13" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -1721,7 +1721,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1813,7 +1813,7 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1906,7 +1906,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1994,7 +1994,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2076,7 +2076,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
-<td class="tally" data-browser="node10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -2166,7 +2166,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2256,7 +2256,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2338,7 +2338,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
-<td class="tally" data-browser="node10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -2423,7 +2423,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2508,7 +2508,7 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2590,7 +2590,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">15/15</td>
 <td class="tally" data-browser="node8_10" data-tally="1">15/15</td>
-<td class="tally" data-browser="node10" data-tally="1">15/15</td>
+<td class="tally" data-browser="node10_13" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/15</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/15</td>
@@ -2686,7 +2686,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2782,7 +2782,7 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2868,7 +2868,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2954,7 +2954,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3046,7 +3046,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3140,7 +3140,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3226,7 +3226,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3317,7 +3317,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3403,7 +3403,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3499,7 +3499,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3595,7 +3595,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3689,7 +3689,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3776,7 +3776,7 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3861,7 +3861,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3955,7 +3955,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4037,7 +4037,7 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">17/17</td>
 <td class="tally" data-browser="node8_10" data-tally="1">17/17</td>
-<td class="tally" data-browser="node10" data-tally="1">17/17</td>
+<td class="tally" data-browser="node10_13" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/17</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/17</td>
@@ -4122,7 +4122,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4207,7 +4207,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4292,7 +4292,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4377,7 +4377,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4462,7 +4462,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4547,7 +4547,7 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4632,7 +4632,7 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4717,7 +4717,7 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4802,7 +4802,7 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4887,7 +4887,7 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4972,7 +4972,7 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5057,7 +5057,7 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5142,7 +5142,7 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5227,7 +5227,7 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5312,7 +5312,7 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5397,7 +5397,7 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5482,7 +5482,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5574,7 +5574,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -5662,7 +5662,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5750,7 +5750,7 @@ return (function(){
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5834,7 +5834,7 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.75" data-flagged-tally="1">12/16</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.75" data-flagged-tally="1">12/16</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -5924,7 +5924,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6015,7 +6015,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6106,7 +6106,7 @@ return true;
 <td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6196,7 +6196,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6287,7 +6287,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6378,7 +6378,7 @@ return true;
 <td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6470,7 +6470,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6562,7 +6562,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6655,7 +6655,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6745,7 +6745,7 @@ return true;
 <td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6834,7 +6834,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -6926,7 +6926,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7018,7 +7018,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7111,7 +7111,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7201,7 +7201,7 @@ return true;
 <td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7290,7 +7290,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7372,7 +7372,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
-<td class="tally not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
+<td class="tally not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -7461,7 +7461,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7550,7 +7550,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7644,7 +7644,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7738,7 +7738,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7824,7 +7824,7 @@ return i === 0;
 <td class="yes obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node10_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="duktape2_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="duktape2_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -7908,7 +7908,7 @@ return i === 0;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
-<td class="tally" data-browser="node10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -7994,7 +7994,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8081,7 +8081,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8163,7 +8163,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/3</td>
-<td class="tally" data-browser="node10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10_13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -8274,7 +8274,7 @@ function check() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
 <td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8377,7 +8377,7 @@ function check() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
 <td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8482,7 +8482,7 @@ function check() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
 <td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8568,7 +8568,7 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8660,7 +8660,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8746,7 +8746,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8832,7 +8832,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8914,7 +8914,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0" data-flagged-tally="1">0/2</td>
-<td class="tally" data-browser="node10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -9006,7 +9006,7 @@ iterator.next().then(function(step){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9108,7 +9108,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9202,7 +9202,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9286,7 +9286,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/3</td>
-<td class="tally" data-browser="node10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10_13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -9377,7 +9377,7 @@ return false;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9469,7 +9469,7 @@ return false;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9566,7 +9566,7 @@ return it.next().value;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -182,7 +182,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node10_13 engine" data-browser="node10_13"><a href="#node10_13" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform duktape1_5 engine obsolete" data-browser="duktape1_5"><a href="#duktape1_5" class="browser-name"><abbr title="Duktape 1.5">DUK 1.5</abbr></a></th>
 <th class="platform duktape1_6 engine obsolete" data-browser="duktape1_6"><a href="#duktape1_6" class="browser-name"><abbr title="Duktape 1.6">DUK 1.6</abbr></a></th>
 <th class="platform duktape1_7 engine obsolete" data-browser="duktape1_7"><a href="#duktape1_7" class="browser-name"><abbr title="Duktape 1.7">DUK 1.7</abbr></a></th>
@@ -263,7 +263,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">5/5</td>
 <td class="tally" data-browser="node8_10" data-tally="1">5/5</td>
-<td class="tally" data-browser="node10" data-tally="1">5/5</td>
+<td class="tally" data-browser="node10_13" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/5</td>
@@ -343,7 +343,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -425,7 +425,7 @@ return value === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -505,7 +505,7 @@ return { a: true, }.a === true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -585,7 +585,7 @@ return [1,].length === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -665,7 +665,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -744,7 +744,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">13/13</td>
 <td class="tally" data-browser="node8_10" data-tally="1">13/13</td>
-<td class="tally" data-browser="node10" data-tally="1">13/13</td>
+<td class="tally" data-browser="node10_13" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/13</td>
@@ -826,7 +826,7 @@ return typeof Object.create == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -908,7 +908,7 @@ return typeof Object.defineProperty == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -990,7 +990,7 @@ return typeof Object.defineProperties == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1072,7 +1072,7 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1154,7 +1154,7 @@ return typeof Object.keys == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1236,7 +1236,7 @@ return typeof Object.seal == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1318,7 +1318,7 @@ return typeof Object.freeze == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1400,7 +1400,7 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1482,7 +1482,7 @@ return typeof Object.isSealed == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1564,7 +1564,7 @@ return typeof Object.isFrozen == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1646,7 +1646,7 @@ return typeof Object.isExtensible == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1728,7 +1728,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1810,7 +1810,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1887,7 +1887,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally obsolete" data-browser="node8_3" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="node8_10" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
-<td class="tally" data-browser="node10" data-tally="1">12/12</td>
+<td class="tally" data-browser="node10_13" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/12</td>
@@ -1969,7 +1969,7 @@ return typeof Array.isArray == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2051,7 +2051,7 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2133,7 +2133,7 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2215,7 +2215,7 @@ return typeof Array.prototype.every == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2297,7 +2297,7 @@ return typeof Array.prototype.some == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2379,7 +2379,7 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2461,7 +2461,7 @@ return typeof Array.prototype.map == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2543,7 +2543,7 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2625,7 +2625,7 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2707,7 +2707,7 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2829,7 +2829,7 @@ return true;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2921,7 +2921,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2998,7 +2998,7 @@ try {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
-<td class="tally" data-browser="node10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/2</td>
@@ -3080,7 +3080,7 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3162,7 +3162,7 @@ return typeof String.prototype.trim == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3239,7 +3239,7 @@ return typeof String.prototype.trim == 'function';
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_10" data-tally="1">3/3</td>
-<td class="tally" data-browser="node10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10_13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/3</td>
@@ -3321,7 +3321,7 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3403,7 +3403,7 @@ return typeof Date.now == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3493,7 +3493,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3575,7 +3575,7 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3657,7 +3657,7 @@ return typeof JSON == 'object';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3736,7 +3736,7 @@ return typeof JSON == 'object';
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_10" data-tally="1">3/3</td>
-<td class="tally" data-browser="node10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10_13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/3</td>
@@ -3819,7 +3819,7 @@ return result;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3902,7 +3902,7 @@ return result;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3985,7 +3985,7 @@ return result;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4062,7 +4062,7 @@ return result;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">8/8</td>
 <td class="tally" data-browser="node8_10" data-tally="1">8/8</td>
-<td class="tally" data-browser="node10" data-tally="1">8/8</td>
+<td class="tally" data-browser="node10_13" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/8</td>
@@ -4152,7 +4152,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4234,7 +4234,7 @@ return parseInt('010') === 10;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4314,7 +4314,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4394,7 +4394,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4475,7 +4475,7 @@ return _\u200c\u200d;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4557,7 +4557,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4645,7 +4645,7 @@ return result;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4731,7 +4731,7 @@ catch(e) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4808,7 +4808,7 @@ catch(e) {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">19/19</td>
 <td class="tally" data-browser="node8_10" data-tally="1">19/19</td>
-<td class="tally" data-browser="node10" data-tally="1">19/19</td>
+<td class="tally" data-browser="node10_13" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/19</td>
@@ -4893,7 +4893,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4974,7 +4974,7 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5057,7 +5057,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5154,7 +5154,7 @@ return test(String, &apos;&apos;)
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5237,7 +5237,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5318,7 +5318,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5403,7 +5403,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5488,7 +5488,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5575,7 +5575,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5659,7 +5659,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5741,7 +5741,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5824,7 +5824,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5911,7 +5911,7 @@ return (function(x){
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5992,7 +5992,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6073,7 +6073,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6154,7 +6154,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6235,7 +6235,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6316,7 +6316,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6397,7 +6397,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -182,6 +182,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform duktape1_5 engine obsolete" data-browser="duktape1_5"><a href="#duktape1_5" class="browser-name"><abbr title="Duktape 1.5">DUK 1.5</abbr></a></th>
 <th class="platform duktape1_6 engine obsolete" data-browser="duktape1_6"><a href="#duktape1_6" class="browser-name"><abbr title="Duktape 1.6">DUK 1.6</abbr></a></th>
 <th class="platform duktape1_7 engine obsolete" data-browser="duktape1_7"><a href="#duktape1_7" class="browser-name"><abbr title="Duktape 1.7">DUK 1.7</abbr></a></th>
@@ -262,6 +263,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">5/5</td>
 <td class="tally" data-browser="node8_10" data-tally="1">5/5</td>
+<td class="tally" data-browser="node10" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/5</td>
@@ -341,6 +343,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -422,6 +425,7 @@ return value === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -501,6 +505,7 @@ return { a: true, }.a === true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -580,6 +585,7 @@ return [1,].length === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -659,6 +665,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -678,7 +685,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr><th colspan="77" class="separator"></th>
+<tr><th colspan="78" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -737,6 +744,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">13/13</td>
 <td class="tally" data-browser="node8_10" data-tally="1">13/13</td>
+<td class="tally" data-browser="node10" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/13</td>
@@ -818,6 +826,7 @@ return typeof Object.create == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -899,6 +908,7 @@ return typeof Object.defineProperty == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -980,6 +990,7 @@ return typeof Object.defineProperties == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1061,6 +1072,7 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1142,6 +1154,7 @@ return typeof Object.keys == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1223,6 +1236,7 @@ return typeof Object.seal == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1304,6 +1318,7 @@ return typeof Object.freeze == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1385,6 +1400,7 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1466,6 +1482,7 @@ return typeof Object.isSealed == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1547,6 +1564,7 @@ return typeof Object.isFrozen == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1628,6 +1646,7 @@ return typeof Object.isExtensible == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1709,6 +1728,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1790,6 +1810,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -1866,6 +1887,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally obsolete" data-browser="node8_3" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="node8_10" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
+<td class="tally" data-browser="node10" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/12</td>
@@ -1947,6 +1969,7 @@ return typeof Array.isArray == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2028,6 +2051,7 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2109,6 +2133,7 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2190,6 +2215,7 @@ return typeof Array.prototype.every == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2271,6 +2297,7 @@ return typeof Array.prototype.some == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2352,6 +2379,7 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2433,6 +2461,7 @@ return typeof Array.prototype.map == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2514,6 +2543,7 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2595,6 +2625,7 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2676,6 +2707,7 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2797,6 +2829,7 @@ return true;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2888,6 +2921,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -2964,6 +2998,7 @@ try {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/2</td>
@@ -3045,6 +3080,7 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3126,6 +3162,7 @@ return typeof String.prototype.trim == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3202,6 +3239,7 @@ return typeof String.prototype.trim == 'function';
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/3</td>
@@ -3283,6 +3321,7 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3364,6 +3403,7 @@ return typeof Date.now == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3453,6 +3493,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3534,6 +3575,7 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3615,6 +3657,7 @@ return typeof JSON == 'object';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3634,7 +3677,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr><th colspan="77" class="separator"></th>
+<tr><th colspan="78" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -3693,6 +3736,7 @@ return typeof JSON == 'object';
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">3/3</td>
 <td class="tally" data-browser="node8_10" data-tally="1">3/3</td>
+<td class="tally" data-browser="node10" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/3</td>
@@ -3775,6 +3819,7 @@ return result;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3857,6 +3902,7 @@ return result;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -3939,6 +3985,7 @@ return result;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4015,6 +4062,7 @@ return result;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">8/8</td>
 <td class="tally" data-browser="node8_10" data-tally="1">8/8</td>
+<td class="tally" data-browser="node10" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/8</td>
@@ -4104,6 +4152,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4185,6 +4234,7 @@ return parseInt('010') === 10;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4264,6 +4314,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4343,6 +4394,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4423,6 +4475,7 @@ return _\u200c\u200d;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4504,6 +4557,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4591,6 +4645,7 @@ return result;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4676,6 +4731,7 @@ catch(e) {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4752,6 +4808,7 @@ catch(e) {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">19/19</td>
 <td class="tally" data-browser="node8_10" data-tally="1">19/19</td>
+<td class="tally" data-browser="node10" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="duktape1_5" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="duktape1_6" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="duktape1_7" data-tally="0">0/19</td>
@@ -4836,6 +4893,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4916,6 +4974,7 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -4998,6 +5057,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5094,6 +5154,7 @@ return test(String, &apos;&apos;)
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5176,6 +5237,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5256,6 +5318,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5340,6 +5403,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5424,6 +5488,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5510,6 +5575,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5593,6 +5659,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5674,6 +5741,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5756,6 +5824,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5842,6 +5911,7 @@ return (function(x){
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -5922,6 +5992,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6002,6 +6073,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6082,6 +6154,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6162,6 +6235,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6242,6 +6316,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>
@@ -6322,6 +6397,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape1_5">No</td>
 <td class="no obsolete" data-browser="duktape1_6">No</td>
 <td class="no obsolete" data-browser="duktape1_7">No</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -183,7 +183,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
-<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node10_13 engine" data-browser="node10_13"><a href="#node10_13" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
@@ -251,7 +251,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
-<td class="tally" data-browser="node10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -318,7 +318,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -385,7 +385,7 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -449,7 +449,7 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">4/4</td>
 <td class="tally" data-browser="node8_10" data-tally="1">4/4</td>
-<td class="tally" data-browser="node10" data-tally="1">4/4</td>
+<td class="tally" data-browser="node10_13" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -516,7 +516,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -583,7 +583,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -650,7 +650,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -745,7 +745,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -809,7 +809,7 @@ try {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
-<td class="tally" data-browser="node10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
@@ -876,7 +876,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -940,7 +940,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
-<td class="tally" data-browser="node10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
@@ -1007,7 +1007,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1071,7 +1071,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">5/5</td>
 <td class="tally" data-browser="node8_10" data-tally="1">5/5</td>
-<td class="tally" data-browser="node10" data-tally="1">5/5</td>
+<td class="tally" data-browser="node10_13" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/5</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/5</td>
@@ -1138,7 +1138,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1205,7 +1205,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1272,7 +1272,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1339,7 +1339,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1434,7 +1434,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1498,7 +1498,7 @@ try {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">6/6</td>
 <td class="tally" data-browser="node8_10" data-tally="1">6/6</td>
-<td class="tally" data-browser="node10" data-tally="1">6/6</td>
+<td class="tally" data-browser="node10_13" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/6</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/6</td>
@@ -1565,7 +1565,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1632,7 +1632,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1699,7 +1699,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1794,7 +1794,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1862,7 +1862,7 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1937,7 +1937,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2001,7 +2001,7 @@ try {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
-<td class="tally" data-browser="node10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2068,7 +2068,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2132,7 +2132,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
-<td class="tally" data-browser="node10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2199,7 +2199,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2263,7 +2263,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
-<td class="tally" data-browser="node10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2330,7 +2330,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2394,7 +2394,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
-<td class="tally" data-browser="node10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2461,7 +2461,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2525,7 +2525,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
-<td class="tally" data-browser="node10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2592,7 +2592,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2656,7 +2656,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
-<td class="tally" data-browser="node10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2723,7 +2723,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2787,7 +2787,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
-<td class="tally" data-browser="node10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2854,7 +2854,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -183,6 +183,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
@@ -250,6 +251,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">2/2</td>
 <td class="tally" data-browser="node8_10" data-tally="1">2/2</td>
+<td class="tally" data-browser="node10" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -316,6 +318,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -382,6 +385,7 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -445,6 +449,7 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">4/4</td>
 <td class="tally" data-browser="node8_10" data-tally="1">4/4</td>
+<td class="tally" data-browser="node10" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -511,6 +516,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -577,6 +583,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -643,6 +650,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -737,6 +745,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -800,6 +809,7 @@ try {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
@@ -866,6 +876,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -929,6 +940,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
@@ -995,6 +1007,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1058,6 +1071,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">5/5</td>
 <td class="tally" data-browser="node8_10" data-tally="1">5/5</td>
+<td class="tally" data-browser="node10" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/5</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/5</td>
@@ -1124,6 +1138,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1190,6 +1205,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1256,6 +1272,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1322,6 +1339,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1416,6 +1434,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1479,6 +1498,7 @@ try {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">6/6</td>
 <td class="tally" data-browser="node8_10" data-tally="1">6/6</td>
+<td class="tally" data-browser="node10" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/6</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/6</td>
@@ -1545,6 +1565,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1611,6 +1632,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1677,6 +1699,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1771,6 +1794,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1838,6 +1862,7 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1912,6 +1937,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1975,6 +2001,7 @@ try {
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2041,6 +2068,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2104,6 +2132,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2170,6 +2199,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2233,6 +2263,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2299,6 +2330,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2362,6 +2394,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2428,6 +2461,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2491,6 +2525,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2557,6 +2592,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2620,6 +2656,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2686,6 +2723,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -2749,6 +2787,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="1">1/1</td>
 <td class="tally" data-browser="node8_10" data-tally="1">1/1</td>
+<td class="tally" data-browser="node10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">1/1</td>
@@ -2815,6 +2854,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -196,6 +196,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
@@ -212,7 +213,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="80">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="81">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-string-left-right-trim">string trimming</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -281,6 +282,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="node8_10" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally" data-browser="node10" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -363,6 +365,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -445,6 +448,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -527,6 +531,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -609,6 +614,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -688,6 +694,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -772,6 +779,7 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -860,6 +868,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -952,6 +961,7 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1031,6 +1041,7 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/3</td>
+<td class="tally" data-browser="node10" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -1116,6 +1127,7 @@ return new C().x === &apos;x&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1207,6 +1219,7 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1295,6 +1308,7 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1374,6 +1388,7 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -1459,6 +1474,7 @@ return C.x === &apos;x&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1547,6 +1563,7 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1626,6 +1643,7 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)" data-flagged-tally="1">4/7</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)" data-flagged-tally="1">4/7</td>
 <td class="tally" data-browser="node8_10" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)" data-flagged-tally="1">4/7</td>
+<td class="tally" data-browser="node10" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
@@ -1710,6 +1728,7 @@ return fn + &apos;&apos; === str;
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1793,6 +1812,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1876,6 +1896,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -1959,6 +1980,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2042,6 +2064,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2125,6 +2148,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2208,6 +2232,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2287,6 +2312,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -2369,6 +2395,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2453,6 +2480,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2535,6 +2563,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2614,6 +2643,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/8</td>
+<td class="tally" data-browser="node10" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
@@ -2696,6 +2726,7 @@ return (1n + 2n) === 3n;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2778,6 +2809,7 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2860,6 +2892,7 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2942,6 +2975,7 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3027,6 +3061,7 @@ return view[0] === -0x8000000000000000n;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3112,6 +3147,7 @@ return view[0] === 0n;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3194,6 +3230,7 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3276,6 +3313,7 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3359,6 +3397,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3371,7 +3410,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="80">Draft (stage 2)</td>
+<tr class="category"><td colspan="81">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -3449,6 +3488,7 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3528,6 +3568,7 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/1</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/1</td>
+<td class="tally" data-browser="node10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
@@ -3618,6 +3659,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3703,6 +3745,7 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3789,6 +3832,7 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3868,6 +3912,7 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/4</td>
+<td class="tally" data-browser="node10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -3956,6 +4001,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4048,6 +4094,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4135,6 +4182,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4222,6 +4270,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4305,6 +4354,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4384,6 +4434,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/4</td>
+<td class="tally" data-browser="node10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -4469,6 +4520,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4555,6 +4607,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4640,6 +4693,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4725,6 +4779,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4737,7 +4792,7 @@ return set.size === 2
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="80">Proposal (stage 1)</td>
+<tr class="category"><td colspan="81">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -4812,6 +4867,7 @@ return do {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4891,6 +4947,7 @@ return do {
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/7</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/7</td>
+<td class="tally" data-browser="node10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
@@ -4973,6 +5030,7 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5055,6 +5113,7 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5137,6 +5196,7 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5229,6 +5289,7 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5312,6 +5373,7 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5394,6 +5456,7 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5476,6 +5539,7 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5559,6 +5623,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5644,6 +5709,7 @@ return Math.signbit(-0) === false
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5723,6 +5789,7 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/7</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/7</td>
+<td class="tally" data-browser="node10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
@@ -5807,6 +5874,7 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5889,6 +5957,7 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5972,6 +6041,7 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6054,6 +6124,7 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6136,6 +6207,7 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6219,6 +6291,7 @@ return Math.radians(90) === Math.PI / 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6301,6 +6374,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6380,6 +6454,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/7</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/7</td>
+<td class="tally" data-browser="node10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
@@ -6462,6 +6537,7 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6544,6 +6620,7 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6628,6 +6705,7 @@ return score === 1;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6717,6 +6795,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6806,6 +6885,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6895,6 +6975,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6984,6 +7065,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7063,6 +7145,7 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/8</td>
+<td class="tally" data-browser="node10" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
@@ -7148,6 +7231,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7235,6 +7319,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7320,6 +7405,7 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7405,6 +7491,7 @@ return C.has(3) + C.has(4);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7490,6 +7577,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7577,6 +7665,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7662,6 +7751,7 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7747,6 +7837,7 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7841,6 +7932,7 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7927,6 +8019,7 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8006,6 +8099,7 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/3</td>
+<td class="tally" data-browser="node10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -8090,6 +8184,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8174,6 +8269,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8258,6 +8354,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8344,6 +8441,7 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8423,6 +8521,7 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/12</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/12</td>
+<td class="tally" data-browser="node10" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/12</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/12</td>
@@ -8509,6 +8608,7 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8595,6 +8695,7 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8681,6 +8782,7 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8767,6 +8869,7 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8853,6 +8956,7 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8939,6 +9043,7 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9025,6 +9130,7 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9114,6 +9220,7 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9201,6 +9308,7 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9287,6 +9395,7 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9373,6 +9482,7 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9459,6 +9569,7 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9538,6 +9649,7 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/8</td>
+<td class="tally" data-browser="node10" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
@@ -9620,6 +9732,7 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9702,6 +9815,7 @@ return Object.isFrozen([# 42 #]);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9784,6 +9898,7 @@ return Object.isSealed({| foo: 42 |});
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9866,6 +9981,7 @@ return Object.isSealed([| 42 |]);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9956,6 +10072,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10047,6 +10164,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10137,6 +10255,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10228,6 +10347,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10310,6 +10430,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10397,6 +10518,7 @@ return results.length === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10476,6 +10598,7 @@ return results.length === 3
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -10558,6 +10681,7 @@ return [1, 2, 3].lastItem === 3;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10640,6 +10764,7 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10719,6 +10844,7 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/15</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/15</td>
+<td class="tally" data-browser="node10" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/15</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/15</td>
@@ -10806,6 +10932,7 @@ return map.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10891,6 +11018,7 @@ return map.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10976,6 +11104,7 @@ return map.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11062,6 +11191,7 @@ return map.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11148,6 +11278,7 @@ return map.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11234,6 +11365,7 @@ return map.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11320,6 +11452,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11406,6 +11539,7 @@ return set.deleteAll(2, 3) === true
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11488,6 +11622,7 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11573,6 +11708,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11655,6 +11791,7 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11737,6 +11874,7 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11823,6 +11961,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11905,6 +12044,7 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11987,6 +12127,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11999,7 +12140,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="80">Strawman (stage 0)</td>
+<tr class="category"><td colspan="81">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12068,6 +12209,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12152,6 +12294,7 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12235,6 +12378,7 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12317,6 +12461,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12396,6 +12541,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -12479,6 +12625,7 @@ return f();
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12561,6 +12708,7 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12648,6 +12796,7 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12741,6 +12890,7 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12830,6 +12980,7 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12909,6 +13060,7 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12993,6 +13145,7 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13077,6 +13230,7 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13156,6 +13310,7 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -13238,6 +13393,7 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13320,6 +13476,7 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13402,6 +13559,7 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13484,6 +13642,7 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13566,6 +13725,7 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13648,6 +13808,7 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13730,6 +13891,7 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13809,6 +13971,7 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13897,6 +14060,7 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13992,6 +14156,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14071,6 +14236,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14155,6 +14321,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14240,6 +14407,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14252,7 +14420,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="ios11_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="80">Pre-strawman</td>
+<tr class="category"><td colspan="81">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -14321,6 +14489,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -14403,6 +14572,7 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14485,6 +14655,7 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14567,6 +14738,7 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14649,6 +14821,7 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14731,6 +14904,7 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14813,6 +14987,7 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14895,6 +15070,7 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14977,6 +15153,7 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15059,6 +15236,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -196,7 +196,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
-<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
+<th class="platform node10_13 engine" data-browser="node10_13"><a href="#node10_13" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
@@ -282,7 +282,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="node8_10" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally" data-browser="node10" data-tally="1">4/4</td>
+<td class="tally" data-browser="node10_13" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -365,7 +365,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -448,7 +448,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -531,7 +531,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -614,7 +614,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -694,7 +694,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
-<td class="tally" data-browser="node10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -779,7 +779,7 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -868,7 +868,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -961,7 +961,7 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="node10_13">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1041,7 +1041,7 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/3</td>
-<td class="tally" data-browser="node10" data-tally="0" data-flagged-tally="1">0/3</td>
+<td class="tally" data-browser="node10_13" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -1127,7 +1127,7 @@ return new C().x === &apos;x&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="node10_13">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1219,7 +1219,7 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="node10_13">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1308,7 +1308,7 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="node10_13">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1388,7 +1388,7 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
-<td class="tally" data-browser="node10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -1474,7 +1474,7 @@ return C.x === &apos;x&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1563,7 +1563,7 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1643,7 +1643,7 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)" data-flagged-tally="1">4/7</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)" data-flagged-tally="1">4/7</td>
 <td class="tally" data-browser="node8_10" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)" data-flagged-tally="1">4/7</td>
-<td class="tally" data-browser="node10" data-tally="1">7/7</td>
+<td class="tally" data-browser="node10_13" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
@@ -1728,7 +1728,7 @@ return fn + &apos;&apos; === str;
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1812,7 +1812,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1896,7 +1896,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -1980,7 +1980,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2064,7 +2064,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2148,7 +2148,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2232,7 +2232,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2312,7 +2312,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
-<td class="tally" data-browser="node10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -2395,7 +2395,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2480,7 +2480,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2563,7 +2563,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2643,7 +2643,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/8</td>
-<td class="tally" data-browser="node10" data-tally="1">8/8</td>
+<td class="tally" data-browser="node10_13" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
@@ -2726,7 +2726,7 @@ return (1n + 2n) === 3n;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2809,7 +2809,7 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2892,7 +2892,7 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2975,7 +2975,7 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3061,7 +3061,7 @@ return view[0] === -0x8000000000000000n;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3147,7 +3147,7 @@ return view[0] === 0n;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3230,7 +3230,7 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3313,7 +3313,7 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3397,7 +3397,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3488,7 +3488,7 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3568,7 +3568,7 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/1</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/1</td>
-<td class="tally" data-browser="node10" data-tally="0">0/1</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/1</td>
@@ -3659,7 +3659,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3745,7 +3745,7 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3832,7 +3832,7 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3912,7 +3912,7 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/4</td>
-<td class="tally" data-browser="node10" data-tally="0">0/4</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -4001,7 +4001,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4094,7 +4094,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4182,7 +4182,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4270,7 +4270,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4354,7 +4354,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no flagged" data-browser="node10">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="node10_13">Flag<a href="#chrome-harmony-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4434,7 +4434,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/4</td>
-<td class="tally" data-browser="node10" data-tally="0">0/4</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -4520,7 +4520,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4607,7 +4607,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4693,7 +4693,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4779,7 +4779,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4867,7 +4867,7 @@ return do {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4947,7 +4947,7 @@ return do {
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/7</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/7</td>
-<td class="tally" data-browser="node10" data-tally="0">0/7</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
@@ -5030,7 +5030,7 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5113,7 +5113,7 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5196,7 +5196,7 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5289,7 +5289,7 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5373,7 +5373,7 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5456,7 +5456,7 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5539,7 +5539,7 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5623,7 +5623,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5709,7 +5709,7 @@ return Math.signbit(-0) === false
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5789,7 +5789,7 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/7</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/7</td>
-<td class="tally" data-browser="node10" data-tally="0">0/7</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
@@ -5874,7 +5874,7 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5957,7 +5957,7 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6041,7 +6041,7 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6124,7 +6124,7 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6207,7 +6207,7 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6291,7 +6291,7 @@ return Math.radians(90) === Math.PI / 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6374,7 +6374,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6454,7 +6454,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/7</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/7</td>
-<td class="tally" data-browser="node10" data-tally="0">0/7</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/7</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/7</td>
@@ -6537,7 +6537,7 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6620,7 +6620,7 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6705,7 +6705,7 @@ return score === 1;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6795,7 +6795,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6885,7 +6885,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6975,7 +6975,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7065,7 +7065,7 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7145,7 +7145,7 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/8</td>
-<td class="tally" data-browser="node10" data-tally="0">0/8</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
@@ -7231,7 +7231,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7319,7 +7319,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7405,7 +7405,7 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7491,7 +7491,7 @@ return C.has(3) + C.has(4);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7577,7 +7577,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7665,7 +7665,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7751,7 +7751,7 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7837,7 +7837,7 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7932,7 +7932,7 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8019,7 +8019,7 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8099,7 +8099,7 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/3</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/3</td>
-<td class="tally" data-browser="node10" data-tally="0">0/3</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
@@ -8184,7 +8184,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8269,7 +8269,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8354,7 +8354,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8441,7 +8441,7 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8521,7 +8521,7 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/12</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/12</td>
-<td class="tally" data-browser="node10" data-tally="0">0/12</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/12</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/12</td>
@@ -8608,7 +8608,7 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8695,7 +8695,7 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8782,7 +8782,7 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8869,7 +8869,7 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -8956,7 +8956,7 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9043,7 +9043,7 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9130,7 +9130,7 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9220,7 +9220,7 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9308,7 +9308,7 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9395,7 +9395,7 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9482,7 +9482,7 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9569,7 +9569,7 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9649,7 +9649,7 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/8</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/8</td>
-<td class="tally" data-browser="node10" data-tally="0">0/8</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
@@ -9732,7 +9732,7 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9815,7 +9815,7 @@ return Object.isFrozen([# 42 #]);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9898,7 +9898,7 @@ return Object.isSealed({| foo: 42 |});
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -9981,7 +9981,7 @@ return Object.isSealed([| 42 |]);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10072,7 +10072,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10164,7 +10164,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10255,7 +10255,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10347,7 +10347,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10430,7 +10430,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10518,7 +10518,7 @@ return results.length === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10598,7 +10598,7 @@ return results.length === 3
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
-<td class="tally" data-browser="node10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
@@ -10681,7 +10681,7 @@ return [1, 2, 3].lastItem === 3;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10764,7 +10764,7 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -10844,7 +10844,7 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/15</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/15</td>
-<td class="tally" data-browser="node10" data-tally="0">0/15</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/15</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/15</td>
@@ -10932,7 +10932,7 @@ return map.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11018,7 +11018,7 @@ return map.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11104,7 +11104,7 @@ return map.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11191,7 +11191,7 @@ return map.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11278,7 +11278,7 @@ return map.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11365,7 +11365,7 @@ return map.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11452,7 +11452,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11539,7 +11539,7 @@ return set.deleteAll(2, 3) === true
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11622,7 +11622,7 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11708,7 +11708,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11791,7 +11791,7 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11874,7 +11874,7 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -11961,7 +11961,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -12044,7 +12044,7 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -12127,7 +12127,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -12209,7 +12209,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12294,7 +12294,7 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12378,7 +12378,7 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12461,7 +12461,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12541,7 +12541,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -12625,7 +12625,7 @@ return f();
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12708,7 +12708,7 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12796,7 +12796,7 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12890,7 +12890,7 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12980,7 +12980,7 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13060,7 +13060,7 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13145,7 +13145,7 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13230,7 +13230,7 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13310,7 +13310,7 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -13393,7 +13393,7 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13476,7 +13476,7 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13559,7 +13559,7 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13642,7 +13642,7 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13725,7 +13725,7 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13808,7 +13808,7 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13891,7 +13891,7 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13971,7 +13971,7 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14060,7 +14060,7 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14156,7 +14156,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14236,7 +14236,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14321,7 +14321,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14407,7 +14407,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14489,7 +14489,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -14572,7 +14572,7 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14655,7 +14655,7 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14738,7 +14738,7 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14821,7 +14821,7 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14904,7 +14904,7 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14987,7 +14987,7 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15070,7 +15070,7 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15153,7 +15153,7 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15236,7 +15236,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node8_3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node8_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node8_10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node10_13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_0" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="duktape2_1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="duktape2_2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -170,7 +170,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node10_13 engine" data-browser="node10_13"><a href="#node10_13" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
@@ -242,7 +242,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/57</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/57</td>
-<td class="tally" data-browser="node10" data-tally="0">0/57</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/57</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/57</td>
@@ -321,7 +321,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -392,7 +392,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -463,7 +463,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -534,7 +534,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -605,7 +605,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -676,7 +676,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -747,7 +747,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -818,7 +818,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -889,7 +889,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -960,7 +960,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1031,7 +1031,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1104,7 +1104,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1177,7 +1177,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1250,7 +1250,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1323,7 +1323,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1396,7 +1396,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1469,7 +1469,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1542,7 +1542,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1615,7 +1615,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1688,7 +1688,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1761,7 +1761,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1834,7 +1834,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1907,7 +1907,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1980,7 +1980,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2053,7 +2053,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2126,7 +2126,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2199,7 +2199,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2272,7 +2272,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2345,7 +2345,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2418,7 +2418,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2491,7 +2491,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2564,7 +2564,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2637,7 +2637,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2710,7 +2710,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2783,7 +2783,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2856,7 +2856,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2929,7 +2929,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3002,7 +3002,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3075,7 +3075,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3148,7 +3148,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3221,7 +3221,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3294,7 +3294,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3367,7 +3367,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3440,7 +3440,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3513,7 +3513,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3586,7 +3586,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3659,7 +3659,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3732,7 +3732,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3805,7 +3805,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3878,7 +3878,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3951,7 +3951,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4024,7 +4024,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4097,7 +4097,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4170,7 +4170,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4243,7 +4243,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4316,7 +4316,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4387,7 +4387,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4457,7 +4457,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/4</td>
-<td class="tally" data-browser="node10" data-tally="0">0/4</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -4528,7 +4528,7 @@ return typeof uneval == &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4607,7 +4607,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4678,7 +4678,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4836,7 +4836,7 @@ return true;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4908,7 +4908,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4983,7 +4983,7 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5060,7 +5060,7 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5139,7 +5139,7 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5212,7 +5212,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5286,7 +5286,7 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5361,7 +5361,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5434,7 +5434,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5517,7 +5517,7 @@ return executed;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5590,7 +5590,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5663,7 +5663,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5738,7 +5738,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5809,7 +5809,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5880,7 +5880,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5951,7 +5951,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6026,7 +6026,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6098,7 +6098,7 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6203,7 +6203,7 @@ catch(e) {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6314,7 +6314,7 @@ catch(e) {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6424,7 +6424,7 @@ global.test((function () {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6497,7 +6497,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6575,7 +6575,7 @@ return passed;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6664,7 +6664,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6741,7 +6741,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6820,7 +6820,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6891,7 +6891,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6963,7 +6963,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7034,7 +7034,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7103,7 +7103,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7174,7 +7174,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7253,7 +7253,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7324,7 +7324,7 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7393,7 +7393,7 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7462,7 +7462,7 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7533,7 +7533,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7616,7 +7616,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="yes" data-browser="node10">Yes</td>
+<td class="yes" data-browser="node10_13">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -7689,7 +7689,7 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -7762,7 +7762,7 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7835,7 +7835,7 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -7908,7 +7908,7 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7978,7 +7978,7 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="node8_3" data-tally="0.5">1/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0.5">1/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
-<td class="tally" data-browser="node10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">2/2</td>
@@ -8051,7 +8051,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -8129,7 +8129,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
-<td class="no" data-browser="node10">No</td>
+<td class="no" data-browser="node10_13">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -170,6 +170,7 @@
 <th class="platform node8_3 engine obsolete" data-browser="node8_3"><a href="#node8_3" class="browser-name"><abbr title="Node.js">Node &gt;=8.3 &lt;8.7</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node8_7 engine obsolete" data-browser="node8_7"><a href="#node8_7" class="browser-name"><abbr title="Node.js">Node &gt;=8.7 &lt;8.10</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node8_10 engine" data-browser="node8_10"><a href="#node8_10" class="browser-name"><abbr title="Node.js">Node &gt;=8.10 &lt;9</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node10 engine" data-browser="node10"><a href="#node10" class="browser-name"><abbr title="Node.js">Node &gt;=10.13 &lt;11</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
@@ -241,6 +242,7 @@
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/57</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/57</td>
+<td class="tally" data-browser="node10" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/57</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/57</td>
@@ -319,6 +321,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -389,6 +392,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -459,6 +463,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -529,6 +534,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -599,6 +605,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -669,6 +676,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -739,6 +747,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -809,6 +818,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -879,6 +889,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -949,6 +960,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1019,6 +1031,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1091,6 +1104,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1163,6 +1177,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1235,6 +1250,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1307,6 +1323,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1379,6 +1396,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1451,6 +1469,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1523,6 +1542,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1595,6 +1615,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1667,6 +1688,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1739,6 +1761,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1811,6 +1834,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1883,6 +1907,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -1955,6 +1980,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2027,6 +2053,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2099,6 +2126,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2171,6 +2199,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2243,6 +2272,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2315,6 +2345,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2387,6 +2418,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2459,6 +2491,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2531,6 +2564,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2603,6 +2637,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2675,6 +2710,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2747,6 +2783,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2819,6 +2856,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2891,6 +2929,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -2963,6 +3002,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3035,6 +3075,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3107,6 +3148,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3179,6 +3221,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3251,6 +3294,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3323,6 +3367,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3395,6 +3440,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3467,6 +3513,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3539,6 +3586,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3611,6 +3659,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3683,6 +3732,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3755,6 +3805,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3827,6 +3878,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3899,6 +3951,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -3971,6 +4024,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4043,6 +4097,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4115,6 +4170,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4187,6 +4243,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4259,6 +4316,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4329,6 +4387,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4341,7 +4400,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/4</td>
@@ -4398,6 +4457,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="node8_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0">0/4</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/4</td>
+<td class="tally" data-browser="node10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
@@ -4468,6 +4528,7 @@ return typeof uneval == &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4546,6 +4607,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4616,6 +4678,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4773,6 +4836,7 @@ return true;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4844,6 +4908,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4856,7 +4921,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -4918,6 +4983,7 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -4994,6 +5060,7 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5072,6 +5139,7 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5144,6 +5212,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5156,7 +5225,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -5217,6 +5286,7 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5291,6 +5361,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5363,6 +5434,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5445,6 +5517,7 @@ return executed;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5517,6 +5590,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5589,6 +5663,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5601,7 +5676,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -5663,6 +5738,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5733,6 +5809,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5803,6 +5880,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5873,6 +5951,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -5947,6 +6026,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6018,6 +6098,7 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6030,7 +6111,7 @@ return arr[1] === arr;
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -6122,6 +6203,7 @@ catch(e) {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6232,6 +6314,7 @@ catch(e) {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6341,6 +6424,7 @@ global.test((function () {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6413,6 +6497,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6490,6 +6575,7 @@ return passed;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6502,7 +6588,7 @@ return passed;
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -6578,6 +6664,7 @@ try {
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6654,6 +6741,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6732,6 +6820,7 @@ return true;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6802,6 +6891,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6873,6 +6963,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -6885,7 +6976,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
@@ -6943,6 +7034,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7011,6 +7103,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7023,7 +7116,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
@@ -7081,6 +7174,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7159,6 +7253,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7171,7 +7266,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
@@ -7229,6 +7324,7 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7297,6 +7393,7 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7365,6 +7462,7 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7435,6 +7533,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7447,7 +7546,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -7517,6 +7616,7 @@ try {
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
+<td class="yes" data-browser="node10">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -7589,6 +7689,7 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -7661,6 +7762,7 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7733,6 +7835,7 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -7805,6 +7908,7 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
@@ -7817,7 +7921,7 @@ return 'description' in new Error();
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr><th colspan="68" class="separator"></th>
+<tr><th colspan="69" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a>global</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/2</td>
@@ -7874,6 +7978,7 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="node8_3" data-tally="0.5">1/2</td>
 <td class="tally obsolete" data-browser="node8_7" data-tally="0.5">1/2</td>
 <td class="tally" data-browser="node8_10" data-tally="0">0/2</td>
+<td class="tally" data-browser="node10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">2/2</td>
@@ -7946,6 +8051,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
@@ -8023,6 +8129,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
 <td class="no" data-browser="node8_10">No</td>
+<td class="no" data-browser="node10">No</td>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>


### PR DESCRIPTION
Node 10.13 uses the same V8 version as Chrome 68 (V8 v6.8).

I figured it out by looking up Node's V8 version and then finding a Chrome release using a matching V8 version:

```sh
$ node --version
v10.13.0
```
```sh
❯ node -e "console.log(process.versions.v8)"
6.8.275.32-node.36
```

https://github.com/chromium/chromium/blob/68.0.3440.134/DEPS#L104

https://github.com/v8/v8/commit/e74ffb8d10fa5a8e29ae1187294a1c76346c712f