### PR TITLE
Update Closure Compiler to v20181125

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -2356,6 +2356,7 @@ exports.tests = [
         res: {
           babel6: true,
           closure: true,
+          closure20181028: false,
           typescript2_1: true,
           jsx: true,
           ie11: false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -18538,6 +18538,11 @@ exports.tests = [
         ejs: true,
         babel6: babel.corejs,
         typescript1: typescript.corejs,
+        closure20181125: {
+          val: false,
+          note_id: 'closure-mathfround',
+          note_html: 'Requires native support for <code>Float32Array</code>'
+        },
         tr: true,
         es6shim: true,
         edge12: true,

--- a/environments.json
+++ b/environments.json
@@ -144,6 +144,30 @@
     "short": "Closure 2018.10",
     "family": "Closure",
     "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20181028": {
+    "full": "Closure Compiler v20181028",
+    "short": "Closure 2018.10",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20181125": {
+    "full": "Closure Compiler v20181125",
+    "short": "Closure 2018.11",
+    "family": "Closure",
+    "platformtype": "compiler",
     "obsolete": false,
     "test_suites": [
       "es6",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -135,7 +135,9 @@
 <th class="platform closure20180716 compiler obsolete" data-browser="closure20180716"><a href="#closure20180716" class="browser-name"><abbr title="Closure Compiler v20180716">Closure 2018.07</abbr></a></th>
 <th class="platform closure20180805 compiler obsolete" data-browser="closure20180805"><a href="#closure20180805" class="browser-name"><abbr title="Closure Compiler v20180805">Closure 2018.08</abbr></a></th>
 <th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
-<th class="platform closure20181008 compiler" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
+<th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
+<th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
+<th class="platform closure20181125 compiler" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
 <th class="platform typescript1 compiler obsolete" data-browser="typescript1"><a href="#typescript1" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_6 compiler obsolete" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_7 compiler obsolete" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
@@ -208,7 +210,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="82">2016 features</td>
+      <tr class="category"><td colspan="84">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -222,7 +224,9 @@
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20181008" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20181125" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -306,7 +310,9 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -390,7 +396,9 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -479,7 +487,9 @@ return true;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -560,7 +570,9 @@ return true;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20181008" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20181125" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">3/3</td>
@@ -648,7 +660,9 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -754,7 +768,9 @@ return 24;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -843,7 +859,9 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -912,7 +930,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2016 misc</td>
+<tr class="category"><td colspan="84">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -936,7 +954,9 @@ return true;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1033,7 +1053,9 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -1122,7 +1144,9 @@ return true;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1207,7 +1231,9 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -1293,7 +1319,9 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -1384,7 +1412,9 @@ return passed;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1477,7 +1507,9 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1546,7 +1578,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2017 features</td>
+<tr class="category"><td colspan="84">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1560,7 +1592,9 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20181008" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20181125" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">4/4</td>
@@ -1647,7 +1681,9 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1738,7 +1774,9 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1830,7 +1868,9 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1917,7 +1957,9 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1998,7 +2040,9 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20181008" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
@@ -2087,7 +2131,9 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2176,7 +2222,9 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2257,7 +2305,9 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20181008" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
@@ -2341,7 +2391,9 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -2425,7 +2477,9 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -2506,7 +2560,9 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally" data-browser="closure20181008" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally" data-browser="closure20181125" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
@@ -2601,7 +2657,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2696,7 +2754,9 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2781,7 +2841,9 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7">?</td>
@@ -2866,7 +2928,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2957,7 +3021,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3050,7 +3116,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3135,7 +3203,9 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7">?</td>
@@ -3225,7 +3295,9 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3310,7 +3382,9 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7">?</td>
@@ -3405,7 +3479,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3500,7 +3576,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3593,7 +3671,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3679,7 +3759,9 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3763,7 +3845,9 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3856,7 +3940,9 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3937,7 +4023,9 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/17</td>
@@ -4021,7 +4109,9 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4105,7 +4195,9 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4189,7 +4281,9 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4273,7 +4367,9 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4357,7 +4453,9 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4441,7 +4539,9 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4525,7 +4625,9 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4609,7 +4711,9 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4693,7 +4797,9 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4777,7 +4883,9 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4861,7 +4969,9 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4945,7 +5055,9 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5029,7 +5141,9 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5113,7 +5227,9 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5197,7 +5313,9 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5281,7 +5399,9 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5365,7 +5485,9 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5434,7 +5556,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
 </tr>
-<tr class="category"><td colspan="82">2017 misc</td>
+<tr class="category"><td colspan="84">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[22]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -5456,7 +5578,9 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5543,7 +5667,9 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5630,7 +5756,9 @@ return (function(){
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5699,7 +5827,7 @@ return (function(){
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2017 annex b</td>
+<tr class="category"><td colspan="84">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -5713,7 +5841,9 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -5802,7 +5932,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5892,7 +6024,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5982,7 +6116,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6071,7 +6207,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6161,7 +6299,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6251,7 +6391,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6342,7 +6484,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6433,7 +6577,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6525,7 +6671,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6614,7 +6762,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6702,7 +6852,9 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6793,7 +6945,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6884,7 +7038,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6976,7 +7132,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7065,7 +7223,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7153,7 +7313,9 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7234,7 +7396,9 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -7322,7 +7486,9 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7410,7 +7576,9 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7503,7 +7671,9 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7596,7 +7766,9 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7681,7 +7853,9 @@ return i === 0;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7750,7 +7924,7 @@ return i === 0;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2018 features</td>
+<tr class="category"><td colspan="84">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -7764,7 +7938,9 @@ return i === 0;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20181008" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="closure20181125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
@@ -7849,7 +8025,9 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -7935,7 +8113,9 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -8016,7 +8196,9 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20181008" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20181125" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">3/3</td>
@@ -8126,7 +8308,9 @@ function check() {
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8228,7 +8412,9 @@ function check() {
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8332,7 +8518,9 @@ function check() {
 <td class="yes obsolete" data-browser="closure20180716">Yes</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8417,7 +8605,9 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="unknown obsolete" data-browser="typescript1">?</td>
 <td class="unknown obsolete" data-browser="typescript2_6">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7">?</td>
@@ -8508,7 +8698,9 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8593,7 +8785,9 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8678,7 +8872,9 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8759,7 +8955,9 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20181008" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">2/2</td>
@@ -8850,7 +9048,9 @@ iterator.next().then(function(step){
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -8951,7 +9151,9 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -9020,7 +9222,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="ios11_3">No</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2018 misc</td>
+<tr class="category"><td colspan="84">2018 misc</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -9044,7 +9246,9 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="yes" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes" data-browser="closure20181125">Yes</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9113,7 +9317,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="ios11_3">Yes</td>
 <td class="yes" data-browser="ios12">Yes</td>
 </tr>
-<tr class="category"><td colspan="82">2019 misc</td>
+<tr class="category"><td colspan="84">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://tc39.github.io/proposal-optional-catch-binding/">optional catch binding</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
@@ -9127,7 +9331,9 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">3/3</td>
@@ -9217,7 +9423,9 @@ return false;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -9308,7 +9516,9 @@ return false;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -9404,7 +9614,9 @@ return it.next().value;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -9488,7 +9700,9 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9569,7 +9783,9 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/7</td>
@@ -9655,7 +9871,9 @@ return fn + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9740,7 +9958,9 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9825,7 +10045,9 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9910,7 +10132,9 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9995,7 +10219,9 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10080,7 +10306,9 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10165,7 +10393,9 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -141,7 +141,9 @@
 <th class="platform closure20180716 compiler obsolete" data-browser="closure20180716"><a href="#closure20180716" class="browser-name"><abbr title="Closure Compiler v20180716">Closure 2018.07</abbr></a></th>
 <th class="platform closure20180805 compiler obsolete" data-browser="closure20180805"><a href="#closure20180805" class="browser-name"><abbr title="Closure Compiler v20180805">Closure 2018.08</abbr></a></th>
 <th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
-<th class="platform closure20181008 compiler" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
+<th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
+<th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
+<th class="platform closure20181125 compiler" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
 <th class="platform typescript1 compiler obsolete" data-browser="typescript1"><a href="#typescript1" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_6 compiler obsolete" data-browser="typescript2_6"><a href="#typescript2_6" class="browser-name"><abbr title="TypeScript 2.6 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform typescript2_7 compiler obsolete" data-browser="typescript2_7"><a href="#typescript2_7" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
@@ -212,7 +214,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="80">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="82">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/tc39/proposal-string-left-right-trim">string trimming</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -226,7 +228,9 @@
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">4/4</td>
@@ -308,7 +312,9 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -390,7 +396,9 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -472,7 +480,9 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -554,7 +564,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -633,7 +645,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/2</td>
@@ -717,7 +731,9 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -805,7 +821,9 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -897,7 +915,9 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -976,7 +996,9 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -1061,7 +1083,9 @@ return new C().x === &apos;x&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -1152,7 +1176,9 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1240,7 +1266,9 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1319,7 +1347,9 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -1404,7 +1434,9 @@ return C.x === &apos;x&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -1492,7 +1524,9 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1571,7 +1605,9 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -1653,7 +1689,9 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1737,7 +1775,9 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -1816,7 +1856,9 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/8</td>
@@ -1898,7 +1940,9 @@ return (1n + 2n) === 3n;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -1980,7 +2024,9 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2062,7 +2108,9 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2144,7 +2192,9 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2229,7 +2279,9 @@ return view[0] === -0x8000000000000000n;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2314,7 +2366,9 @@ return view[0] === 0n;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2396,7 +2450,9 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2478,7 +2534,9 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2561,7 +2619,9 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2644,7 +2704,9 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2711,7 +2773,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="80">Draft (stage 2)</td>
+<tr class="category"><td colspan="82">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -2734,7 +2796,9 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -2813,7 +2877,9 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">1/1</td>
@@ -2903,7 +2969,9 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -2988,7 +3056,9 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3074,7 +3144,9 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3153,7 +3225,9 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/4</td>
@@ -3241,7 +3315,9 @@ try {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3333,7 +3409,9 @@ try {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3420,7 +3498,9 @@ try {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3507,7 +3587,9 @@ try {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3590,7 +3672,9 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes</td>
@@ -3669,7 +3753,9 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/4</td>
@@ -3754,7 +3840,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3840,7 +3928,9 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -3925,7 +4015,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4010,7 +4102,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4089,7 +4183,9 @@ return set.size === 2
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/2</td>
@@ -4174,7 +4270,9 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4259,7 +4357,9 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4326,7 +4426,7 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="80">Proposal (stage 1)</td>
+<tr class="category"><td colspan="82">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -4346,7 +4446,9 @@ return do {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -4425,7 +4527,9 @@ return do {
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">7/7</td>
@@ -4507,7 +4611,9 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -4589,7 +4695,9 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -4671,7 +4779,9 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -4763,7 +4873,9 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -4846,7 +4958,9 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -4928,7 +5042,9 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5010,7 +5126,9 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5093,7 +5211,9 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -5178,7 +5298,9 @@ return Math.signbit(-0) === false
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5257,7 +5379,9 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">7/7</td>
@@ -5341,7 +5465,9 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5423,7 +5549,9 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5506,7 +5634,9 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5588,7 +5718,9 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5670,7 +5802,9 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5753,7 +5887,9 @@ return Math.radians(90) === Math.PI / 2
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5835,7 +5971,9 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5914,7 +6052,9 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">7/7</td>
@@ -5996,7 +6136,9 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6078,7 +6220,9 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6162,7 +6306,9 @@ return score === 1;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6251,7 +6397,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6340,7 +6488,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6429,7 +6579,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6518,7 +6670,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6597,7 +6751,9 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="1">8/8</td>
@@ -6682,7 +6838,9 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6769,7 +6927,9 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6854,7 +7014,9 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6939,7 +7101,9 @@ return C.has(3) + C.has(4);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7024,7 +7188,9 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7111,7 +7277,9 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7196,7 +7364,9 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7281,7 +7451,9 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="yes obsolete" data-browser="typescript1">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_6">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7375,7 +7547,9 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -7461,7 +7635,9 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -7540,7 +7716,9 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/3</td>
@@ -7624,7 +7802,9 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -7708,7 +7888,9 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -7792,7 +7974,9 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -7878,7 +8062,9 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -7957,7 +8143,9 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/12</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/12</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/12</td>
@@ -8043,7 +8231,9 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8129,7 +8319,9 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8215,7 +8407,9 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8301,7 +8495,9 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8387,7 +8583,9 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8473,7 +8671,9 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8559,7 +8759,9 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8648,7 +8850,9 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8735,7 +8939,9 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8821,7 +9027,9 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8907,7 +9115,9 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -8993,7 +9203,9 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9072,7 +9284,9 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/8</td>
@@ -9154,7 +9368,9 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9236,7 +9452,9 @@ return Object.isFrozen([# 42 #]);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9318,7 +9536,9 @@ return Object.isSealed({| foo: 42 |});
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9400,7 +9620,9 @@ return Object.isSealed([| 42 |]);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9490,7 +9712,9 @@ try {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9581,7 +9805,9 @@ try {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9671,7 +9897,9 @@ try {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9762,7 +9990,9 @@ try {
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9844,7 +10074,9 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -9931,7 +10163,9 @@ return results.length === 3
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10010,7 +10244,9 @@ return results.length === 3
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/2</td>
@@ -10092,7 +10328,9 @@ return [1, 2, 3].lastItem === 3;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10174,7 +10412,9 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10253,7 +10493,9 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/15</td>
-<td class="tally" data-browser="closure20181008" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/15</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/15</td>
+<td class="tally" data-browser="closure20181125" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="typescript1" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="typescript2_6" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="typescript2_7" data-tally="0">0/15</td>
@@ -10340,7 +10582,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10425,7 +10669,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10510,7 +10756,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10596,7 +10844,9 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10682,7 +10932,9 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10768,7 +11020,9 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10854,7 +11108,9 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -10940,7 +11196,9 @@ return set.deleteAll(2, 3) === true
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11022,7 +11280,9 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11107,7 +11367,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11189,7 +11451,9 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11271,7 +11535,9 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11357,7 +11623,9 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11439,7 +11707,9 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11521,7 +11791,9 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="closure20180716">No</td>
 <td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181008">No</td>
+<td class="no obsolete" data-browser="closure20181028">No</td>
+<td class="no" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="typescript1">No</td>
 <td class="no obsolete" data-browser="typescript2_6">No</td>
 <td class="no obsolete" data-browser="typescript2_7">No</td>
@@ -11588,7 +11860,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no" data-browser="ios11_3">No</td>
 <td class="no" data-browser="ios12">No</td>
 </tr>
-<tr class="category"><td colspan="80">Strawman (stage 0)</td>
+<tr class="category"><td colspan="82">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -11602,7 +11874,9 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -11686,7 +11960,9 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11769,7 +12045,9 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -11851,7 +12129,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -11930,7 +12210,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -12013,7 +12295,9 @@ return f();
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12095,7 +12379,9 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12182,7 +12468,9 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12275,7 +12563,9 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -12364,7 +12654,9 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12443,7 +12735,9 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -12527,7 +12821,9 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12611,7 +12907,9 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12690,7 +12988,9 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -12772,7 +13072,9 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12854,7 +13156,9 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -12936,7 +13240,9 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13018,7 +13324,9 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13100,7 +13408,9 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13182,7 +13492,9 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13264,7 +13576,9 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13343,7 +13657,9 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13431,7 +13747,9 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13526,7 +13844,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13605,7 +13925,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -13689,7 +14011,9 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13774,7 +14098,9 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -13841,7 +14167,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="ios11_3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="80">Pre-strawman</td>
+<tr class="category"><td colspan="82">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -13855,7 +14181,9 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
@@ -13937,7 +14265,9 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14019,7 +14349,9 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14101,7 +14433,9 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14183,7 +14517,9 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14265,7 +14601,9 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14347,7 +14685,9 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14429,7 +14769,9 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14511,7 +14853,9 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14593,7 +14937,9 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>


### PR DESCRIPTION
- v20181028: Object rest properties is degraded (https://github.com/google/closure-compiler/issues/3139)
- v20181125: `Math.fround` is supported requiring `Float32Array` (https://github.com/google/closure-compiler/commit/5d04b3ccad67e6d2a1a9edcc8f31a7fa2a1ba996)

https://github.com/google/closure-compiler/wiki/Releases