### PR TITLE
Update test results for GraalVM 1.0.0 RC10

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -599,7 +599,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
-          graalvm: false,
+          graalvm: true,
         }
       },
       {
@@ -631,7 +631,7 @@ exports.tests = [
           opera10_50: false,
           safari10_1: true,
           duktape2_0: false,
-          graalvm: false,
+          graalvm: true,
         }
       },
       {
@@ -2790,7 +2790,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_2: false,
-          graalvm: false,
+          graalvm: true,
         },
       },
       {
@@ -2819,7 +2819,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_2: false,
-          graalvm: false,
+          graalvm: true,
         },
       },
       {
@@ -2853,7 +2853,7 @@ exports.tests = [
           safaritp: true,
           webkit: true,
           duktape2_2: false,
-          graalvm: false,
+          graalvm: true,
         }
       }
     ]
@@ -2884,7 +2884,7 @@ exports.tests = [
           safari11: false,
           safari12: true,
           safaritp: true,
-          graalvm: false,
+          graalvm: true,
         },
       },
       {
@@ -2906,7 +2906,7 @@ exports.tests = [
           safari11: false,
           safari12: true,
           safaritp: true,
-          graalvm: false,
+          graalvm: true,
         },
       },
       {
@@ -2927,7 +2927,7 @@ exports.tests = [
           chrome70: true,
           safari11: false,
           safari12: false,
-          graalvm: false,
+          graalvm: true,
         },
       },
     ]

--- a/data-es6.js
+++ b/data-es6.js
@@ -561,6 +561,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -852,6 +853,7 @@ exports.tests = [
         xs6: true,
         jxa: true,
         duktape2_0: false,
+        graalvm: true,
       }
     },
     {
@@ -1156,6 +1158,7 @@ exports.tests = [
         node6_5: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -1387,6 +1390,7 @@ exports.tests = [
         node4: true,
         xs6: true,
         duktape2_0: false,
+        graalvm: true,
       },
     },
     {
@@ -10195,7 +10199,7 @@ exports.tests = [
         edge14: edge.experimental,
         safari10: true,
         duktape2_0: false,
-        graalvm: false,
+        graalvm: true,
       },
     },
     {

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -574,7 +574,7 @@ exports.tests = [
         opera10_50: false,
         node0_12: true,
         duktape2_0: false,
-        graalvm: false,
+        graalvm: true,
       }
     }
   ],

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -331,7 +331,7 @@ exports.tests = [
       node8_7: false,
       duktape2_0: false,
       duktape2_1: false,
-      graalvm: false,
+      graalvm: true,
     }
   }, {
     name: '"globalThis" global property has correct property descriptor',
@@ -371,7 +371,7 @@ exports.tests = [
       node8_7: false,
       duktape2_0: false,
       duktape2_1: false,
-      graalvm: false,
+      graalvm: true,
     }
   }]
 },
@@ -528,7 +528,7 @@ exports.tests = [
     chrome68: chrome.harmony,
     opera10_50: false,
     duktape2_0: false,
-    graalvm: false,
+    graalvm: true,
   }
 },
 {
@@ -1440,7 +1440,7 @@ exports.tests = [
         safari12: true,
         safaritp: true,
         duktape2_2: false,
-        graalvm: false,
+        graalvm: true,
       }
     },
     {
@@ -1463,7 +1463,7 @@ exports.tests = [
         opera10_50: false,
         safari12: true,
         duktape2_2: false,
-        graalvm: false,
+        graalvm: true,
       }
     }
   ]
@@ -2271,7 +2271,7 @@ exports.tests = [
       res: {
         firefox52: false,
         chrome67: true,
-        graalvm: false,
+        graalvm: true,
       },
     },
     {
@@ -2285,7 +2285,7 @@ exports.tests = [
       res: {
         firefox52: false,
         chrome67: true,
-        graalvm: false,
+        graalvm: true,
       },
     },
     {
@@ -2296,7 +2296,7 @@ exports.tests = [
       res: {
         firefox52: false,
         chrome67: true,
-        graalvm: false,
+        graalvm: true,
       },
     },
     {
@@ -2307,7 +2307,7 @@ exports.tests = [
       res: {
         firefox52: false,
         chrome67: true,
-        graalvm: false,
+        graalvm: true,
       },
     },
   ],
@@ -2992,6 +2992,7 @@ exports.tests = [
     chrome70: false,
     chrome71: false,
     chrome72: true,
+    graalvm: true,
   }
 },
 {

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -1266,7 +1266,7 @@ exports.tests = [
         opera10_50: false,
         rhino1_7: true,
         duktape2_0: false,
-        graalvm: true,
+        graalvm: false,
       }
     },
     {
@@ -1291,7 +1291,7 @@ exports.tests = [
         besen: true,
         rhino1_7: true,
         duktape2_0: false,
-        graalvm: true,
+        graalvm: false,
       },
     },
     {
@@ -1305,7 +1305,7 @@ exports.tests = [
         opera10_50: false,
         rhino1_7: null,
         duktape2_0: false,
-        graalvm: true,
+        graalvm: false,
       },
     },
     {
@@ -1407,7 +1407,7 @@ exports.tests = [
         besen: null,
         rhino1_7: null,
         duktape2_0: false,
-        graalvm: true,
+        graalvm: false,
       },
     },
   ]
@@ -1428,7 +1428,7 @@ exports.tests = [
     opera10_50: false,
     rhino1_7: null,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -1477,7 +1477,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1529,7 +1529,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -1549,7 +1549,7 @@ exports.tests = [
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
 },
 {
@@ -1574,7 +1574,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1598,7 +1598,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1630,7 +1630,11 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
-    graalvm: true,
+    graalvm: {
+      val: "flagged",
+      note_id: 'graalvm-nashorn-compat',
+      note_html: 'The feature has to be enabled via the <code>--nashorn-compat</code> flag.'
+    },
   }
 },
 {
@@ -1651,7 +1655,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1672,7 +1676,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -1700,7 +1704,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1720,7 +1724,7 @@ exports.tests = [
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1747,7 +1751,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1771,7 +1775,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1802,7 +1806,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1827,7 +1831,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -1867,7 +1871,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1909,7 +1913,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -1961,7 +1965,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
 },
 {
@@ -1987,7 +1991,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -2013,7 +2017,7 @@ exports.tests = [
     opera7_5: false,
     opera10_50: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -2043,7 +2047,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -2121,7 +2125,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -2144,7 +2148,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -2166,7 +2170,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -2183,7 +2187,7 @@ exports.tests = [
     rhino1_7: true,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -2206,7 +2210,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
 },
 {
@@ -2232,7 +2236,7 @@ exports.tests = [
     ejs: true,
     android4_0: true,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -2255,7 +2259,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -2277,7 +2281,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -2298,7 +2302,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
 },
 {
@@ -2318,7 +2322,7 @@ exports.tests = [
     node0_10: true,
     android5_0: true,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -2378,7 +2382,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -2405,7 +2409,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -2431,7 +2435,7 @@ exports.tests = [
     nashorn1_8: true,
     nashorn9: true,
     nashorn10: true,
-    graalvm: true,
+    graalvm: false,
   }
 },
 {
@@ -2453,7 +2457,7 @@ exports.tests = [
     rhino1_7: false,
     phantom: false,
     duktape2_0: false,
-    graalvm: true,
+    graalvm: false,
   },
   separator: 'after'
 },
@@ -2520,7 +2524,7 @@ exports.tests = [
         node8_7: false,
         duktape2_0: false,
         duktape2_1: true,
-        graalvm: true,
+        graalvm: false,
       }
     }]
   }

--- a/environments.json
+++ b/environments.json
@@ -2682,13 +2682,13 @@
     ]
   },
   "graalvm": {
-    "full": "GraalVM JavaScript 1.0.0 RC3",
+    "full": "GraalVM JavaScript 1.0.0 RC10",
     "family": "GraalVM 1.0",
     "short": "GraalVM 1.0",
     "platformtype": "engine",
     "note_id": "graalvm-node-mode",
     "note_html": "Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.",
-    "release": "2018-07-01",
+    "release": "2018-12-05",
     "unstable": false,
     "test_suites": [
       "es5",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -199,7 +199,7 @@
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
-<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC3">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
+<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC10">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10 mobile obsolete" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10.0-10.2</abbr></a></th>
@@ -2759,7 +2759,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/15</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/15</td>
-<td class="tally" data-browser="graalvm" data-tally="0.8666666666666667" style="background-color:hsl(104,47%,50%)">13/15</td>
+<td class="tally" data-browser="graalvm" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ios10" data-tally="0">0/15</td>
@@ -3245,7 +3245,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -3345,7 +3345,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -9905,7 +9905,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
-<td class="tally" data-browser="graalvm" data-tally="0">0/3</td>
+<td class="tally" data-browser="graalvm" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios10" data-tally="0">0/3</td>
@@ -10002,7 +10002,7 @@ return false;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -10100,7 +10100,7 @@ return false;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -10203,7 +10203,7 @@ return it.next().value;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -10291,7 +10291,7 @@ return it.next().value;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/3</td>
-<td class="tally" data-browser="graalvm" data-tally="0">0/3</td>
+<td class="tally" data-browser="graalvm" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios10" data-tally="0">0/3</td>
@@ -10382,7 +10382,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -10473,7 +10473,7 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -10564,7 +10564,7 @@ return Symbol().description === undefined;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -193,7 +193,7 @@
 <th class="platform nashorn1_8 engine" data-browser="nashorn1_8"><a href="#nashorn1_8" class="browser-name"><abbr title="Oracle Nashorn 1.8">JJS 1.8</abbr></a></th>
 <th class="platform nashorn9 engine obsolete" data-browser="nashorn9"><a href="#nashorn9" class="browser-name"><abbr title="Oracle Nashorn 9">JJS 9</abbr></a></th>
 <th class="platform nashorn10 engine" data-browser="nashorn10"><a href="#nashorn10" class="browser-name"><abbr title="Oracle Nashorn 10">JJS 10</abbr></a></th>
-<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC3">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
+<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC10">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10 mobile obsolete" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10.0-10.2</abbr></a></th>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -187,7 +187,7 @@
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
-<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC3">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
+<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC10">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10 mobile obsolete" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10.0-10.2</abbr></a></th>
@@ -1559,7 +1559,7 @@ try {
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/6</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/6</td>
-<td class="tally" data-browser="graalvm" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally" data-browser="graalvm" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="ios10" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
@@ -2016,7 +2016,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -203,7 +203,7 @@
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
-<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC3">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
+<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC10">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10 mobile obsolete" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10.0-10.2</abbr></a></th>
@@ -737,7 +737,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
-<td class="tally" data-browser="graalvm" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10" data-tally="0">0/2</td>
@@ -828,7 +828,7 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -923,7 +923,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -1022,7 +1022,7 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -1752,7 +1752,7 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/2</td>
-<td class="tally" data-browser="graalvm" data-tally="0">0/2</td>
+<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10" data-tally="0">0/2</td>
@@ -1841,7 +1841,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -1932,7 +1932,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -2018,7 +2018,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/8</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/8</td>
-<td class="tally" data-browser="graalvm" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
+<td class="tally" data-browser="graalvm" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ios10" data-tally="0">0/8</td>
@@ -2466,7 +2466,7 @@ return view[0] === -0x8000000000000000n;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -2558,7 +2558,7 @@ return view[0] === 0n;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -2647,7 +2647,7 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -2736,7 +2736,7 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -2916,7 +2916,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="no" data-browser="graalvm">No</td>
+<td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>

--- a/node.js
+++ b/node.js
@@ -55,7 +55,7 @@ $('#body tbody tr').each(function (index) {
   }
 });
 
-setTimeout(function(){
+process.on('exit', function(){
   Object.keys(results).forEach(function(test) {
     var result = results[test];
     var name = desc[test];
@@ -65,4 +65,4 @@ setTimeout(function(){
       console.log(chalk[result === "Strict" ? 'cyan' : result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (name[0]!== '§' ? '\t' + name : name.slice(1)) + '\t'));
     }
   });
-},500);
+});

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -174,7 +174,7 @@
 <th class="platform duktape2_0 engine obsolete" data-browser="duktape2_0"><a href="#duktape2_0" class="browser-name"><abbr title="Duktape 2.0">DUK 2.0</abbr></a></th>
 <th class="platform duktape2_1 engine obsolete" data-browser="duktape2_1"><a href="#duktape2_1" class="browser-name"><abbr title="Duktape 2.1">DUK 2.1</abbr></a></th>
 <th class="platform duktape2_2 engine" data-browser="duktape2_2"><a href="#duktape2_2" class="browser-name"><abbr title="Duktape 2.2">DUK 2.2</abbr></a></th>
-<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC3">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
+<th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 1.0.0 RC10">GraalVM 1.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10 mobile obsolete" data-browser="ios10"><a href="#ios10" class="browser-name"><abbr title="iOS Safari">iOS 10.0-10.2</abbr></a></th>
@@ -4638,7 +4638,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="duktape2_2" data-tally="0">0/4</td>
-<td class="tally" data-browser="graalvm" data-tally="1">4/4</td>
+<td class="tally" data-browser="graalvm" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios10" data-tally="0">0/4</td>
@@ -4712,7 +4712,7 @@ return typeof uneval == &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -4794,7 +4794,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -4868,7 +4868,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5029,7 +5029,7 @@ return true;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5104,7 +5104,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5262,7 +5262,7 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5420,7 +5420,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5497,7 +5497,7 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5575,7 +5575,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5651,7 +5651,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5737,7 +5737,7 @@ return executed;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no flagged" data-browser="graalvm">Flag<a href="#graalvm-nashorn-compat-note"><sup>[8]</sup></a></td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5813,7 +5813,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5889,7 +5889,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -5967,7 +5967,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6041,7 +6041,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6115,7 +6115,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6189,7 +6189,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6267,7 +6267,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6342,7 +6342,7 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6450,7 +6450,7 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6564,7 +6564,7 @@ catch(e) {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6677,7 +6677,7 @@ global.test((function () {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6753,7 +6753,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6834,7 +6834,7 @@ return passed;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -6926,7 +6926,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7162,7 +7162,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7237,7 +7237,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7311,7 +7311,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7383,7 +7383,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7457,7 +7457,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7539,7 +7539,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios10">Yes</td>
@@ -7613,7 +7613,7 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7685,7 +7685,7 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7757,7 +7757,7 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7831,7 +7831,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -7993,7 +7993,7 @@ return 'lineNumber' in new Error();
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -8069,7 +8069,7 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -8145,7 +8145,7 @@ return 'fileName' in new Error();
 <td class="yes obsolete" data-browser="duktape2_0">Yes</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -8221,7 +8221,7 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no" data-browser="duktape2_2">No</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -8294,7 +8294,7 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="duktape2_2" data-tally="1">2/2</td>
-<td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
+<td class="tally" data-browser="graalvm" data-tally="0.5">1/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10" data-tally="0">0/2</td>
@@ -8451,7 +8451,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="duktape2_0">No</td>
 <td class="yes obsolete" data-browser="duktape2_1">Yes</td>
 <td class="yes" data-browser="duktape2_2">Yes</td>
-<td class="yes" data-browser="graalvm">Yes</td>
+<td class="no" data-browser="graalvm">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10">No</td>
@@ -8467,7 +8467,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
       </table>
       <div id="footnotes">
         <!-- FOOTNOTES -->
-      <p id="khtml-note">  <sup>[1]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-old-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[4]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="edge-experimental-flag-note">  <sup>[5]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="firefox-nightly-note">  <sup>[6]</sup> The feature is available only in Firefox Nightly builds.</p><p id="chrome-simd-note">  <sup>[7]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-simd&quot;</code> flag</p></div>
+      <p id="khtml-note">  <sup>[1]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-old-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[4]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="edge-experimental-flag-note">  <sup>[5]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="firefox-nightly-note">  <sup>[6]</sup> The feature is available only in Firefox Nightly builds.</p><p id="chrome-simd-note">  <sup>[7]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-simd&quot;</code> flag</p><p id="graalvm-nashorn-compat-note">  <sup>[8]</sup> The feature has to be enabled via the <code>--nashorn-compat</code> flag.</p></div>
     </div>
     <pre class="info-tooltip" style="display:none"></pre>
     <script src="../jquery.floatThead.min.js"></script>


### PR DESCRIPTION
Hi,

I have updated the test results for GraalVM to reflect the current version (1.0.0 RC10). This accounts for some new positives due to bug fixes and new features added since the last version recorded in the table (1.0.0 RC3).

It also fixes the non-standard table, in which GraalVM was mistakenly reported to support everything outside of SIMD.

As part of running the test suites on the new GraalVM, I have also taken a look at the test runners included in the repo. The `node.js` runner had an issue with using `setTimeout(_, 250)` to wait for tests to finish before producing the report. This led to some asynchronous tests (those which use longer delays and therefore don't have time to finish) to be reported as false negatives, both on the original node.js and on GraalVM. I fixed this by using `process.on('exit', _)`, which waits for the event queue to drain before exiting.