### PR TITLE
The matchAll feature is only available in Firefox Nightly builds

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -519,7 +519,7 @@ exports.tests = [
     ie11: false,
     firefox2: false,
     firefox65: false,
-    firefox66: true,
+    firefox66: firefox.nightly,
     chrome67: false,
     chrome68: chrome.harmony,
     opera10_50: false,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -940,7 +940,7 @@ return a === &apos;1a2b&apos;
 <td class="no" data-browser="firefox63">No</td>
 <td class="no" data-browser="firefox64">No</td>
 <td class="no unstable" data-browser="firefox65">No</td>
-<td class="yes unstable" data-browser="firefox66">Yes</td>
+<td class="no unstable" data-browser="firefox66">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome63">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>


### PR DESCRIPTION
Sorry, I pushed the wrong patch with #1388.
The `String.prototype.matchAll` feature is only available in Nightly builds for now.  This patch fixes the result.