### PR TITLE
Firefox 66 Nightly implements String.prototype.matchAll

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -518,6 +518,8 @@ exports.tests = [
     typescript1: typescript.corejs,
     ie11: false,
     firefox2: false,
+    firefox65: false,
+    firefox66: true,
     chrome67: false,
     chrome68: chrome.harmony,
     opera10_50: false,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -940,7 +940,7 @@ return a === &apos;1a2b&apos;
 <td class="no" data-browser="firefox63">No</td>
 <td class="no" data-browser="firefox64">No</td>
 <td class="no unstable" data-browser="firefox65">No</td>
-<td class="no unstable" data-browser="firefox66">No</td>
+<td class="yes unstable" data-browser="firefox66">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>


### PR DESCRIPTION
Firefox Nightly builds now implement the String.prototype.matchAll proposal:
https://bugzilla.mozilla.org/show_bug.cgi?id=1435829